### PR TITLE
﻿feat: add AuthInterceptor to attach JWT on every HTTP request

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { Routes, RouterModule, Router } from '@angular/router';
+import { Routes, RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoginComponent } from './charactermanager/components/login/login.component';
 import { FormsModule } from '@angular/forms';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { AuthInterceptor } from './interceptors/auth.interceptor';
 
 
 const routes: Routes =[
@@ -29,7 +29,9 @@ const routes: Routes =[
     HttpClientModule,
     RouterModule.forRoot(routes)
   ],
-  providers: [],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -1,7 +1,6 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
-import { EventEmitter, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { PC } from '../models/pc';
-import { AuthService } from './auth.service';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({
@@ -13,7 +12,7 @@ export class PCService {
   private activePCSubject = new BehaviorSubject<PC | null>(null);
   activePC$ = this.activePCSubject.asObservable();
 
-  constructor(private authService: AuthService, private http: HttpClient) {}
+  constructor(private http: HttpClient) {}
 
   readonly pcUrl = 'http://localhost:8080/api/v1/pc/';
 
@@ -22,14 +21,7 @@ export class PCService {
   }
 
   getPCs() {
-    const token = this.authService.getToken();
-
-    const headers = new HttpHeaders({
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json'
-    });
-    
-    return this.http.get<PC[]>(this.pcUrl + 'all', { headers });
+    return this.http.get<PC[]>(this.pcUrl + 'all');
   }
 
   PCById(params: HttpParams) {
@@ -49,25 +41,10 @@ export class PCService {
   }
 
   addPC(newPC: PC) {
-    const token = this.authService.getToken();
-
-    const headers = new HttpHeaders({
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json'
-    });
-
-    return this.http.post<PC>(this.pcUrl + 'add', newPC, { headers });
+    return this.http.post<PC>(this.pcUrl + 'add', newPC);
   }
 
-  deletePC(id: number){
-    const token = this.authService.getToken();
-
-    const headers = new HttpHeaders({
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json'
-    });
-    
-    return this.http.delete<PC[]>(this.pcUrl + 'delete/' + id, { headers });
+  deletePC(id: number) {
+    return this.http.delete<PC[]>(this.pcUrl + 'delete/' + id);
   }
-
 }

--- a/src/app/interceptors/auth.interceptor.ts
+++ b/src/app/interceptors/auth.interceptor.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { AuthService } from '../charactermanager/services/auth.service';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private authService: AuthService) {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const token = this.authService.getToken();
+
+    if (token) {
+      const authRequest = request.clone({
+        setHeaders: { Authorization: `Bearer ${token}` }
+      });
+      return next.handle(authRequest);
+    }
+
+    return next.handle(request);
+  }
+}


### PR DESCRIPTION
Create AuthInterceptor that reads the token from AuthService and clones each outgoing request with an Authorization header. Register it as a multi-provider in AppModule. Remove redundant manual header construction from PCService.