### PR TITLE
feat: add Starting Equipment step to character wizard

### DIFF
--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
@@ -235,8 +235,8 @@
     </div>
   </ng-container>
 
-  <!-- ── Step 7: Spells ─────────────────────────────────────────────── -->
-  <ng-container *ngIf="step === 7">
+  <!-- ── Step 7: Spells (spellcasting classes only) ────────────────── -->
+  <ng-container *ngIf="step === 7 && isSpellcastingClass">
     <div class="modal-title">Choose Your Spells</div>
     <div class="modal-sub">
       Select {{ maxCantrips }} cantrip{{ maxCantrips !== 1 ? 's' : '' }} and
@@ -288,6 +288,63 @@
       <span [class.complete]="selectedLeveled === maxKnownSpells">
         {{ selectedLeveled }}/{{ maxKnownSpells }} spells
       </span>
+    </div>
+  </ng-container>
+
+  <!-- ── Step 7/8: Starting Equipment ──────────────────────────────── -->
+  <ng-container *ngIf="step === equipmentStep">
+    <div class="modal-title">Starting Equipment</div>
+    <div class="modal-sub">
+      Choose a ready-made kit or take gold and outfit yourself your own way.
+    </div>
+
+    <div *ngIf="loadingEquipment" class="loading">Loading equipment…</div>
+
+    <div *ngIf="!loadingEquipment && currentClassEquipment" class="equip-options">
+
+      <!-- Option A: Item kit -->
+      <button type="button"
+              class="equip-card"
+              [class.active]="equipmentChoice === 'A'"
+              (click)="equipmentChoice = 'A'">
+        <div class="equip-card-header">
+          <span class="equip-card-label">Option A</span>
+          <span class="equip-card-tag">Starter Kit</span>
+        </div>
+        <ul class="equip-list">
+          <li *ngFor="let w of currentClassEquipment!.optionA.weapons">
+            {{ w.name }}<span *ngIf="w.notes"> {{ w.notes }}</span>
+            <em class="equip-dmg">{{ w.dmg }}</em>
+          </li>
+          <li *ngFor="let g of currentClassEquipment!.optionA.gear">
+            {{ g.name }}
+          </li>
+          <li *ngIf="currentClassEquipment!.optionA.gp > 0">
+            {{ currentClassEquipment!.optionA.gp }} gp
+          </li>
+        </ul>
+      </button>
+
+      <!-- Option B: Gold -->
+      <button type="button"
+              class="equip-card"
+              [class.active]="equipmentChoice === 'B'"
+              (click)="equipmentChoice = 'B'">
+        <div class="equip-card-header">
+          <span class="equip-card-label">Option B</span>
+          <span class="equip-card-tag">Buy Your Own</span>
+        </div>
+        <div class="equip-gold-amount">
+          {{ currentClassEquipment!.optionB.gp }} gp
+        </div>
+        <div class="equip-gold-note">to spend at any shop</div>
+      </button>
+    </div>
+
+    <!-- Background gold (always granted) -->
+    <div *ngIf="!loadingEquipment && background" class="equip-bg-gold">
+      <span class="detail-label">Background Gold</span>
+      <span class="detail-value">+{{ backgroundStartingGold }} gp from {{ background }}</span>
     </div>
   </ng-container>
 

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
@@ -362,6 +362,112 @@
   margin-top: 8px;
 }
 
+// ── Starting Equipment step ───────────────────────────────────────────────
+
+.equip-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.equip-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  padding: 12px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  width: 100%;
+
+  &.active {
+    border-color: var(--gold);
+    background: color-mix(in oklch, var(--gold) 10%, var(--bg-2));
+    box-shadow: var(--glow-gold);
+  }
+
+  &:hover:not(.active) {
+    border-color: rgba(212, 176, 106, 0.4);
+  }
+}
+
+.equip-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.equip-card-label {
+  font-family: 'Cinzel', serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--gold);
+}
+
+.equip-card-tag {
+  font-family: 'EB Garamond', serif;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+}
+
+.equip-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+
+  li {
+    font-family: 'EB Garamond', serif;
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+}
+
+.equip-dmg {
+  font-style: italic;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.equip-gold-amount {
+  font-family: 'Cinzel', serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--gold);
+  line-height: 1.1;
+  margin-bottom: 2px;
+}
+
+.equip-gold-note {
+  font-family: 'EB Garamond', serif;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  font-style: italic;
+}
+
+.equip-bg-gold {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  font-size: 13px;
+}
+
 // ── Step 5: Proficiency & Language styles ────────────────────────────────
 
 .prof-section {

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.ts
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/cor
 import { Subject } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import { PC, PcSpell } from '../../models/pc';
-import { BackgroundGroup, DndBackground, DndClass, DndSpell } from '../../models/dnd-api.types';
+import { BackgroundGroup, ClassEquipment, DndBackground, DndClass, DndSpell } from '../../models/dnd-api.types';
 import { ALL_SKILLS, CLASS_SKILL_CHOICES, DndResourcesService, SPELL_COUNTS, SPELLCASTING_CLASSES, STANDARD_LANGUAGES } from '../../services/dnd-resources.service';
 import { fmtMod, modFromScore } from '../../utils/character-math';
 
@@ -25,7 +25,12 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   }
 
   get totalSteps(): number {
-    return this.isSpellcastingClass ? 7 : 6;
+    return this.isSpellcastingClass ? 8 : 7;
+  }
+
+  /** The step number for equipment — always the last step. */
+  get equipmentStep(): number {
+    return this.isSpellcastingClass ? 8 : 7;
   }
 
   get stepRange(): number[] {
@@ -161,6 +166,19 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   bonusPlus2: Ability | '' = '';
   bonusPlus1: Ability | '' = '';
 
+  // ── Step 7/8: Starting Equipment ─────────────────────────────────────────
+  equipmentChoice: 'A' | 'B' | '' = '';
+  classEquipmentData: Record<string, ClassEquipment> | null = null;
+  loadingEquipment = false;
+
+  get currentClassEquipment(): ClassEquipment | null {
+    return this.classEquipmentData?.[this.clazz.toLowerCase()] ?? null;
+  }
+
+  get backgroundStartingGold(): number {
+    return this.dndResources.getBackgroundGold(this.background);
+  }
+
   @Output() confirm = new EventEmitter<Partial<PC>>();
   @Output() close   = new EventEmitter<void>();
 
@@ -229,6 +247,9 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   // ── Navigation ───────────────────────────────────────────────────────────
 
   get canAdvance(): boolean {
+    // Equipment is always the final step regardless of class
+    if (this.step === this.equipmentStep) return !!this.equipmentChoice;
+
     switch (this.step) {
       case 1: return this.name.trim().length > 0;
       case 2: return !!this.species;
@@ -239,7 +260,7 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
                   && !!this.bonusPlus2
                   && !!this.bonusPlus1
                   && this.bonusPlus2 !== this.bonusPlus1;
-      case 7: return true; // spell selection is optional
+      case 7: return true; // spells — optional for casters (non-casters never reach here via switch)
       default: return false;
     }
   }
@@ -250,7 +271,7 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
     // Safety: fire triggers if detail not yet loaded when entering a step
     if (this.step === 3 && !this.classDetail      && !this.loadingClassDetail      && this.clazz)      this.classTrigger$.next(this.clazz);
     if (this.step === 4 && !this.backgroundDetail && !this.loadingBackgroundDetail && this.background) this.backgroundTrigger$.next(this.background);
-    // Load spells when entering step 7
+    // Load spells when entering step 7 (casters only)
     if (this.step === 7 && this.isSpellcastingClass && !this.spellList.length) {
       this.loadingSpells = true;
       this.dndResources.getSpellsForClass(this.clazz)
@@ -258,6 +279,16 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
         .subscribe(spells => {
           this.spellList    = spells;
           this.loadingSpells = false;
+        });
+    }
+    // Load equipment data when entering the equipment step
+    if (this.step === this.equipmentStep && !this.classEquipmentData) {
+      this.loadingEquipment = true;
+      this.dndResources.getClassEquipment()
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(data => {
+          this.classEquipmentData = data;
+          this.loadingEquipment   = false;
         });
     }
   }
@@ -271,6 +302,16 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   trackByName(_: number, name: string): string { return name; }
   trackBySource(_: number, group: BackgroundGroup): string { return group.source; }
   trackBySpellName(_: number, spell: DndSpell): string { return spell.name; }
+
+  // ── Starting coins ───────────────────────────────────────────────────────
+
+  private buildStartingCoins(): { cp: number; sp: number; ep: number; gp: number; pp: number } {
+    const bgGold = this.backgroundStartingGold;
+    const classGold = this.equipmentChoice === 'A'
+      ? (this.currentClassEquipment?.optionA.gp ?? 0)
+      : (this.currentClassEquipment?.optionB.gp ?? 0);
+    return { cp: 0, sp: 0, ep: 0, gp: bgGold + classGold, pp: 0 };
+  }
 
   // ── Starting spell slots (level 1) ───────────────────────────────────────
 
@@ -425,9 +466,13 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
       skills:           [...this.backgroundSkillProfs, ...this.selectedSkills]
                           .reduce((acc, s) => ({ ...acc, [s]: 'prof' as const }), {}),
       languages:        ['Common', ...(this.languageChoice ? [this.languageChoice] : [])],
-      coins:            { cp: 0, sp: 0, ep: 0, gp: 10, pp: 0 },
-      weapons:          [],
-      gear:             [],
+      coins:            this.buildStartingCoins(),
+      weapons:          this.equipmentChoice === 'A'
+                          ? (this.currentClassEquipment?.optionA.weapons ?? [])
+                          : [],
+      gear:             this.equipmentChoice === 'A'
+                          ? (this.currentClassEquipment?.optionA.gear ?? [])
+                          : [],
       features:         [],
       spells: this.selectedSpells.map((s): PcSpell => ({
         lvl:            s.level,

--- a/src/app/charactermanager/models/dnd-api.types.ts
+++ b/src/app/charactermanager/models/dnd-api.types.ts
@@ -84,3 +84,30 @@ export interface DndSpell {
   cantripUpgrade?: string;    // cantrip damage scaling text
   higherLevelSlot?: string;   // upcast description
 }
+
+// ── Starting equipment types ──────────────────────────────────────────────────
+
+export interface WeaponEntry {
+  name: string;
+  dmg: string;
+  notes?: string;
+  magic?: boolean;
+}
+
+export interface GearEntry {
+  name: string;
+  notes?: string;
+  equipped?: boolean;
+  magic?: boolean;
+}
+
+export interface EquipmentOptionA {
+  weapons: WeaponEntry[];
+  gear: GearEntry[];
+  gp: number;
+}
+
+export interface ClassEquipment {
+  optionA: EquipmentOptionA;
+  optionB: { gp: number };
+}

--- a/src/app/charactermanager/services/dnd-resources.service.ts
+++ b/src/app/charactermanager/services/dnd-resources.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of, shareReplay } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BackgroundGroup, DndBackground, DndClass, DndListResponse, DndResource, DndSpell } from '../models/dnd-api.types';
+import { BackgroundGroup, ClassEquipment, DndBackground, DndClass, DndListResponse, DndResource, DndSpell } from '../models/dnd-api.types';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -145,6 +145,15 @@ export const STANDARD_LANGUAGES: string[] = [
   'Giant', 'Gnomish', 'Goblin', 'Halfling', 'Orc', 'Primordial',
 ];
 
+/** Starting gold granted by each PHB background (2024 PHB values) */
+export const BACKGROUND_GOLD: Record<string, number> = {
+  // Player's Handbook
+  'Acolyte': 15,    'Artisan': 25,   'Charlatan': 15, 'Criminal': 15,
+  'Entertainer': 15,'Farmer': 15,    'Guard': 10,     'Guide': 10,
+  'Hermit': 5,      'Merchant': 25,  'Noble': 25,     'Sage': 15,
+  'Sailor': 10,     'Scribe': 10,    'Soldier': 10,   'Wayfarer': 15,
+};
+
 @Injectable({ providedIn: 'root' })
 export class DndResourcesService {
   /** 2014 ruleset — kept for backward compatibility */
@@ -153,6 +162,7 @@ export class DndResourcesService {
   private dnd2024Url     = 'https://www.dnd5eapi.co/api/2024/';
 
   private spells$: Observable<DndSpell[]> | null = null;
+  private classEquipment$: Observable<Record<string, ClassEquipment>> | null = null;
 
   constructor(private http: HttpClient) {}
 
@@ -229,5 +239,23 @@ export class DndResourcesService {
     return this.getSpells().pipe(
       map(spells => spells.filter(s => s.classes.includes(key)))
     );
+  }
+
+  /** Starting equipment packages for all 12 classes. Fetched once, cached. */
+  getClassEquipment(): Observable<Record<string, ClassEquipment>> {
+    if (!this.classEquipment$) {
+      this.classEquipment$ = this.http
+        .get<Record<string, ClassEquipment>>('/assets/data/equipment/class-equipment-2024.json')
+        .pipe(shareReplay(1));
+    }
+    return this.classEquipment$;
+  }
+
+  /**
+   * Background starting gold per 2024 PHB.
+   * Returns 15 gp as a safe default for backgrounds not in the map.
+   */
+  getBackgroundGold(backgroundName: string): number {
+    return BACKGROUND_GOLD[backgroundName] ?? 15;
   }
 }

--- a/src/assets/data/equipment/class-equipment-2024.json
+++ b/src/assets/data/equipment/class-equipment-2024.json
@@ -1,0 +1,180 @@
+{
+  "barbarian": {
+    "optionA": {
+      "weapons": [
+        { "name": "Greataxe", "dmg": "1d12 slashing" },
+        { "name": "Handaxe", "dmg": "1d6 slashing", "notes": "×4" }
+      ],
+      "gear": [
+        { "name": "Explorer's Pack" },
+        { "name": "Shield" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 75 }
+  },
+  "bard": {
+    "optionA": {
+      "weapons": [
+        { "name": "Dagger", "dmg": "1d4 piercing", "notes": "×2" }
+      ],
+      "gear": [
+        { "name": "Leather Armor", "equipped": true },
+        { "name": "Musical Instrument (your choice)" },
+        { "name": "Entertainer's Pack" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 100 }
+  },
+  "cleric": {
+    "optionA": {
+      "weapons": [
+        { "name": "Mace", "dmg": "1d6 bludgeoning" }
+      ],
+      "gear": [
+        { "name": "Chain Mail", "equipped": true },
+        { "name": "Shield" },
+        { "name": "Holy Symbol" },
+        { "name": "Priest's Pack" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 110 }
+  },
+  "druid": {
+    "optionA": {
+      "weapons": [
+        { "name": "Quarterstaff", "dmg": "1d6 bludgeoning" }
+      ],
+      "gear": [
+        { "name": "Leather Armor", "equipped": true },
+        { "name": "Shield" },
+        { "name": "Druidic Focus (Wooden Staff)" },
+        { "name": "Herbalism Kit" },
+        { "name": "Explorer's Pack" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 50 }
+  },
+  "fighter": {
+    "optionA": {
+      "weapons": [
+        { "name": "Longsword", "dmg": "1d8 slashing" },
+        { "name": "Light Crossbow", "dmg": "1d8 piercing", "notes": "80/320 ft" }
+      ],
+      "gear": [
+        { "name": "Chain Mail", "equipped": true },
+        { "name": "Shield" },
+        { "name": "Crossbow Bolts (20)" },
+        { "name": "Dungeoneer's Pack" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 175 }
+  },
+  "monk": {
+    "optionA": {
+      "weapons": [
+        { "name": "Shortsword", "dmg": "1d6 piercing" }
+      ],
+      "gear": [
+        { "name": "Dungeoneer's Pack" },
+        { "name": "Artisan's Tools (your choice)" }
+      ],
+      "gp": 11
+    },
+    "optionB": { "gp": 50 }
+  },
+  "paladin": {
+    "optionA": {
+      "weapons": [
+        { "name": "Longsword", "dmg": "1d8 slashing" }
+      ],
+      "gear": [
+        { "name": "Chain Mail", "equipped": true },
+        { "name": "Shield" },
+        { "name": "Holy Symbol" },
+        { "name": "Priest's Pack" }
+      ],
+      "gp": 9
+    },
+    "optionB": { "gp": 150 }
+  },
+  "ranger": {
+    "optionA": {
+      "weapons": [
+        { "name": "Shortsword", "dmg": "1d6 piercing", "notes": "×2" },
+        { "name": "Longbow", "dmg": "1d8 piercing", "notes": "150/600 ft" }
+      ],
+      "gear": [
+        { "name": "Leather Armor", "equipped": true },
+        { "name": "Arrows (20)" },
+        { "name": "Dungeoneer's Pack" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 150 }
+  },
+  "rogue": {
+    "optionA": {
+      "weapons": [
+        { "name": "Shortsword", "dmg": "1d6 piercing" },
+        { "name": "Shortbow", "dmg": "1d6 piercing", "notes": "80/320 ft" },
+        { "name": "Dagger", "dmg": "1d4 piercing", "notes": "×2" }
+      ],
+      "gear": [
+        { "name": "Leather Armor", "equipped": true },
+        { "name": "Arrows (20)" },
+        { "name": "Burglar's Pack" },
+        { "name": "Thieves' Tools" }
+      ],
+      "gp": 0
+    },
+    "optionB": { "gp": 100 }
+  },
+  "sorcerer": {
+    "optionA": {
+      "weapons": [
+        { "name": "Dagger", "dmg": "1d4 piercing", "notes": "×2" },
+        { "name": "Light Crossbow", "dmg": "1d8 piercing", "notes": "80/320 ft" }
+      ],
+      "gear": [
+        { "name": "Arcane Focus (Crystal)" },
+        { "name": "Crossbow Bolts (20)" },
+        { "name": "Dungeoneer's Pack" }
+      ],
+      "gp": 50
+    },
+    "optionB": { "gp": 50 }
+  },
+  "warlock": {
+    "optionA": {
+      "weapons": [
+        { "name": "Dagger", "dmg": "1d4 piercing", "notes": "×2" }
+      ],
+      "gear": [
+        { "name": "Leather Armor", "equipped": true },
+        { "name": "Arcane Focus (Orb)" },
+        { "name": "Scholar's Pack" }
+      ],
+      "gp": 15
+    },
+    "optionB": { "gp": 100 }
+  },
+  "wizard": {
+    "optionA": {
+      "weapons": [
+        { "name": "Dagger", "dmg": "1d4 piercing", "notes": "×2" }
+      ],
+      "gear": [
+        { "name": "Spellbook" },
+        { "name": "Arcane Focus (Quarterstaff)" },
+        { "name": "Scholar's Pack" }
+      ],
+      "gp": 5
+    },
+    "optionB": { "gp": 50 }
+  }
+}


### PR DESCRIPTION
Inserts a new final wizard step (step 7 for non-casters, step 8 for spellcasters) where the player chooses between a class kit or a gold budget, plus their background gold is always shown and added.

Data:
- New asset: assets/data/equipment/class-equipment-2024.json Covers all 12 classes; each entry has optionA (weapons[], gear[], gp) and optionB (gp). Loaded lazily via shareReplay when entering the step.
- BACKGROUND_GOLD map in DndResourcesService: PHB background → starting gp (defaults to 15 gp for expansion backgrounds not listed)
- ClassEquipment, WeaponEntry, GearEntry, EquipmentOptionA interfaces added to dnd-api.types.ts

Wizard:
- totalSteps: 6/7 → 7/8 (non-caster/caster)
- equipmentStep getter: always the last step (7 or 8)
- canAdvance: equipment step requires a choice ('A' or 'B')
- Spell block guarded with isSpellcastingClass so non-casters skip it
- Equipment step loads JSON asset on first entry (lazy, cached)
- submit(): buildStartingCoins() sums background gold + class option gold; weapons/gear populated from optionA data if chosen, otherwise empty

UI: two card buttons (Starter Kit vs Buy Your Own) in a 2-column grid; background gold shown below as a detail row.