### PR TITLE
feat: add character review step as final wizard step

### DIFF
--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
@@ -478,6 +478,206 @@
     </div>
   </ng-container>
 
+  <!-- ── Review Step ────────────────────────────────────────────────── -->
+  <ng-container *ngIf="step === reviewStep">
+    <div class="modal-title">Review Your Hero</div>
+    <div class="modal-sub">Everything looks right? Click Inscribe to bring your hero to life.</div>
+
+    <!-- Combat stats banner -->
+    <div class="review-stat-bar">
+      <div class="review-stat">
+        <span class="review-stat-label">HP</span>
+        <span class="review-stat-value">{{ reviewHp }}</span>
+      </div>
+      <div class="review-stat">
+        <span class="review-stat-label">AC</span>
+        <span class="review-stat-value">{{ reviewAc }}</span>
+      </div>
+      <div class="review-stat">
+        <span class="review-stat-label">Initiative</span>
+        <span class="review-stat-value">{{ reviewInitiative }}</span>
+      </div>
+      <div class="review-stat">
+        <span class="review-stat-label">Speed</span>
+        <span class="review-stat-value">30 ft</span>
+      </div>
+      <div class="review-stat">
+        <span class="review-stat-label">Prof Bonus</span>
+        <span class="review-stat-value">+2</span>
+      </div>
+    </div>
+
+    <div class="review-scroll">
+
+      <!-- Identity -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Identity</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(1)">Edit</button>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Name</span>
+          <span class="review-value">{{ name }}</span>
+        </div>
+        <div *ngIf="player" class="review-row">
+          <span class="review-label">Player</span>
+          <span class="review-value">{{ player }}</span>
+        </div>
+        <div *ngIf="party" class="review-row">
+          <span class="review-label">Party</span>
+          <span class="review-value">{{ party }}</span>
+        </div>
+      </div>
+
+      <!-- Species -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Species</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(2)">Edit</button>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Species</span>
+          <span class="review-value">{{ species }}</span>
+        </div>
+        <div *ngIf="speciesDetail" class="review-row">
+          <span class="review-label">Size / Speed</span>
+          <span class="review-value">{{ speciesDetail.size }}, {{ speciesDetail.speed }} ft.</span>
+        </div>
+        <div *ngIf="reviewSpeciesTraitNames" class="review-row">
+          <span class="review-label">Traits</span>
+          <span class="review-value review-value--wrap">{{ reviewSpeciesTraitNames }}</span>
+        </div>
+      </div>
+
+      <!-- Class -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Class</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(3)">Edit</button>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Class</span>
+          <span class="review-value">{{ clazz }}</span>
+        </div>
+        <div *ngIf="selectedSubclass" class="review-row">
+          <span class="review-label">Subclass</span>
+          <span class="review-value">{{ selectedSubclass }}</span>
+        </div>
+        <div *ngIf="classDetail" class="review-row">
+          <span class="review-label">Hit Die</span>
+          <span class="review-value">d{{ classDetail.hit_die }}</span>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Saving Throws</span>
+          <span class="review-value">{{ classSavingThrows }}</span>
+        </div>
+      </div>
+
+      <!-- Background -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Background</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(4)">Edit</button>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Background</span>
+          <span class="review-value">{{ background }}</span>
+        </div>
+        <div *ngIf="backgroundFeatName" class="review-row">
+          <span class="review-label">Origin Feat</span>
+          <span class="review-value">{{ backgroundFeatName }}</span>
+        </div>
+        <div *ngIf="bonusPlus2 && bonusPlus1" class="review-row">
+          <span class="review-label">Ability Bonuses</span>
+          <span class="review-value">+2 {{ bonusPlus2 }}, +1 {{ bonusPlus1 }}</span>
+        </div>
+      </div>
+
+      <!-- Proficiencies & Languages -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Proficiencies &amp; Languages</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(5)">Edit</button>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Skills</span>
+          <span class="review-value review-value--wrap">{{ reviewAllSkills.join(', ') || '—' }}</span>
+        </div>
+        <div *ngIf="backgroundToolProfs.length" class="review-row">
+          <span class="review-label">Tools</span>
+          <span class="review-value review-value--wrap">{{ backgroundToolProfs.join(', ') }}</span>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Languages</span>
+          <span class="review-value">Common{{ languageChoice ? ', ' + languageChoice : '' }}</span>
+        </div>
+      </div>
+
+      <!-- Ability Scores -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Ability Scores</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(6)">Edit</button>
+        </div>
+        <div class="review-ability-grid">
+          <div *ngFor="let ability of abilities" class="review-ability">
+            <span class="review-ability-label">{{ ability }}</span>
+            <span class="review-ability-score">{{ finalScore(ability) }}</span>
+            <span class="review-ability-mod">{{ modifier(finalScore(ability)) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Spells (casters only) -->
+      <div *ngIf="isSpellcastingClass" class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Spells</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(7)">Edit</button>
+        </div>
+        <ng-container *ngIf="selectedSpells.length === 0">
+          <div class="review-row">
+            <span class="review-value review-value--muted">No spells selected yet</span>
+          </div>
+        </ng-container>
+        <div *ngIf="reviewCantripNames" class="review-row">
+          <span class="review-label">Cantrips</span>
+          <span class="review-value review-value--wrap">{{ reviewCantripNames }}</span>
+        </div>
+        <div *ngIf="reviewLeveledSpellNames" class="review-row">
+          <span class="review-label">1st Level</span>
+          <span class="review-value review-value--wrap">{{ reviewLeveledSpellNames }}</span>
+        </div>
+      </div>
+
+      <!-- Starting Equipment -->
+      <div class="review-section">
+        <div class="review-section-header">
+          <span class="review-section-title">Starting Equipment</span>
+          <button type="button" class="btn review-edit-btn" (click)="goToStep(equipmentStep)">Edit</button>
+        </div>
+        <ng-container *ngIf="equipmentChoice === 'A' && currentClassEquipment">
+          <div *ngIf="reviewWeaponNames" class="review-row">
+            <span class="review-label">Weapons</span>
+            <span class="review-value review-value--wrap">{{ reviewWeaponNames }}</span>
+          </div>
+          <div *ngIf="reviewGearNames" class="review-row">
+            <span class="review-label">Gear</span>
+            <span class="review-value review-value--wrap">{{ reviewGearNames }}</span>
+          </div>
+        </ng-container>
+        <div *ngIf="equipmentChoice === 'B'" class="review-row">
+          <span class="review-label">Gold Budget</span>
+          <span class="review-value">{{ currentClassEquipment?.optionB?.gp ?? 0 }} gp to spend</span>
+        </div>
+        <div class="review-row">
+          <span class="review-label">Starting Gold</span>
+          <span class="review-value">{{ reviewStartingGp }} gp total</span>
+        </div>
+      </div>
+
+    </div><!-- end .review-scroll -->
+  </ng-container>
+
   <!-- ── Actions ─────────────────────────────────────────────────────── -->
   <div class="modal-actions">
     <button class="btn" type="button" (click)="step > 1 ? back() : cancel()">

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
@@ -891,3 +891,170 @@
   min-width: 160px;
   margin-bottom: 0;
 }
+
+// ── Review step ───────────────────────────────────────────────────────────
+
+.review-stat-bar {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-bottom: 18px;
+  padding: 12px 0;
+  border-top: 1px solid var(--border-soft);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.review-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.review-stat-label {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.review-stat-value {
+  font-family: 'Cinzel', serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--gold);
+  line-height: 1;
+}
+
+.review-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 340px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+  padding-right: 4px;
+}
+
+.review-section {
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+
+  &:last-child { border-bottom: none; }
+}
+
+.review-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.review-section-title {
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--gold);
+  opacity: 0.8;
+}
+
+.review-edit-btn {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  color: rgba(255, 255, 255, 0.4);
+  border-color: rgba(255, 255, 255, 0.12);
+  background: transparent;
+
+  &:hover {
+    color: var(--gold);
+    border-color: rgba(212, 176, 106, 0.4);
+    background: rgba(212, 176, 106, 0.06);
+  }
+}
+
+.review-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  padding: 2px 0;
+  font-size: 13px;
+}
+
+.review-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.35);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.review-value {
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 500;
+  text-align: right;
+
+  &--wrap {
+    text-align: right;
+    word-break: break-word;
+    white-space: normal;
+  }
+
+  &--muted {
+    color: rgba(255, 255, 255, 0.3);
+    font-style: italic;
+    font-size: 12px;
+  }
+}
+
+.review-ability-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+}
+
+.review-ability {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 7px 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 4px;
+}
+
+.review-ability-label {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.35);
+  text-transform: uppercase;
+}
+
+.review-ability-score {
+  font-family: 'Cinzel', serif;
+  font-size: 17px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1;
+}
+
+.review-ability-mod {
+  font-family: 'EB Garamond', serif;
+  font-size: 12px;
+  color: #a78bfa;
+  font-style: italic;
+}

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.spec.ts
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.spec.ts
@@ -75,15 +75,22 @@ describe('CreateCharacterModalComponent — logic', () => {
 
   // ── Step count ────────────────────────────────────────────────────────────
 
-  describe('totalSteps', () => {
-    it('is 7 for a non-spellcasting class (Fighter)', () => {
+  describe('totalSteps / reviewStep / equipmentStep', () => {
+    it('totalSteps is 8 for a non-spellcasting class (Fighter)', () => {
       component.clazz = 'Fighter';
-      expect(component.totalSteps).toBe(7);
+      expect(component.totalSteps).toBe(8);
     });
 
-    it('is 8 for a spellcasting class (Wizard)', () => {
+    it('totalSteps is 9 for a spellcasting class (Wizard)', () => {
       component.clazz = 'Wizard';
-      expect(component.totalSteps).toBe(8);
+      expect(component.totalSteps).toBe(9);
+    });
+
+    it('reviewStep is the last step (equals totalSteps)', () => {
+      component.clazz = 'Fighter';
+      expect(component.reviewStep).toBe(component.totalSteps);
+      component.clazz = 'Wizard';
+      expect(component.reviewStep).toBe(component.totalSteps);
     });
 
     it('equipmentStep is 7 for non-casters', () => {
@@ -589,6 +596,103 @@ describe('CreateCharacterModalComponent — logic', () => {
       });
 
       component.submit();
+    });
+  });
+
+  // ── Review step ───────────────────────────────────────────────────────────
+
+  describe('canAdvance at review step', () => {
+    it('is always true at the review step', () => {
+      component.clazz = 'Fighter';
+      component.step = component.reviewStep;
+      expect(component.canAdvance).toBeTrue();
+    });
+
+    it('is always true at the review step for casters', () => {
+      component.clazz = 'Wizard';
+      component.step = component.reviewStep;
+      expect(component.canAdvance).toBeTrue();
+    });
+  });
+
+  describe('goToStep', () => {
+    it('sets step to the given value', () => {
+      component.step = component.reviewStep;
+      component.goToStep(3);
+      expect(component.step).toBe(3);
+    });
+
+    it('can jump back to step 1 from review', () => {
+      component.step = component.reviewStep;
+      component.goToStep(1);
+      expect(component.step).toBe(1);
+    });
+  });
+
+  describe('review computed properties', () => {
+    beforeEach(() => {
+      component.abilityMethod = 'standard';
+      component.assignments = { STR: 8, DEX: 12, CON: 13, INT: 15, WIS: 14, CHA: 10 };
+      component.bonusPlus2 = 'INT';
+      component.bonusPlus1 = 'WIS';
+      (component as any).classDetail = { hit_die: 6, saving_throws: [{ name: 'INT' }, { name: 'WIS' }] };
+    });
+
+    it('reviewHp = hit die + CON modifier', () => {
+      // d6 + CON mod(13) = 6 + 1 = 7
+      expect(component.reviewHp).toBe(7);
+    });
+
+    it('reviewAc = 10 + DEX modifier', () => {
+      // 10 + mod(12) = 10 + 1 = 11
+      expect(component.reviewAc).toBe(11);
+    });
+
+    it('reviewInitiative matches formatted DEX modifier', () => {
+      expect(component.reviewInitiative).toBe('+1'); // DEX 12 → +1
+    });
+
+    it('reviewAllSkills deduplicates background and class skills', () => {
+      // Background mock grants Arcana and History; selected also includes them
+      component.selectedSkills = ['Arcana', 'History'];
+      const skills = component.reviewAllSkills;
+      const arcanaCount = skills.filter(s => s === 'Arcana').length;
+      expect(arcanaCount).toBe(1);
+    });
+
+    it('reviewAllSkills combines background and extra class skills', () => {
+      component.selectedSkills = ['Insight', 'Investigation'];
+      const skills = component.reviewAllSkills;
+      expect(skills).toContain('Arcana');    // from background
+      expect(skills).toContain('History');   // from background
+      expect(skills).toContain('Insight');   // class pick
+      expect(skills).toContain('Investigation'); // class pick
+    });
+
+    it('reviewCantripNames lists only cantrip names', () => {
+      component.selectedSpells = [
+        { level: 0, name: 'Prestidigitation', school: 'transmutation', actionType: '1 action', classes: [], concentration: false, ritual: false, range: '', components: [], duration: '', description: '', material: '' },
+        { level: 1, name: 'Magic Missile',    school: 'evocation',     actionType: '1 action', classes: [], concentration: false, ritual: false, range: '', components: [], duration: '', description: '', material: '' },
+      ];
+      expect(component.reviewCantripNames).toBe('Prestidigitation');
+    });
+
+    it('reviewLeveledSpellNames lists only leveled spell names', () => {
+      component.selectedSpells = [
+        { level: 0, name: 'Prestidigitation', school: 'transmutation', actionType: '1 action', classes: [], concentration: false, ritual: false, range: '', components: [], duration: '', description: '', material: '' },
+        { level: 1, name: 'Magic Missile',    school: 'evocation',     actionType: '1 action', classes: [], concentration: false, ritual: false, range: '', components: [], duration: '', description: '', material: '' },
+      ];
+      expect(component.reviewLeveledSpellNames).toBe('Magic Missile');
+    });
+
+    it('reviewStartingGp totals background gold + class gold (Option B)', () => {
+      component.clazz = 'Wizard';
+      component.equipmentChoice = 'B';
+      component.classEquipmentData = {
+        wizard: { optionA: { weapons: [], gear: [], gp: 0 }, optionB: { gp: 25 } }
+      };
+      // Background gold mock = 15, class option B = 25
+      expect(component.reviewStartingGp).toBe(40);
     });
   });
 });

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.ts
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.ts
@@ -27,12 +27,17 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   }
 
   get totalSteps(): number {
+    return this.isSpellcastingClass ? 9 : 8;
+  }
+
+  /** The step number for equipment — one before the review step. */
+  get equipmentStep(): number {
     return this.isSpellcastingClass ? 8 : 7;
   }
 
-  /** The step number for equipment — always the last step. */
-  get equipmentStep(): number {
-    return this.isSpellcastingClass ? 8 : 7;
+  /** The final review step — always the last step. */
+  get reviewStep(): number {
+    return this.isSpellcastingClass ? 9 : 8;
   }
 
   get stepRange(): number[] {
@@ -335,7 +340,9 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   // ── Navigation ───────────────────────────────────────────────────────────
 
   get canAdvance(): boolean {
-    // Equipment is always the final step regardless of class
+    // Review step: Inscribe is always available once you reach it
+    if (this.step === this.reviewStep) return true;
+    // Equipment step gate
     if (this.step === this.equipmentStep) return !!this.equipmentChoice;
 
     switch (this.step) {
@@ -386,6 +393,61 @@ export class CreateCharacterModalComponent implements OnInit, OnDestroy {
   }
 
   back(): void { if (this.step > 1) this.step--; }
+
+  /** Jump directly to any step — used by Edit buttons in the review step. */
+  goToStep(n: number): void { this.step = n; }
+
+  // ── Review step computed properties ──────────────────────────────────────
+
+  get reviewHp(): number {
+    const hitDie = this.classDetail?.hit_die ?? 8;
+    return hitDie + this.modNum(this.finalScore('CON'));
+  }
+
+  get reviewAc(): number {
+    return 10 + this.modNum(this.finalScore('DEX'));
+  }
+
+  get reviewInitiative(): string {
+    return this.modifier(this.finalScore('DEX'));
+  }
+
+  /** Combined skill proficiencies: background (locked) + class choices */
+  get reviewAllSkills(): string[] {
+    const seen = new Set<string>();
+    return [...this.backgroundSkillProfs, ...this.selectedSkills].filter(s => {
+      if (seen.has(s)) return false;
+      seen.add(s);
+      return true;
+    });
+  }
+
+  get reviewSpeciesTraitNames(): string {
+    return (this.speciesDetail?.traits ?? []).map(t => t.name).join(', ');
+  }
+
+  get reviewCantripNames(): string {
+    return this.selectedSpells.filter(s => s.level === 0).map(s => s.name).join(', ');
+  }
+
+  get reviewLeveledSpellNames(): string {
+    return this.selectedSpells.filter(s => s.level > 0).map(s => s.name).join(', ');
+  }
+
+  get reviewWeaponNames(): string {
+    return (this.currentClassEquipment?.optionA.weapons ?? []).map(w => w.name).join(', ');
+  }
+
+  get reviewGearNames(): string {
+    return (this.currentClassEquipment?.optionA.gear ?? []).map(g => g.name).join(', ');
+  }
+
+  get reviewStartingGp(): number {
+    return this.backgroundStartingGold
+      + (this.equipmentChoice === 'A'
+          ? (this.currentClassEquipment?.optionA.gp ?? 0)
+          : (this.currentClassEquipment?.optionB.gp ?? 0));
+  }
 
   // ── Class detail ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
New reviewStep getter (8 for non-casters, 9 for casters); totalSteps updated to include it; equipmentStep unchanged Review shows a scrollable summary of every wizard choice: identity, species (traits/size/speed), class (subclass, hit die, saves), background (feat, ability bonuses), proficiencies & languages, ability score grid with modifiers, spells (casters), starting equipment, and a combat stat banner (HP, AC, Initiative, Speed, Prof Bonus) Each section has an Edit button that jumps back to its step via goToStep(); Inscribe button remains at the bottom via the existing step === totalSteps pattern canAdvance returns true at the review step so Inscribe is never blocked Review computed getters: reviewHp, reviewAc, reviewInitiative, reviewAllSkills (deduped), reviewCantripNames, reviewLeveledSpellNames, reviewWeaponNames, reviewGearNames, reviewStartingGp 13 new spec tests covering all review getters, goToStep, and canAdvance at review step 197/197 tests pass, clean ng build