### PR TITLE
chore: add GitHub Actions CI/CD and environment API URL slots

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,92 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-east-1
+  NODE_VERSION: "18"  # Angular 14 requires Node 14-18
+
+jobs:
+  build-and-deploy:
+    name: Build, upload & invalidate
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write   # required for OIDC
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build ─────────────────────────────────────────────────────────────────
+
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Overwrite the production environment file with real API URLs.
+      # AUTH_SERVICE_URL and CHARACTER_SERVICE_URL come from the Terraform outputs
+      # of table-mimic (auth_service_url and character_service_url).
+      - name: Inject production API URLs
+        env:
+          AUTH_URL: ${{ secrets.AUTH_SERVICE_URL }}
+          CHARACTER_URL: ${{ secrets.CHARACTER_SERVICE_URL }}
+        run: |
+          cat > src/environments/environment.prod.ts << 'ENVEOF'
+          export const environment = {
+            production: true,
+            demoMode: false,
+            authApiUrl: '${AUTH_URL}',
+            characterApiUrl: '${CHARACTER_URL}',
+          };
+          ENVEOF
+          # Expand the shell variables (heredoc keeps them literal above)
+          sed -i "s|\${AUTH_URL}|${AUTH_URL}|g" src/environments/environment.prod.ts
+          sed -i "s|\${CHARACTER_URL}|${CHARACTER_URL}|g" src/environments/environment.prod.ts
+
+      - name: Build
+        run: npm run build -- --configuration production
+
+      # ── AWS credentials via OIDC ──────────────────────────────────────────────
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ── Deploy to S3 ──────────────────────────────────────────────────────────
+      # Angular uses outputHashing: "all" in production, so JS/CSS/image filenames
+      # contain a content hash. Those can be cached indefinitely — only index.html
+      # needs a short TTL so deploys are visible quickly.
+
+      - name: Sync dist/ to S3
+        run: |
+          # Long-cache all hashed assets (Angular adds content hash to filenames)
+          aws s3 sync dist/character-creator/ "s3://${{ secrets.S3_BUCKET }}/" \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" \
+            --region "$AWS_REGION"
+
+          # Short-cache index.html so new deploys are picked up immediately
+          aws s3 cp dist/character-creator/index.html \
+            "s3://${{ secrets.S3_BUCKET }}/index.html" \
+            --cache-control "public, max-age=0, must-revalidate" \
+            --region "$AWS_REGION"
+
+      # ── CloudFront invalidation ───────────────────────────────────────────────
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+            --paths "/*"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,9 @@
+// Production values are injected by the CI/CD workflow at build time.
+// Do not hardcode API URLs here — they are written by deploy.yml using
+// the AUTH_SERVICE_URL and CHARACTER_SERVICE_URL GitHub Actions secrets.
 export const environment = {
   production: true,
-  demoMode: false  // Production should use real APIs
+  demoMode: false,
+  authApiUrl: '',
+  characterApiUrl: '',
 };


### PR DESCRIPTION
- Updated environment.prod.ts to include authApiUrl and characterApiUrl fields. Values are injected at build time by the CI/CD workflow using AUTH_SERVICE_URL and CHARACTER_SERVICE_URL GitHub Actions secrets.
- Added .github/workflows/deploy.yml: OIDC auth, Node 18 build, API URL injection into environment.prod.ts, S3 sync with split cache-control (1yr for hashed assets, 0 for index.html), CloudFront invalidation.