### PR TITLE
ci: run deploy job in the production GitHub Environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
   build-and-deploy:
     name: Build, upload & invalidate
     runs-on: ubuntu-latest
+    # Runs in the "production" GitHub Environment so the OIDC token subject is
+    # repo:<org>/<repo>:environment:production — matching the deploy role's trust.
+    environment: production
 
     permissions:
       id-token: write   # required for OIDC


### PR DESCRIPTION
Matches the frontend deploy role's OIDC trust (repo:<org>/<repo>:environment: production) so sts:AssumeRoleWithWebIdentity succeeds.