### PR TITLE
build: raise anyComponentStyle budget to fit modal stylesheet

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,8 +37,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "8kb",
+                  "maximumError": "16kb"
                 }
               ],
               "fileReplacements": [


### PR DESCRIPTION
The production build failed because create-character-modal.component.scss (14.8 kB) exceeded the 4 kB per-component style budget. Raise the budget to 8 kB warn / 16 kB error so the production build passes.