### PR TITLE
fix: use injected API URLs instead of hardcoded localhost

### DIFF
--- a/src/app/charactermanager/services/auth.service.ts
+++ b/src/app/charactermanager/services/auth.service.ts
@@ -8,7 +8,7 @@ import { environment } from '../../../environments/environment';
   providedIn: 'root'
 })
 export class AuthService {
-  private authUrl = 'http://localhost:8085/api/v1/auth';
+  private authUrl = `${environment.authApiUrl}/api/v1/auth`;
 
   constructor(private router: Router, private http: HttpClient) {}
 

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -210,7 +210,7 @@ export class PCService {
 
   constructor(private http: HttpClient) {}
 
-  readonly pcUrl = 'http://localhost:8080/api/v1/pc/';
+  readonly pcUrl = `${environment.characterApiUrl}/api/v1/pc/`;
 
   // Pushes a known list into the reactive stream (used by external loaders)
   setPCs(pcs: PC[]) {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,9 @@
 
 export const environment = {
   production: false,
-  demoMode: false
+  demoMode: false,
+  authApiUrl: 'http://localhost:8085',
+  characterApiUrl: 'http://localhost:8080'
 };
 
 /*


### PR DESCRIPTION
auth.service and pc.service hardcoded http://localhost:8085/8080, so the deployed site called localhost and registration failed. Read the base URLs from environment.authApiUrl/characterApiUrl (injected at build time from the AUTH_SERVICE_URL/CHARACTER_SERVICE_URL secrets). Add those fields to the dev environment too so local development still points at localhost.