### PR TITLE
feat: add DM mode shell with campaign dashboard (Phase 1)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { PreferencesService } from './charactermanager/services/preferences.service';
 
 @Component({
   selector: 'app-root',
@@ -8,4 +9,8 @@ import { Component } from '@angular/core';
 export class AppComponent {
 
   title = 'character-creator';
+
+  // Injected at bootstrap so the persisted theme (data-theme on <html>) is
+  // applied on the first paint, before any settings panel is opened.
+  constructor(private _prefs: PreferencesService) {}
 }

--- a/src/app/charactermanager/charactermanager-app.component.ts
+++ b/src/app/charactermanager/charactermanager-app.component.ts
@@ -5,6 +5,9 @@ import { Subscription } from 'rxjs';
 import { PC } from './models/pc';
 import { PCService } from './services/pc.service';
 import { CharacterModalService } from './services/character-modal.service';
+import { CampaignModalService } from './services/campaign-modal.service';
+import { UiStateService } from './services/ui-state.service';
+import { CampaignDraft } from './models/campaign';
 
 @Component({
   selector: 'app-charactermanager-app',
@@ -21,18 +24,35 @@ import { CharacterModalService } from './services/character-modal.service';
         (close)="closeCreate()">
       </app-create-character-modal>
     </div>
+
+    <!-- Create-campaign overlay (DM mode) -->
+    <div *ngIf="isCampaignModalOpen"
+         class="modal-backdrop"
+         (click)="closeCampaign()">
+      <app-create-campaign-modal
+        (confirm)="onCreateCampaign($event)"
+        (close)="closeCampaign()">
+      </app-create-campaign-modal>
+    </div>
+
+    <!-- Settings slide-over (its own fixed backdrop + panel) -->
+    <app-settings-panel *ngIf="isSettingsOpen"></app-settings-panel>
   `,
   styles: []
 })
 export class CharactermanagerAppComponent implements OnInit, OnDestroy {
   pcs: PC[] = [];
   isCreateModalOpen = false;
+  isCampaignModalOpen = false;
+  isSettingsOpen = false;
 
   private subs: Subscription[] = [];
 
   constructor(
     private pcService: PCService,
     private characterModal: CharacterModalService,
+    private campaignModal: CampaignModalService,
+    private uiState: UiStateService,
     private router: Router,
   ) {}
 
@@ -41,6 +61,8 @@ export class CharactermanagerAppComponent implements OnInit, OnDestroy {
       this.pcService.pcs$.subscribe(pcs => { this.pcs = pcs; }),
 
       this.characterModal.isOpen$.subscribe(open => { this.isCreateModalOpen = open; }),
+      this.campaignModal.isOpen$.subscribe(open => { this.isCampaignModalOpen = open; }),
+      this.uiState.settingsOpen$.subscribe(open => { this.isSettingsOpen = open; }),
 
       this.router.events
         .pipe(filter(e => e instanceof NavigationEnd))
@@ -60,4 +82,7 @@ export class CharactermanagerAppComponent implements OnInit, OnDestroy {
 
   closeCreate(): void  { this.characterModal.closeCreateModal(); }
   onCreate(draft: Partial<PC>): void { this.characterModal.onCreated(draft); }
+
+  closeCampaign(): void { this.campaignModal.closeCreateModal(); }
+  onCreateCampaign(draft: CampaignDraft): void { this.campaignModal.onCreated(draft); }
 }

--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -19,6 +19,16 @@ import { BackgroundStoryComponent } from './components/character-sheet/panels/ba
 import { CreateCharacterModalComponent } from './components/create-character-modal/create-character-modal.component';
 import { DeleteConfirmationModalComponent } from './components/main-content/delete-confirmation-modal/delete-confirmation-modal.component';
 
+// ── DM mode ──────────────────────────────────────────────────────────────
+import { SettingsPanelComponent } from './components/settings-panel/settings-panel.component';
+import { RoleSwitchComponent } from './components/settings-panel/role-switch/role-switch.component';
+import { CampaignSidebarComponent } from './components/campaign-sidebar/campaign-sidebar.component';
+import { CampaignDashboardComponent } from './components/campaign-dashboard/campaign-dashboard.component';
+import { PartyBoardComponent } from './components/campaign-dashboard/party-board/party-board.component';
+import { CampaignChronicleComponent } from './components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component';
+import { PartyTreasuryComponent } from './components/campaign-dashboard/party-treasury/party-treasury.component';
+import { CreateCampaignModalComponent } from './components/create-campaign-modal/create-campaign-modal.component';
+
 import { MaterialModule } from '../shared/material.module';
 import { HttpClientModule } from '@angular/common/http';
 import { PCService } from './services/pc.service';
@@ -56,6 +66,14 @@ const routes: Routes = [
     FeaturesListComponent,
     CoinPurseComponent,
     BackgroundStoryComponent,
+    SettingsPanelComponent,
+    RoleSwitchComponent,
+    CampaignSidebarComponent,
+    CampaignDashboardComponent,
+    PartyBoardComponent,
+    CampaignChronicleComponent,
+    PartyTreasuryComponent,
+    CreateCampaignModalComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component.html
@@ -1,0 +1,23 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Campaign Chronicle</span>
+    <span style="font-family: 'EB Garamond', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      {{ campaign.arc }}
+    </span>
+  </div>
+
+  <p class="prose"><span class="drop">{{ dropCap }}</span>{{ rest }}</p>
+
+  <div style="margin-top: 18px;" *ngIf="campaign.threads.length">
+    <span class="eyebrow" style="display: block; margin-bottom: 4px;">Open Threads</span>
+    <div class="thread" *ngFor="let t of campaign.threads">
+      <span class="thread-mark">✦</span>
+      <span>{{ t }}</span>
+    </div>
+  </div>
+
+  <div class="secrets-box" *ngIf="campaign.secrets">
+    <span class="eyebrow">DM Secrets · hidden from players</span>
+    <p>{{ campaign.secrets }}</p>
+  </div>
+</div>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { Campaign } from '../../../models/campaign';
+
+/** Campaign Chronicle: prose recap (drop cap), open threads, DM-only secrets. */
+@Component({
+  selector: 'app-campaign-chronicle',
+  templateUrl: './campaign-chronicle.component.html',
+})
+export class CampaignChronicleComponent {
+  @Input() campaign!: Campaign;
+
+  get dropCap(): string { return this.campaign.chronicle.charAt(0); }
+  get rest(): string { return this.campaign.chronicle.slice(1); }
+}

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -1,0 +1,88 @@
+<ng-container *ngIf="vm$ | async as vm; else empty">
+  <div class="fade-in">
+
+    <!-- Header -->
+    <header class="sheet-header" style="grid-template-columns: 1fr auto;">
+      <div class="sheet-id">
+        <div class="eyebrow">Campaign · Session {{ vm.campaign.session }} · {{ vm.members.length }} heroes</div>
+        <h1 class="sheet-name">{{ vm.campaign.name }}</h1>
+        <div class="sheet-subtitle">
+          {{ vm.campaign.setting }}<span class="dot">✦</span><em>{{ vm.campaign.arc }}</em>
+        </div>
+      </div>
+      <div class="sheet-actions">
+        <button class="btn">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <path d="M8 1l6 3.5v7L8 15l-6-3.5v-7L8 1z"/><path d="M8 1v14M2 4.5l6 3.5 6-3.5"/>
+          </svg>
+          Roll Initiative
+        </button>
+        <button class="btn">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <path d="M2 3a1 1 0 011-1h4a1 1 0 011 1v11M8 3a1 1 0 011-1h4a1 1 0 011 1v11M2 14h12"/>
+          </svg>
+          New Session
+        </button>
+      </div>
+    </header>
+
+    <!-- Aggregate vitals strip -->
+    <div class="vitals" style="grid-template-columns: repeat(5, minmax(0, 1fr));">
+      <div class="vital">
+        <span class="eyebrow">Heroes</span>
+        <div class="vital-value numeric">{{ vm.members.length }}</div>
+        <div class="vital-caption">at the table</div>
+      </div>
+      <div class="vital">
+        <span class="eyebrow">Avg Level</span>
+        <div class="vital-value numeric">{{ vm.avgLevel }}</div>
+        <div class="vital-caption">party tier</div>
+      </div>
+      <div class="vital">
+        <span class="eyebrow">Top Pass. Perc</span>
+        <div class="vital-value numeric">{{ vm.topPassivePerception }}</div>
+        <div class="vital-caption">set your DCs</div>
+      </div>
+      <div class="vital">
+        <span class="eyebrow">Conditions</span>
+        <div class="vital-value numeric" [style.color]="vm.activeConditions ? 'var(--crimson)' : 'var(--text)'">
+          {{ vm.activeConditions }}
+        </div>
+        <div class="vital-caption">active now</div>
+      </div>
+      <div class="vital">
+        <span class="eyebrow">Next Session</span>
+        <div class="vital-value" style="font-size: 20px;">{{ vm.campaign.next }}</div>
+        <div class="vital-caption">be prepared</div>
+      </div>
+    </div>
+
+    <app-party-board [members]="vm.members" (openHero)="openHero($event)"></app-party-board>
+
+    <div class="dm-cols" style="margin-top: 20px;">
+      <app-campaign-chronicle [campaign]="vm.campaign"></app-campaign-chronicle>
+      <app-party-treasury [members]="vm.members"></app-party-treasury>
+    </div>
+  </div>
+</ng-container>
+
+<ng-template #empty>
+  <div class="empty">
+    <div class="empty-sigil">
+      <!-- SigilEmpty -->
+      <svg viewBox="0 0 120 120" width="120" height="120" fill="none" stroke="currentColor" stroke-width="0.7">
+        <circle cx="60" cy="60" r="56" opacity="0.4"/>
+        <circle cx="60" cy="60" r="42"/>
+        <circle cx="60" cy="60" r="28"/>
+        <polygon points="60,12 72,46 108,46 78,68 90,104 60,82 30,104 42,68 12,46 48,46"/>
+        <path d="M60 4v112M4 60h112M19 19l82 82M101 19L19 101" opacity="0.4"/>
+      </svg>
+    </div>
+    <div>
+      <div class="empty-title">No Campaign Chosen</div>
+      <div class="empty-sub">Select a campaign from the chronicle to survey your table.</div>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Campaign } from '../../models/campaign';
+import { PC } from '../../models/pc';
+import { CampaignService } from '../../services/campaign.service';
+import { PCService } from '../../services/pc.service';
+import { UiStateService } from '../../services/ui-state.service';
+import { passiveScore } from '../../utils/character-math';
+
+interface DashboardVm {
+  campaign: Campaign;
+  members: PC[];
+  avgLevel: string;
+  topPassivePerception: number | string;
+  activeConditions: number;
+}
+
+/**
+ * DM dashboard shell: header + aggregate vitals strip + party board + the
+ * two-column chronicle/treasury row. Shows an empty state until a campaign is
+ * selected in the campaign sidebar.
+ */
+@Component({
+  selector: 'app-campaign-dashboard',
+  templateUrl: './campaign-dashboard.component.html',
+})
+export class CampaignDashboardComponent {
+  vm$: Observable<DashboardVm | null> = combineLatest([
+    this.uiState.activeCampaignId$,
+    this.campaignService.campaigns$,
+    this.pcService.pcs$,
+  ]).pipe(
+    map(([activeId, campaigns, pcs]) => {
+      const campaign = campaigns.find(c => c.id === activeId) ?? null;
+      if (!campaign) return null;
+      const members = this.campaignService.membersOf(campaign, pcs);
+      const avgLevel = members.length
+        ? (members.reduce((s, m) => s + m.level, 0) / members.length).toFixed(1)
+        : '—';
+      const topPassivePerception = members.length
+        ? Math.max(...members.map(m => passiveScore(m, 'Perception', 'WIS')))
+        : '—';
+      const activeConditions = members.reduce((s, m) => s + (m.conditions?.length ?? 0), 0);
+      return { campaign, members, avgLevel, topPassivePerception, activeConditions };
+    })
+  );
+
+  constructor(
+    private campaignService: CampaignService,
+    private pcService: PCService,
+    private uiState: UiStateService,
+  ) {}
+
+  /** Cross-link: open the clicked hero's full sheet in Player mode. */
+  openHero(pc: PC): void {
+    this.pcService.setActivePC(pc);
+    this.uiState.setRole('player');
+  }
+}

--- a/src/app/charactermanager/components/campaign-dashboard/party-board/party-board.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/party-board/party-board.component.html
@@ -1,0 +1,62 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Party Vitals Board</span>
+    <span style="font-family: 'EB Garamond', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      click a hero to open their sheet
+    </span>
+  </div>
+
+  <div class="board">
+    <div class="board-row head">
+      <span>Hero</span>
+      <span>Hit Points</span>
+      <span class="num">AC</span>
+      <span class="num">Pass. Perc</span>
+      <span class="num">Pass. Ins</span>
+      <span>Conditions</span>
+      <span></span>
+    </div>
+
+    <div *ngIf="members.length === 0"
+         style="padding: 18px 8px; color: var(--text-dim); font-style: italic;">
+      No heroes assigned to this campaign yet.
+    </div>
+
+    <div
+      *ngFor="let pc of members"
+      class="board-row member"
+      (click)="openHero.emit(pc)"
+    >
+      <div class="board-hero">
+        <div class="portrait" [style.background]="tintFor(pc)">{{ initialsFor(pc) }}</div>
+        <div style="min-width: 0;">
+          <div class="board-hero-name">{{ pc.name }}</div>
+          <div class="board-hero-sub">{{ pc.clazz }} {{ pc.level }}</div>
+        </div>
+      </div>
+
+      <div class="board-hp" [class.bloodied]="bloodied(pc)">
+        <div class="hp-text">
+          <span>{{ pc.hp?.cur }}/{{ pc.hp?.max }}<ng-container *ngIf="pc.hp?.temp"> +{{ pc.hp?.temp }}</ng-container></span>
+          <span>{{ hpPct(pc) | number:'1.0-0' }}%</span>
+        </div>
+        <div class="vital-bar"><span [style.width.%]="hpPct(pc)"></span></div>
+      </div>
+
+      <div class="board-num lit">{{ pc.ac }}</div>
+      <div class="board-num">{{ passivePerception(pc) }}</div>
+      <div class="board-num">{{ passiveInsight(pc) }}</div>
+
+      <div class="board-conditions">
+        <span *ngIf="!pc.conditions?.length" class="board-cond calm">steady</span>
+        <span *ngFor="let c of pc.conditions" class="board-cond">{{ c }}</span>
+      </div>
+
+      <!-- IconChevron rotated -->
+      <svg class="board-chev" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5"
+           style="transform: rotate(-90deg);">
+        <path d="M2 4l3 3 3-3"/>
+      </svg>
+    </div>
+  </div>
+</div>

--- a/src/app/charactermanager/components/campaign-dashboard/party-board/party-board.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/party-board/party-board.component.ts
@@ -1,0 +1,37 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { PC } from '../../../models/pc';
+import { passiveScore, tintFor } from '../../../utils/character-math';
+
+/**
+ * Party Vitals Board — one row per campaign member with HP bar, AC, passive
+ * Perception/Insight and conditions. Clicking a row opens that hero's sheet.
+ */
+@Component({
+  selector: 'app-party-board',
+  templateUrl: './party-board.component.html',
+})
+export class PartyBoardComponent {
+  @Input() members: PC[] = [];
+  @Output() openHero = new EventEmitter<PC>();
+
+  tintFor(pc: PC): string { return tintFor(pc); }
+
+  initialsFor(pc: PC): string {
+    return (pc.portraitInitials || pc.name.slice(0, 2)).toUpperCase();
+  }
+
+  hpPct(pc: PC): number {
+    const max = pc.hp?.max ?? 0;
+    const cur = pc.hp?.cur ?? 0;
+    return max <= 0 ? 0 : Math.max(0, Math.min(100, (cur / max) * 100));
+  }
+
+  bloodied(pc: PC): boolean {
+    const max = pc.hp?.max ?? 0;
+    const cur = pc.hp?.cur ?? 0;
+    return max > 0 && cur <= max / 2;
+  }
+
+  passivePerception(pc: PC): number { return passiveScore(pc, 'Perception', 'WIS'); }
+  passiveInsight(pc: PC): number { return passiveScore(pc, 'Insight', 'WIS'); }
+}

--- a/src/app/charactermanager/components/campaign-dashboard/party-treasury/party-treasury.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/party-treasury/party-treasury.component.html
@@ -1,0 +1,18 @@
+<div class="panel">
+  <div class="panel-header"><span class="panel-title">Party Treasury</span></div>
+
+  <div class="treasury-list">
+    <div class="treasury-row" *ngFor="let row of rows">
+      <span class="treasury-name">{{ row.name }}</span>
+      <span class="treasury-amt">{{ row.gp | number:'1.0-0' }} gp</span>
+    </div>
+    <div *ngIf="rows.length === 0" style="color: var(--text-dim); font-style: italic; font-size: 13px;">
+      Empty coffers.
+    </div>
+  </div>
+
+  <div class="treasury-total">
+    <span class="label">Table Total</span>
+    <span class="big numeric">{{ total | number:'1.0-0' }} gp</span>
+  </div>
+</div>

--- a/src/app/charactermanager/components/campaign-dashboard/party-treasury/party-treasury.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/party-treasury/party-treasury.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+import { PC } from '../../../models/pc';
+import { goldValue } from '../../../utils/character-math';
+
+interface TreasuryRow { name: string; gp: number; }
+
+/** Party Treasury: each hero's wealth in gp plus a table total. */
+@Component({
+  selector: 'app-party-treasury',
+  templateUrl: './party-treasury.component.html',
+})
+export class PartyTreasuryComponent {
+  @Input() set members(value: PC[]) {
+    this.rows = value.map(m => ({ name: m.name.split(' ')[0], gp: goldValue(m.coins) }));
+    this.total = value.reduce((sum, m) => sum + goldValue(m.coins), 0);
+  }
+
+  rows: TreasuryRow[] = [];
+  total = 0;
+}

--- a/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.html
+++ b/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.html
@@ -1,0 +1,29 @@
+<div style="padding-top: 8px;">
+
+  <!-- "Your Campaigns" group header -->
+  <div class="party-header" style="cursor: default;">
+    <span class="party-name" style="margin-left: 18px;">Your Campaigns</span>
+    <span class="party-count">{{ padCount((count$ | async) ?? 0) }}</span>
+  </div>
+
+  <div style="padding-top: 4px;">
+    <div
+      *ngFor="let row of rows$ | async"
+      class="campaign-item"
+      [class.active]="(activeCampaignId$ | async) === row.campaign.id"
+      (click)="select(row.campaign.id)"
+    >
+      <!-- IconBanner crest -->
+      <div class="campaign-crest">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3">
+          <path d="M6 3h12v15l-6-3.5L6 18V3z" stroke-linejoin="round"/><path d="M9 8h6M9 11h6"/>
+        </svg>
+      </div>
+      <div style="min-width: 0;">
+        <div class="campaign-name">{{ row.campaign.name }}</div>
+        <div class="campaign-meta">{{ row.heroes }} heroes · {{ row.range }}</div>
+        <div class="campaign-next">Next: {{ row.campaign.next }}</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.ts
+++ b/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { combineLatest, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Campaign } from '../../models/campaign';
+import { CampaignService } from '../../services/campaign.service';
+import { PCService } from '../../services/pc.service';
+import { UiStateService } from '../../services/ui-state.service';
+
+interface CampaignRow {
+  campaign: Campaign;
+  heroes: number;
+  range: string;     // "Lv 7" | "Lv 5–7" | "no heroes"
+}
+
+/** DM-mode sidebar: a "Your Campaigns" list (mirrors PlayerRoster). */
+@Component({
+  selector: 'app-campaign-sidebar',
+  templateUrl: './campaign-sidebar.component.html',
+})
+export class CampaignSidebarComponent {
+  activeCampaignId$ = this.uiState.activeCampaignId$;
+
+  rows$: Observable<CampaignRow[]> = combineLatest([
+    this.campaignService.campaigns$,
+    this.pcService.pcs$,
+  ]).pipe(
+    map(([campaigns, pcs]) =>
+      campaigns.map(campaign => {
+        const members = this.campaignService.membersOf(campaign, pcs);
+        const levels = members.map(m => m.level);
+        const range = levels.length
+          ? (Math.min(...levels) === Math.max(...levels)
+              ? `Lv ${levels[0]}`
+              : `Lv ${Math.min(...levels)}–${Math.max(...levels)}`)
+          : 'no heroes';
+        return { campaign, heroes: members.length, range };
+      })
+    )
+  );
+
+  count$ = this.campaignService.campaigns$.pipe(map(c => c.length));
+
+  constructor(
+    private campaignService: CampaignService,
+    private pcService: PCService,
+    private uiState: UiStateService,
+  ) {}
+
+  select(id: string): void {
+    this.uiState.setActiveCampaign(id);
+  }
+
+  padCount(n: number): string {
+    return n.toString().padStart(2, '0');
+  }
+}

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
@@ -1,0 +1,37 @@
+<div class="modal" style="border-color: var(--celestial);" (click)="$event.stopPropagation()">
+  <div class="modal-title" style="color: var(--celestial-2);">Open a New Campaign</div>
+  <div class="modal-sub">Every table begins with an empty map and a promise of trouble.</div>
+
+  <div class="field">
+    <label>Campaign Name</label>
+    <input [(ngModel)]="name" autocomplete="off" placeholder="e.g. The Ashfall Accord" autofocus>
+  </div>
+
+  <div class="field">
+    <label>Setting</label>
+    <input [(ngModel)]="setting" autocomplete="off" placeholder="where the tale unfolds">
+  </div>
+
+  <div class="field">
+    <label>Next Session</label>
+    <input [(ngModel)]="next" autocomplete="off" placeholder="e.g. Fri · Jun 20">
+  </div>
+
+  <div class="field">
+    <label>Banner Hue</label>
+    <div class="class-picker" style="grid-template-columns: repeat(5, 1fr);">
+      <button
+        *ngFor="let c of tints"
+        class="class-pick"
+        [class.active]="tint === c"
+        style="text-transform: capitalize;"
+        (click)="tint = c"
+      >{{ c }}</button>
+    </div>
+  </div>
+
+  <div class="modal-actions">
+    <button class="btn" (click)="cancel()">Cancel</button>
+    <button class="btn primary" style="flex: none;" (click)="submit()" [disabled]="!name.trim()">Inscribe</button>
+  </div>
+</div>

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
@@ -1,0 +1,31 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { CampaignDraft, CampaignTint } from '../../models/campaign';
+
+/** "Open a New Campaign" modal — mirrors the create-character modal chrome. */
+@Component({
+  selector: 'app-create-campaign-modal',
+  templateUrl: './create-campaign-modal.component.html',
+})
+export class CreateCampaignModalComponent {
+  name = '';
+  setting = '';
+  next = '';
+  tint: CampaignTint = 'celestial';
+
+  readonly tints: CampaignTint[] = ['celestial', 'violet', 'gold', 'crimson', 'emerald'];
+
+  @Output() confirm = new EventEmitter<CampaignDraft>();
+  @Output() close = new EventEmitter<void>();
+
+  submit(): void {
+    if (!this.name.trim()) return;
+    this.confirm.emit({
+      name: this.name.trim(),
+      setting: this.setting.trim(),
+      next: this.next.trim(),
+      tint: this.tint,
+    });
+  }
+
+  cancel(): void { this.close.emit(); }
+}

--- a/src/app/charactermanager/components/settings-panel/role-switch/role-switch.component.html
+++ b/src/app/charactermanager/components/settings-panel/role-switch/role-switch.component.html
@@ -1,0 +1,28 @@
+<div class="role-switch" role="tablist" aria-label="View as" *ngIf="role$ | async as role">
+  <button
+    class="role-seg"
+    [class.active]="role === 'player'"
+    (click)="setRole('player')"
+    role="tab"
+    [attr.aria-selected]="role === 'player'"
+  >
+    <!-- IconHero -->
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4">
+      <circle cx="8" cy="5" r="2.6"/><path d="M3 14c0-2.8 2.2-5 5-5s5 2.2 5 5"/>
+    </svg>
+    Player
+  </button>
+  <button
+    class="role-seg dm"
+    [class.active]="role === 'dm'"
+    (click)="setRole('dm')"
+    role="tab"
+    [attr.aria-selected]="role === 'dm'"
+  >
+    <!-- IconCrown -->
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3">
+      <path d="M2 5l2.5 6h7L14 5l-3.2 2.4L8 3 5.2 7.4 2 5z" stroke-linejoin="round"/><path d="M4 13h8"/>
+    </svg>
+    Dungeon Master
+  </button>
+</div>

--- a/src/app/charactermanager/components/settings-panel/role-switch/role-switch.component.ts
+++ b/src/app/charactermanager/components/settings-panel/role-switch/role-switch.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { UiStateService, Role } from '../../../services/ui-state.service';
+
+/**
+ * Segmented Player / Dungeon Master control. This is the ONLY place the
+ * app-level role is switched (per the DM-mode handoff).
+ */
+@Component({
+  selector: 'app-role-switch',
+  templateUrl: './role-switch.component.html',
+})
+export class RoleSwitchComponent {
+  role$ = this.uiState.role$;
+
+  constructor(private uiState: UiStateService) {}
+
+  setRole(role: Role): void {
+    this.uiState.setRole(role);
+  }
+}

--- a/src/app/charactermanager/components/settings-panel/settings-panel.component.html
+++ b/src/app/charactermanager/components/settings-panel/settings-panel.component.html
@@ -1,0 +1,106 @@
+<div class="slideover-backdrop" (click)="close()"></div>
+
+<aside class="slideover" (click)="$event.stopPropagation()">
+
+  <!-- Header: portrait + identity + close -->
+  <div class="slideover-header">
+    <div class="portrait lg" [style.background]="userTint">{{ user.initials }}</div>
+    <div style="min-width: 0;">
+      <div class="profile-name">{{ user.name }}</div>
+      <div class="profile-email">{{ user.email }}</div>
+      <div class="profile-title" *ngIf="user.title">{{ user.title }} · since {{ user.member_since }}</div>
+    </div>
+    <button class="slideover-close" (click)="close()" aria-label="Close">✕</button>
+  </div>
+
+  <div class="slideover-body">
+
+    <!-- View As -->
+    <div class="slideover-section">
+      <span class="panel-title">View As</span>
+      <app-role-switch></app-role-switch>
+      <div class="pref-sub" style="margin-top: 8px;">
+        Switch between your player and Dungeon&nbsp;Master dashboards.
+      </div>
+    </div>
+
+    <!-- Account -->
+    <div class="slideover-section">
+      <span class="panel-title">Account</span>
+      <div class="field">
+        <label>Display Name</label>
+        <input [value]="user.name" autocomplete="off">
+      </div>
+      <div class="field">
+        <label>Email</label>
+        <input [value]="user.email" autocomplete="off">
+      </div>
+    </div>
+
+    <!-- Default Theme -->
+    <div class="slideover-section">
+      <span class="panel-title">Default Theme</span>
+      <div class="theme-swatches" *ngIf="theme$ | async as theme">
+        <button
+          *ngFor="let t of themes"
+          class="theme-swatch"
+          [class.active]="theme === t.id"
+          (click)="setTheme(t.id)"
+        >
+          <div class="theme-swatch-preview" [style.background]="t.bg">
+            <span class="bar" [style.background]="t.gold" style="width: 60%; left: 8px; top: 14px;"></span>
+            <span class="bar" [style.background]="t.accent" style="width: 38%; left: 8px; top: 24px;"></span>
+          </div>
+          <div class="theme-swatch-label">{{ t.label }}</div>
+        </button>
+      </div>
+    </div>
+
+    <!-- Dice & Rolling -->
+    <div class="slideover-section" *ngIf="dice$ | async as dice">
+      <span class="panel-title">Dice &amp; Rolling</span>
+
+      <div class="pref-row">
+        <div>
+          <div class="pref-label">Roll style</div>
+          <div class="pref-sub">how the dice are cast</div>
+        </div>
+        <div class="seg-mini">
+          <button [class.active]="dice.style === 'digital'" (click)="setDiceStyle('digital')">digital</button>
+          <button [class.active]="dice.style === 'manual'" (click)="setDiceStyle('manual')">manual</button>
+        </div>
+      </div>
+
+      <div class="pref-row">
+        <div>
+          <div class="pref-label">Show modifiers</div>
+          <div class="pref-sub">break down each roll's math</div>
+        </div>
+        <button class="toggle" [class.on]="dice.showMods" (click)="toggleDice('showMods')"
+                [attr.aria-pressed]="dice.showMods"></button>
+      </div>
+
+      <div class="pref-row">
+        <div>
+          <div class="pref-label">Advantage prompt</div>
+          <div class="pref-sub">ask adv/disadv before rolling</div>
+        </div>
+        <button class="toggle" [class.on]="dice.advPrompt" (click)="toggleDice('advPrompt')"
+                [attr.aria-pressed]="dice.advPrompt"></button>
+      </div>
+
+      <div class="pref-row">
+        <div>
+          <div class="pref-label">Critical fanfare</div>
+          <div class="pref-sub">celebrate natural 20s</div>
+        </div>
+        <button class="toggle" [class.on]="dice.critFx" (click)="toggleDice('critFx')"
+                [attr.aria-pressed]="dice.critFx"></button>
+      </div>
+    </div>
+  </div>
+
+  <div class="slideover-footer">
+    <button class="btn danger" (click)="signOut()">Sign Out</button>
+  </div>
+</aside>

--- a/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
+++ b/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
@@ -1,0 +1,63 @@
+import { Component } from '@angular/core';
+import { UiStateService } from '../../services/ui-state.service';
+import { PreferencesService, Theme } from '../../services/preferences.service';
+import { CurrentUserService } from '../../services/current-user.service';
+import { AuthService } from '../../services/auth.service';
+import { DicePrefs } from '../../models/campaign';
+import { tintFor } from '../../utils/character-math';
+
+interface ThemeSwatch {
+  id: Theme;
+  label: string;
+  bg: string;
+  gold: string;
+  accent: string;
+}
+
+/**
+ * Left slide-over with the role toggle (View As), account fields, theme
+ * swatches and dice preferences. Opened from the sidebar account-row gear.
+ */
+@Component({
+  selector: 'app-settings-panel',
+  templateUrl: './settings-panel.component.html',
+})
+export class SettingsPanelComponent {
+  user = this.currentUser.getUser();
+  theme$ = this.prefs.theme$;
+  dice$ = this.prefs.dice$;
+
+  readonly themes: ThemeSwatch[] = [
+    { id: 'midnight',  label: 'Midnight',  bg: '#0d1224', gold: '#d4b06a', accent: '#8fb4ff' },
+    { id: 'candlelit', label: 'Candlelit', bg: '#221808', gold: '#e8b860', accent: '#d8a868' },
+    { id: 'vellum',    label: 'Vellum',    bg: '#e4d6b2', gold: '#8a5e22', accent: '#2a4a8a' },
+  ];
+
+  constructor(
+    private uiState: UiStateService,
+    private prefs: PreferencesService,
+    private currentUser: CurrentUserService,
+    private auth: AuthService,
+  ) {}
+
+  /** Background tint for the header portrait, reusing the shared util. */
+  get userTint(): string { return tintFor({ portraitTint: this.user.tint } as any); }
+
+  close(): void { this.uiState.closeSettings(); }
+
+  setTheme(theme: Theme): void { this.prefs.setTheme(theme); }
+
+  setDiceStyle(style: DicePrefs['style']): void {
+    this.prefs.setDice({ ...this.prefs.dice, style });
+  }
+
+  toggleDice(key: 'showMods' | 'advPrompt' | 'critFx'): void {
+    const dice = this.prefs.dice;
+    this.prefs.setDice({ ...dice, [key]: !dice[key] });
+  }
+
+  signOut(): void {
+    this.close();
+    this.auth.logout();
+  }
+}

--- a/src/app/charactermanager/components/sidenav/sidenav.component.html
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.html
@@ -1,11 +1,11 @@
 <div class="app">
 
   <!-- ═══════════════════════════════════════════════
-       SIDEBAR ROSTER
+       SIDEBAR
        ═══════════════════════════════════════════════ -->
   <aside class="sidebar">
 
-    <!-- Brand block -->
+    <!-- Brand block (constant across both modes) -->
     <div class="brand">
       <div class="brand-mark">
         <!-- SigilBrand — two concentric circles + 10-point star + center dot -->
@@ -22,78 +22,111 @@
       </div>
     </div>
 
-    <!-- Search -->
-    <div class="search">
-      <svg class="search-icon" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5">
-        <circle cx="7" cy="7" r="5"/>
-        <path d="M11 11l4 4"/>
-      </svg>
-      <input
-        [(ngModel)]="query"
-        placeholder="Search heroes, players, classes…"
-        autocomplete="off"
-      >
-    </div>
+    <!-- ── PLAYER MODE: roster ─────────────────────────────────────────── -->
+    <ng-container *ngIf="(role$ | async) === 'player'; else dmSidebar">
 
-    <!-- Party groups (scrollable) -->
-    <div style="overflow-y: auto; flex: 1;">
-
-      <p *ngIf="filteredByParty.length === 0"
-         style="padding: 20px; color: var(--text-dim); font-style: italic; text-align: center; font-size: 13px; margin: 0;">
-        No heroes match that name.
-      </p>
-
-      <div class="party-section" *ngFor="let group of filteredByParty">
-
-        <!-- Party header (collapsible) -->
-        <div
-          class="party-header"
-          [class.collapsed]="collapsedParties.has(group.party)"
-          (click)="toggleCollapse(group.party)"
+      <!-- Search -->
+      <div class="search">
+        <svg class="search-icon" viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="7" cy="7" r="5"/>
+          <path d="M11 11l4 4"/>
+        </svg>
+        <input
+          [(ngModel)]="query"
+          placeholder="Search heroes, players, classes…"
+          autocomplete="off"
         >
-          <svg class="party-chevron" viewBox="0 0 10 10" width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5">
-            <path d="M2 4l3 3 3-3"/>
-          </svg>
-          <span class="party-name">{{ group.party }}</span>
-          <span class="party-count">{{ padCount(group.members.length) }}</span>
-        </div>
-
-        <!-- Roster items -->
-        <div class="roster-items" *ngIf="!collapsedParties.has(group.party)">
-          <div
-            class="roster-item"
-            [class.active]="(activePC$ | async)?.id === pc.id"
-            *ngFor="let pc of group.members"
-            (click)="setActivePC(pc)"
-          >
-            <!-- Portrait circle -->
-            <div class="portrait" [style.background]="tintFor(pc)">
-              {{ initialsFor(pc) }}
-            </div>
-
-            <!-- Name + meta -->
-            <div style="min-width: 0;">
-              <div class="roster-name">{{ pc.name }}</div>
-              <div class="roster-meta">{{ pc.race }} {{ pc.clazz }}</div>
-            </div>
-
-            <!-- Level pill -->
-            <div class="roster-level">L{{ pc.level }}</div>
-          </div>
-        </div>
-
       </div>
-    </div>
 
-    <!-- Footer CTA -->
+      <!-- Party groups (scrollable) -->
+      <div style="overflow-y: auto; flex: 1;">
+
+        <p *ngIf="filteredByParty.length === 0"
+           style="padding: 20px; color: var(--text-dim); font-style: italic; text-align: center; font-size: 13px; margin: 0;">
+          No heroes match that name.
+        </p>
+
+        <div class="party-section" *ngFor="let group of filteredByParty">
+
+          <!-- Party header (collapsible) -->
+          <div
+            class="party-header"
+            [class.collapsed]="collapsedParties.has(group.party)"
+            (click)="toggleCollapse(group.party)"
+          >
+            <svg class="party-chevron" viewBox="0 0 10 10" width="10" height="10" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path d="M2 4l3 3 3-3"/>
+            </svg>
+            <span class="party-name">{{ group.party }}</span>
+            <span class="party-count">{{ padCount(group.members.length) }}</span>
+          </div>
+
+          <!-- Roster items -->
+          <div class="roster-items" *ngIf="!collapsedParties.has(group.party)">
+            <div
+              class="roster-item"
+              [class.active]="(activePC$ | async)?.id === pc.id"
+              *ngFor="let pc of group.members"
+              (click)="setActivePC(pc)"
+            >
+              <!-- Portrait circle -->
+              <div class="portrait" [style.background]="tintFor(pc)">
+                {{ initialsFor(pc) }}
+              </div>
+
+              <!-- Name + meta -->
+              <div style="min-width: 0;">
+                <div class="roster-name">{{ pc.name }}</div>
+                <div class="roster-meta">{{ pc.race }} {{ pc.clazz }}</div>
+              </div>
+
+              <!-- Level pill -->
+              <div class="roster-level">L{{ pc.level }}</div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </ng-container>
+
+    <!-- ── DM MODE: campaign list ──────────────────────────────────────── -->
+    <ng-template #dmSidebar>
+      <div style="overflow-y: auto; flex: 1;">
+        <app-campaign-sidebar></app-campaign-sidebar>
+      </div>
+    </ng-template>
+
+    <!-- Footer: mode action + account row (constant) -->
     <div class="sidebar-footer">
-      <button class="btn primary" (click)="forgeHero()">
+      <button *ngIf="(role$ | async) === 'player'" class="btn primary" (click)="forgeHero()">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"
              style="margin-right: 8px; vertical-align: -2px;">
           <path d="M8 3v10M3 8h10"/>
         </svg>
         Forge Hero
       </button>
+      <button *ngIf="(role$ | async) === 'dm'" class="btn primary" (click)="newCampaign()">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"
+             style="margin-right: 8px; vertical-align: -2px;">
+          <path d="M8 3v10M3 8h10"/>
+        </svg>
+        New Campaign
+      </button>
+
+      <!-- Account row → opens settings slide-over -->
+      <div class="account-row" (click)="openSettings()" title="Open your profile">
+        <div class="portrait" [style.background]="userTint">{{ user.initials }}</div>
+        <div style="min-width: 0;">
+          <div class="account-name">{{ user.name }}</div>
+          <div class="account-email">{{ user.email }}</div>
+        </div>
+        <!-- IconGear -->
+        <svg class="account-gear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>
+      </div>
     </div>
 
   </aside>
@@ -103,7 +136,12 @@
        ═══════════════════════════════════════════════ -->
   <main class="main">
     <div class="main-inner">
-      <router-outlet></router-outlet>
+      <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
+        <router-outlet></router-outlet>
+      </ng-container>
+      <ng-template #dmMain>
+        <app-campaign-dashboard></app-campaign-dashboard>
+      </ng-template>
     </div>
   </main>
 

--- a/src/app/charactermanager/components/sidenav/sidenav.component.ts
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.ts
@@ -3,6 +3,9 @@ import { Subscription } from 'rxjs';
 import { PC } from '../../models/pc';
 import { PCService } from '../../services/pc.service';
 import { CharacterModalService } from '../../services/character-modal.service';
+import { CampaignModalService } from '../../services/campaign-modal.service';
+import { UiStateService } from '../../services/ui-state.service';
+import { CurrentUserService } from '../../services/current-user.service';
 import { tintFor } from '../../utils/character-math';
 
 interface PartyGroup {
@@ -23,11 +26,19 @@ export class SidenavComponent implements OnInit, OnDestroy {
   query = '';
   collapsedParties = new Set<string>();
   activePC$ = this.pcService.activePC$;
+  role$ = this.uiState.role$;
+  user = this.currentUser.getUser();
 
   private allGroups: PartyGroup[] = [];
   private sub!: Subscription;
 
-  constructor(private pcService: PCService, private characterModal: CharacterModalService) {}
+  constructor(
+    private pcService: PCService,
+    private characterModal: CharacterModalService,
+    private campaignModal: CampaignModalService,
+    private uiState: UiStateService,
+    private currentUser: CurrentUserService,
+  ) {}
 
   ngOnInit(): void {
     this.sub = this.pcService.pcsByParty$.subscribe(groupMap => {
@@ -80,4 +91,11 @@ export class SidenavComponent implements OnInit, OnDestroy {
   }
 
   forgeHero(): void { this.characterModal.openCreateModal(); }
+
+  newCampaign(): void { this.campaignModal.openCreateModal(); }
+
+  /** Account-row tint, reusing the shared portrait util. */
+  get userTint(): string { return tintFor({ portraitTint: this.user.tint } as any); }
+
+  openSettings(): void { this.uiState.openSettings(); }
 }

--- a/src/app/charactermanager/models/campaign.ts
+++ b/src/app/charactermanager/models/campaign.ts
@@ -1,0 +1,48 @@
+/**
+ * A campaign a Dungeon Master runs. In Phase 1 the link to characters is the
+ * free-text `party` key (members = PCs whose `party` === campaign.party),
+ * mirroring the existing roster grouping. Phase 2 introduces a persisted
+ * `campaign_id` FK on the PC; this model stays the source of truth for the
+ * DM-facing fields.
+ */
+export interface Campaign {
+  id: string;
+  party: string;        // links to PC.party — members are PCs whose party === this
+  name: string;
+  setting: string;
+  session: number;
+  next: string;         // e.g. "Thu · Jun 12"
+  arc: string;
+  tint: CampaignTint;
+  chronicle: string;    // prose recap (DM-facing)
+  secrets: string;      // DM-only, never shown to players
+  threads: string[];    // open plot threads
+}
+
+export type CampaignTint = 'celestial' | 'violet' | 'gold' | 'crimson' | 'emerald';
+
+/** A new campaign as drafted in the create-campaign modal (pre-id, pre-seed). */
+export interface CampaignDraft {
+  name: string;
+  setting: string;
+  next: string;
+  tint: CampaignTint;
+}
+
+/** Dice & rolling preferences, persisted to localStorage under `tm_dice`. */
+export interface DicePrefs {
+  style: 'digital' | 'manual';
+  showMods: boolean;
+  advPrompt: boolean;
+  critFx: boolean;
+}
+
+/** The signed-in user as shown in the settings panel / account row. */
+export interface CurrentUser {
+  name: string;
+  email: string;
+  initials: string;
+  tint: CampaignTint;
+  title?: string;
+  member_since?: string;
+}

--- a/src/app/charactermanager/services/campaign-modal.service.ts
+++ b/src/app/charactermanager/services/campaign-modal.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { CampaignDraft } from '../models/campaign';
+import { CampaignService } from './campaign.service';
+import { UiStateService } from './ui-state.service';
+
+/** Controls the create-campaign modal and wires submits into CampaignService. */
+@Injectable({ providedIn: 'root' })
+export class CampaignModalService {
+  private openSubject = new BehaviorSubject<boolean>(false);
+  isOpen$ = this.openSubject.asObservable();
+
+  constructor(
+    private campaignService: CampaignService,
+    private uiState: UiStateService,
+  ) {}
+
+  openCreateModal(): void  { this.openSubject.next(true); }
+  closeCreateModal(): void { this.openSubject.next(false); }
+
+  onCreated(draft: CampaignDraft): void {
+    this.closeCreateModal();
+    const campaign = this.campaignService.createCampaign(draft);
+    this.uiState.setActiveCampaign(campaign.id);
+  }
+}

--- a/src/app/charactermanager/services/campaign.service.ts
+++ b/src/app/charactermanager/services/campaign.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Campaign, CampaignDraft } from '../models/campaign';
+import { PC } from '../models/pc';
+import { PCService } from './pc.service';
+
+// ---------------------------------------------------------------------------
+// Demo seed campaigns. `party` links to PC.party (see prototype/data.js).
+// Phase 2 replaces this with a backend; the localStorage layer below is the
+// stand-in store until then.
+// ---------------------------------------------------------------------------
+const DEMO_CAMPAIGNS: Campaign[] = [
+  {
+    id: 'veiled',
+    party: 'The Veiled Compass',
+    name: 'The Veiled Compass',
+    setting: 'Waterdeep & the Sword Coast',
+    session: 14,
+    next: 'Thu · Jun 12',
+    arc: "The Lantern's Debt",
+    tint: 'celestial',
+    chronicle:
+      "What began as a simple courier job has unspooled into a war of whispers. The Crimson Lantern called in Lyra's debt three sessions ago, and the price was a name — a name that belongs to someone at this very table. The party doesn't know yet. Throk suspects.",
+    secrets:
+      "The Lantern's true patron is Vex's archfey. The 'debt' is a leash. Brother Aldric's missing years were spent in the same war the Lantern profits from — reveal at session 16.",
+    threads: [
+      "Who sold the Compass's route to the Shadow-Bear cult?",
+      "Aldric's letter from the orphanage — unopened for 4 sessions",
+      "Vex's patron wants the Crown of the Hollow Court back",
+    ],
+  },
+  {
+    id: 'tomb',
+    party: 'Tomb of the Sleeping Crown',
+    name: 'Tomb of the Sleeping Crown',
+    setting: 'The Barrowlands of Eshvar',
+    session: 6,
+    next: 'Sun · Jun 15',
+    arc: 'Descent to the Third Seal',
+    tint: 'violet',
+    chronicle:
+      "Two delvers, one keyhole, and a crown that does not wish to be found. Pip can fit where Zarev cannot; Zarev can survive what Pip cannot. The Third Seal hums with old bronze — Zarev's blood remembers it, though he was never here before.",
+    secrets:
+      'The Sleeping Crown is bonded to House Ashenheart. Zarev IS the key — the tomb opens for his bloodline, the cult knows it, and Pip\'s employer is the cult.',
+    threads: [
+      "Pip's employer sent a second, sealed contract",
+      'The bronze dragon below the Third Seal — ancestor or warden?',
+      "Three cities want Pip's head; one will follow him here",
+    ],
+  },
+];
+
+const STORAGE_KEY = 'tm_campaigns';
+
+@Injectable({ providedIn: 'root' })
+export class CampaignService {
+  private campaignsSubject = new BehaviorSubject<Campaign[]>(this.loadCampaigns());
+  campaigns$ = this.campaignsSubject.asObservable();
+
+  constructor(private pcService: PCService) {}
+
+  /** Members of a campaign = PCs whose party matches the campaign's party key. */
+  membersOf(campaign: Campaign | null, pcs: PC[]): PC[] {
+    if (!campaign) return [];
+    return pcs.filter(p => p.party === campaign.party);
+  }
+
+  /** Reactive members stream for a campaign id, recomputed as PCs change. */
+  members$(campaignId: string | null): Observable<PC[]> {
+    return combineLatest([this.campaigns$, this.pcService.pcs$]).pipe(
+      map(([campaigns, pcs]) => {
+        const campaign = campaigns.find(c => c.id === campaignId) ?? null;
+        return this.membersOf(campaign, pcs);
+      })
+    );
+  }
+
+  getById(id: string | null): Campaign | undefined {
+    return this.campaignsSubject.getValue().find(c => c.id === id);
+  }
+
+  createCampaign(draft: CampaignDraft): Campaign {
+    const campaign: Campaign = {
+      id: 'c-' + Date.now(),
+      name: draft.name,
+      // Phase 1: a fresh campaign's party key is its own name; players join by
+      // setting their PC's party to match. Phase 2 swaps this for a real FK.
+      party: draft.name,
+      setting: draft.setting || 'An unwritten realm',
+      session: 1,
+      next: draft.next || 'Unscheduled',
+      arc: 'A new beginning',
+      tint: draft.tint,
+      chronicle: 'The chronicle is yet unwritten. Your first session will fill this page.',
+      secrets: '',
+      threads: [],
+    };
+    const next = [...this.campaignsSubject.getValue(), campaign];
+    this.persist(next);
+    return campaign;
+  }
+
+  private persist(campaigns: Campaign[]): void {
+    this.campaignsSubject.next(campaigns);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(campaigns));
+    } catch {
+      // Storage unavailable (private mode / quota) — keep in-memory only.
+    }
+  }
+
+  private loadCampaigns(): Campaign[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw) as Campaign[];
+    } catch {
+      // fall through to demo seed
+    }
+    return [...DEMO_CAMPAIGNS];
+  }
+}

--- a/src/app/charactermanager/services/current-user.service.ts
+++ b/src/app/charactermanager/services/current-user.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { CurrentUser } from '../models/campaign';
+
+/**
+ * Source of the signed-in user shown in the account row / settings header.
+ *
+ * Phase 1 returns a demo DM. The seam is deliberate: Phase 3+ will populate
+ * this from the real auth/session (the JWT principal) without any caller change.
+ */
+@Injectable({ providedIn: 'root' })
+export class CurrentUserService {
+  private user: CurrentUser = {
+    name: 'Quill Ashford',
+    email: 'quill@tablemimic.app',
+    initials: 'QA',
+    tint: 'gold',
+    title: 'Keeper of Chronicles',
+    member_since: 'Spring 2023',
+  };
+
+  getUser(): CurrentUser {
+    return this.user;
+  }
+}

--- a/src/app/charactermanager/services/preferences.service.ts
+++ b/src/app/charactermanager/services/preferences.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { DicePrefs } from '../models/campaign';
+
+export type Theme = 'midnight' | 'candlelit' | 'vellum';
+
+const THEME_KEY = 'tm_theme';
+const DICE_KEY = 'tm_dice';
+
+const DEFAULT_DICE: DicePrefs = { style: 'digital', showMods: true, advPrompt: true, critFx: true };
+const THEMES: Theme[] = ['midnight', 'candlelit', 'vellum'];
+
+/**
+ * User preferences that survive reloads: the active theme (written to
+ * `data-theme` on <html>) and dice-rolling options. Persisted to localStorage.
+ */
+@Injectable({ providedIn: 'root' })
+export class PreferencesService {
+  private themeSubject = new BehaviorSubject<Theme>(this.loadTheme());
+  theme$ = this.themeSubject.asObservable();
+
+  private diceSubject = new BehaviorSubject<DicePrefs>(this.loadDice());
+  dice$ = this.diceSubject.asObservable();
+
+  constructor() {
+    // Apply the persisted theme immediately so the first paint is correct.
+    this.applyTheme(this.themeSubject.getValue());
+  }
+
+  get theme(): Theme { return this.themeSubject.getValue(); }
+  get dice(): DicePrefs { return this.diceSubject.getValue(); }
+
+  setTheme(theme: Theme): void {
+    this.applyTheme(theme);
+    localStorage.setItem(THEME_KEY, theme);
+    this.themeSubject.next(theme);
+  }
+
+  setDice(dice: DicePrefs): void {
+    localStorage.setItem(DICE_KEY, JSON.stringify(dice));
+    this.diceSubject.next(dice);
+  }
+
+  private applyTheme(theme: Theme): void {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+
+  private loadTheme(): Theme {
+    const stored = localStorage.getItem(THEME_KEY) as Theme | null;
+    return stored && THEMES.includes(stored) ? stored : 'midnight';
+  }
+
+  private loadDice(): DicePrefs {
+    try {
+      const raw = localStorage.getItem(DICE_KEY);
+      return raw ? { ...DEFAULT_DICE, ...JSON.parse(raw) } : { ...DEFAULT_DICE };
+    } catch {
+      return { ...DEFAULT_DICE };
+    }
+  }
+}

--- a/src/app/charactermanager/services/ui-state.service.ts
+++ b/src/app/charactermanager/services/ui-state.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type Role = 'player' | 'dm';
+
+/**
+ * Holds app-level UI state that is *not* a route: the Player/DM role, which
+ * campaign is selected in DM mode, and whether the settings slide-over is open.
+ *
+ * The active *character* deliberately stays in PCService (single source of
+ * truth); the DM→player cross-link just calls PCService.setActivePC together
+ * with setRole('player') here.
+ */
+@Injectable({ providedIn: 'root' })
+export class UiStateService {
+  private roleSubject = new BehaviorSubject<Role>('player');
+  role$ = this.roleSubject.asObservable();
+
+  private activeCampaignIdSubject = new BehaviorSubject<string | null>(null);
+  activeCampaignId$ = this.activeCampaignIdSubject.asObservable();
+
+  private settingsOpenSubject = new BehaviorSubject<boolean>(false);
+  settingsOpen$ = this.settingsOpenSubject.asObservable();
+
+  get role(): Role { return this.roleSubject.getValue(); }
+
+  setRole(role: Role): void { this.roleSubject.next(role); }
+
+  setActiveCampaign(id: string | null): void { this.activeCampaignIdSubject.next(id); }
+
+  openSettings(): void  { this.settingsOpenSubject.next(true); }
+  closeSettings(): void { this.settingsOpenSubject.next(false); }
+}

--- a/src/app/charactermanager/utils/character-math.ts
+++ b/src/app/charactermanager/utils/character-math.ts
@@ -57,3 +57,33 @@ export const CONDITIONS_LIST: string[] = [
   'prone', 'restrained', 'stunned', 'unconscious',
   'raging', 'concentration', 'inspired',
 ];
+
+// ── Passive stats (DM dashboard) ────────────────────────────────────────────
+// passive = 10 + abilityMod + (expert ? 2×prof : prof ? prof : 0)
+// Perception and Insight both key off WIS. Mirrors prototype/data.js.
+
+type Ability = 'STR' | 'DEX' | 'CON' | 'INT' | 'WIS' | 'CHA';
+
+/** Proficiency level for a skill, tolerating "Animal Handling" → "Animal". */
+export function skillLevel(pc: PC, name: string): 'prof' | 'expert' | null {
+  const skills = pc.skills ?? {};
+  return skills[name] ?? skills[name.split(' ')[0]] ?? null;
+}
+
+export function passiveScore(pc: PC, skill: string, ability: Ability): number {
+  const score = pc.stats?.[ability] ?? 10;
+  const prof = pc.prof ?? 0;
+  const mod = modFromScore(score);
+  const lvl = skillLevel(pc, skill);
+  const bonus = lvl === 'expert' ? prof * 2 : lvl === 'prof' ? prof : 0;
+  return 10 + mod + bonus;
+}
+
+// ── Coin value ──────────────────────────────────────────────────────────────
+// Total wealth expressed in gold pieces.
+
+export function goldValue(coins: PC['coins']): number {
+  if (!coins) return 0;
+  const { cp = 0, sp = 0, ep = 0, gp = 0, pp = 0 } = coins;
+  return cp / 100 + sp / 10 + ep / 2 + gp + pp * 10;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -330,6 +330,7 @@ app-root { display: block; height: 100vh; width: 100vw; }
   padding: 14px 16px 18px;
   border-top: 1px solid var(--border-soft);
   display: flex;
+  flex-direction: column;
   gap: 8px;
 }
 .btn {
@@ -1270,3 +1271,460 @@ app-root { display: block; height: 100vh; width: 100vw; }
   transition: color 0.15s;
 }
 .auth-link:hover { color: var(--gold-2); }
+
+/* ════════════════════════════════════════════════════════════════════════
+   DM MODE — role switch, account row, campaign list, dashboard, settings
+   Ported from design_handoff_arcane_redesign/prototype/styles.css
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* === ROLE SWITCH (Player / DM) === */
+.role-switch {
+  display: flex;
+  gap: 4px;
+  margin: 0 16px 6px;
+  padding: 4px;
+  background: var(--bg-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 3px;
+}
+.role-seg {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 9px 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  transition: all .15s;
+}
+.role-seg svg { width: 14px; height: 14px; opacity: 0.7; }
+.role-seg:hover { color: var(--text-2); }
+.role-seg.active {
+  color: var(--gold-2);
+  border-color: color-mix(in oklch, var(--gold) 50%, transparent);
+  background: color-mix(in oklch, var(--gold) 16%, var(--surface-2));
+  box-shadow: var(--glow-gold);
+}
+.role-seg.active svg { opacity: 1; }
+.role-seg.dm.active {
+  color: var(--celestial-2);
+  border-color: color-mix(in oklch, var(--celestial) 50%, transparent);
+  background: color-mix(in oklch, var(--celestial) 16%, var(--surface-2));
+  box-shadow: var(--glow);
+}
+
+/* === ACCOUNT ROW (sidebar footer) === */
+.account-row {
+  display: grid;
+  grid-template-columns: 34px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background .12s, border-color .12s;
+}
+.account-row:hover {
+  background: color-mix(in oklch, var(--surface-2) 80%, transparent);
+  border-color: var(--border-soft);
+}
+.account-row .portrait { width: 34px; height: 34px; font-size: 12px; }
+.account-name {
+  font-family: 'Cinzel', serif;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.account-email {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.account-gear { color: var(--text-dim); width: 15px; height: 15px; }
+.account-row:hover .account-gear { color: var(--gold); }
+
+/* === CAMPAIGN LIST (DM sidebar) === */
+.campaign-item {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 12px;
+  margin: 0 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  border: 1px solid transparent;
+  position: relative;
+  transition: background .12s, border-color .12s;
+}
+.campaign-item:hover { background: color-mix(in oklch, var(--surface-2) 80%, transparent); }
+.campaign-item.active {
+  background: color-mix(in oklch, var(--celestial) 14%, transparent);
+  border-color: color-mix(in oklch, var(--celestial) 35%, transparent);
+}
+.campaign-item.active::before {
+  content: '';
+  position: absolute;
+  left: -8px; top: 6px; bottom: 6px;
+  width: 2px;
+  background: var(--celestial);
+  box-shadow: var(--glow);
+}
+.campaign-crest {
+  width: 40px; height: 40px;
+  border-radius: 3px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--celestial-2);
+  border: 1px solid var(--border);
+  background: color-mix(in oklch, var(--celestial) 12%, var(--surface-3));
+}
+.campaign-crest svg { width: 22px; height: 22px; }
+.campaign-name {
+  font-family: 'Cinzel', serif;
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--text);
+  letter-spacing: 0.02em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.campaign-meta {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 1px;
+}
+.campaign-next {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--celestial);
+  margin-top: 3px;
+}
+
+/* === DM DASHBOARD === */
+.vital-caption { font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px; }
+.dm-cols {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 24px;
+}
+@media (max-width: 1100px) { .dm-cols { grid-template-columns: minmax(0, 1fr); } }
+
+/* Party Vitals Board */
+.board { overflow-x: auto; }
+.board-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1.7fr) 150px 56px 64px 64px minmax(120px, 1.3fr) 16px;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 8px;
+  border-bottom: 1px dotted var(--border-soft);
+  min-width: 720px;
+}
+.board-row.head {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 9px;
+}
+.board-row.head > span {
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.board-row.head .num { text-align: center; }
+.board-row.member {
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background .12s;
+}
+.board-row.member:hover { background: color-mix(in oklch, var(--surface-2) 70%, transparent); }
+.board-row:last-child { border-bottom: none; }
+.board-hero {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+.board-hero .portrait { width: 32px; height: 32px; font-size: 11px; }
+.board-hero-name {
+  font-family: 'Cinzel', serif;
+  font-size: 13px;
+  color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.board-hero-sub {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.board-hp {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--text);
+}
+.board-hp .hp-text { display: flex; justify-content: space-between; margin-bottom: 4px; }
+.board-hp .vital-bar { margin-top: 0; }
+.board-hp.bloodied .vital-bar > span { background: var(--crimson); }
+.board-hp.bloodied { color: var(--crimson); }
+.board-num {
+  text-align: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  color: var(--text);
+}
+.board-num.lit { color: var(--gold); }
+.board-conditions { display: flex; flex-wrap: wrap; gap: 4px; }
+.board-cond {
+  font-family: 'Cinzel', serif;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 100px;
+  background: color-mix(in oklch, var(--crimson) 16%, var(--bg-2));
+  border: 1px solid color-mix(in oklch, var(--crimson) 40%, transparent);
+  color: var(--crimson);
+}
+.board-cond.calm {
+  background: var(--bg-2);
+  border-color: var(--border-soft);
+  color: var(--text-dim);
+}
+.board-chev { color: var(--text-dim); width: 12px; height: 12px; }
+.board-row.member:hover .board-chev { color: var(--celestial); }
+
+/* Campaign chronicle threads */
+.thread {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 8px 0;
+  border-bottom: 1px dotted var(--border-soft);
+  font-family: 'EB Garamond', serif;
+  font-size: 14px;
+  color: var(--text-2);
+}
+.thread:last-child { border-bottom: none; }
+.thread-mark { color: var(--celestial); font-size: 12px; padding-top: 2px; }
+.secrets-box {
+  margin-top: 14px;
+  padding: 14px 16px;
+  background: color-mix(in oklch, var(--violet) 12%, var(--bg-2));
+  border: 1px solid color-mix(in oklch, var(--violet) 35%, transparent);
+  border-radius: 3px;
+}
+.secrets-box .eyebrow { color: var(--violet); margin-bottom: 8px; display: block; }
+.secrets-box p {
+  margin: 0;
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 13.5px;
+  color: var(--text-2);
+  line-height: 1.5;
+}
+
+/* Treasury */
+.treasury-list { display: flex; flex-direction: column; gap: 2px; margin-top: 6px; }
+.treasury-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px dotted var(--border-soft);
+  font-size: 14px;
+}
+.treasury-row:last-child { border-bottom: none; }
+.treasury-name { color: var(--text-2); font-family: 'EB Garamond', serif; }
+.treasury-amt { font-family: 'JetBrains Mono', monospace; color: var(--gold); }
+.treasury-total {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.treasury-total .label {
+  font-family: 'Cinzel', serif;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.treasury-total .big {
+  font-family: 'Cinzel', serif;
+  font-weight: 600;
+  font-size: 24px;
+  color: var(--gold);
+}
+
+/* === PROFILE / SETTINGS SLIDE-OVER === */
+.slideover-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.55);
+  backdrop-filter: blur(6px);
+  z-index: 90;
+}
+.slideover {
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  width: min(440px, 94vw);
+  background: var(--surface);
+  border-right: 1px solid var(--gold);
+  box-shadow: 20px 0 60px rgba(0,0,0,0.5), var(--glow-gold);
+  z-index: 91;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(0);
+  animation: slidein .28s cubic-bezier(.2,.8,.2,1);
+}
+/* starts only slightly offset so a frozen timeline still shows it on-screen */
+@keyframes slidein { from { transform: translateX(-34px); } to { transform: translateX(0); } }
+.slideover .role-switch { margin: 0; }
+.slideover-header {
+  padding: 24px 26px 20px;
+  border-bottom: 1px solid var(--border-soft);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+}
+.slideover-close {
+  position: absolute;
+  top: 16px; right: 16px;
+  width: 28px; height: 28px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  display: flex; align-items: center; justify-content: center;
+}
+.slideover-close:hover { color: var(--gold); border-color: var(--gold); }
+.slideover-body { padding: 22px 26px; overflow-y: auto; flex: 1; }
+.slideover-body .panel-title { display: block; margin-bottom: 14px; }
+.slideover-section { margin-bottom: 26px; }
+.profile-name {
+  font-family: 'Cinzel', serif;
+  font-weight: 600;
+  font-size: 22px;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+.profile-email {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+.profile-title {
+  font-family: 'EB Garamond', serif;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--gold);
+  margin-top: 4px;
+}
+
+/* Theme swatch picker */
+.theme-swatches {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.theme-swatch {
+  cursor: pointer;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  transition: border-color .15s, box-shadow .15s, transform .1s;
+}
+.theme-swatch:hover { transform: translateY(-1px); }
+.theme-swatch.active { border-color: var(--gold); box-shadow: var(--glow-gold); }
+.theme-swatch-preview { height: 46px; position: relative; }
+.theme-swatch-preview .bar { position: absolute; height: 3px; border-radius: 2px; }
+.theme-swatch-label {
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: center;
+  padding: 7px 2px;
+  color: var(--text-2);
+  border-top: 1px solid var(--border-soft);
+}
+.theme-swatch.active .theme-swatch-label { color: var(--gold); }
+
+/* Preference toggle rows */
+.pref-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 11px 0;
+  border-bottom: 1px dotted var(--border-soft);
+}
+.pref-row:last-child { border-bottom: none; }
+.pref-label { font-family: 'EB Garamond', serif; font-size: 15px; color: var(--text); }
+.pref-sub { font-family: 'EB Garamond', serif; font-style: italic; font-size: 12px; color: var(--text-dim); margin-top: 1px; }
+.toggle {
+  width: 42px; height: 24px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  transition: background .15s, border-color .15s;
+}
+.toggle::after {
+  content: '';
+  position: absolute;
+  top: 2px; left: 2px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition: transform .15s, background .15s;
+}
+.toggle.on {
+  background: color-mix(in oklch, var(--gold) 30%, var(--bg-2));
+  border-color: var(--gold);
+}
+.toggle.on::after { transform: translateX(18px); background: var(--gold-2); }
+.seg-mini { display: flex; gap: 4px; }
+.seg-mini button {
+  font-family: 'Cinzel', serif;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.seg-mini button.active { color: var(--gold); border-color: var(--gold); background: color-mix(in oklch, var(--gold) 14%, var(--bg-2)); }
+.slideover-footer {
+  padding: 16px 26px 22px;
+  border-top: 1px solid var(--border-soft);
+}
+.slideover-footer .btn { width: 100%; }


### PR DESCRIPTION
Introduces a Player/Dungeon Master role toggle and a full DM-mode UI on client-side/demo data, layering on the arcane redesign without touching the backend (frontend-first phase).

- UiStateService (role$, activeCampaignId$, settingsOpen$) holds app-level role state; the active character stays in PCService (single source of truth).
- CampaignService: demo seeds + localStorage, membersOf() links PCs by party.
- PreferencesService: theme (data-theme on <html>) + dice prefs, persisted; instantiated at bootstrap via AppComponent so the theme applies on first paint.
- Settings slide-over (left) with View As role-switch, account, theme swatches, dice toggles, sign out; opened from a sidebar account-row gear.
- Campaign sidebar (CampaignList) + dashboard: aggregate vitals, party board, chronicle with DM-secrets box, treasury. Clicking a hero row cross-links to that PC sheet in Player mode.
- Passive Perception/Insight + gold-value helpers added to character-math.
- Create-campaign modal mirrors the create-character pattern.

Verified end-to-end in demo mode: role swap, dashboard aggregates, cross-link, theme/dice persistence across reload, campaign creation. No console errors.