### PR TITLE
feat: add character level-up modal and wiring (HP + proficiency bonus)

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -19,6 +19,7 @@ import { BackgroundStoryComponent } from './components/character-sheet/panels/ba
 import { CreateCharacterModalComponent } from './components/create-character-modal/create-character-modal.component';
 import { DeleteConfirmationModalComponent } from './components/main-content/delete-confirmation-modal/delete-confirmation-modal.component';
 import { DiceRollerModalComponent } from './components/dice-roller-modal/dice-roller-modal.component';
+import { LevelUpModalComponent } from './components/level-up-modal/level-up-modal.component';
 
 // ── DM mode ──────────────────────────────────────────────────────────────
 import { SettingsPanelComponent } from './components/settings-panel/settings-panel.component';
@@ -59,6 +60,7 @@ const routes: Routes = [
     DeleteConfirmationModalComponent,
     CreateCharacterModalComponent,
     DiceRollerModalComponent,
+    LevelUpModalComponent,
     CharacterSheetComponent,
     VitalsStripComponent,
     EmptyStateComponent,

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -57,6 +57,13 @@
         </svg>
         Long Rest
       </button>
+      <button class="btn" title="Advance a level" (click)="levelUpRequested.emit()">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
+             style="margin-right: 6px; vertical-align: -2px;">
+          <path d="M8 13V3M8 3L4 7M8 3l4 4M3 14h10"/>
+        </svg>
+        Level Up
+      </button>
       <button class="btn danger icon" (click)="deleteRequested.emit()" title="Delete character">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4">
           <path d="M3 4h10M6 4V2.5A.5.5 0 016.5 2h3a.5.5 0 01.5.5V4M4.5 4l.7 9a1 1 0 001 .9h3.6a1 1 0 001-.9l.7-9"/>

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -12,6 +12,7 @@ export class CharacterSheetComponent implements OnChanges {
   @Input() pc!: PC;
   @Output() deleteRequested = new EventEmitter<void>();
   @Output() rollRequested = new EventEmitter<void>();
+  @Output() levelUpRequested = new EventEmitter<void>();
 
   editingName = false;
   nameDraft = '';

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -1,0 +1,61 @@
+<div class="modal" style="border-color: var(--celestial);">
+
+  <div class="modal-title" style="color: var(--celestial);">Ascend a Level</div>
+
+  <!-- Loading the server-computed preview -->
+  <div *ngIf="loading" class="modal-sub">Consulting the chronicle…</div>
+
+  <!-- Could not compute (e.g. already max level) -->
+  <div *ngIf="!loading && error && !preview" class="modal-sub" style="color: var(--crimson);">
+    {{ error }}
+  </div>
+
+  <!-- The gains for this level -->
+  <ng-container *ngIf="preview as p">
+    <div class="modal-sub">
+      <em style="color: var(--text); font-style: normal;">{{ pc.name }}</em>
+      advances from level {{ p.currentLevel }} to
+      <em style="color: var(--text); font-style: normal;">level {{ p.newLevel }}</em>.
+    </div>
+
+    <ul class="lvl-gains">
+      <li class="lvl-gain">
+        <span class="lvl-gain-label">Hit Points</span>
+        <span class="lvl-gain-value">
+          +{{ p.hpGained }}
+          <span class="lvl-gain-note">
+            (d{{ p.hitDie }} avg {{ fmtMod(p.conModifier) }} CON) → max {{ p.newHpMax }}
+          </span>
+        </span>
+      </li>
+
+      <li class="lvl-gain" [class.is-bump]="profChanged">
+        <span class="lvl-gain-label">Proficiency Bonus</span>
+        <span class="lvl-gain-value">
+          {{ fmtMod(p.currentProfBonus) }}
+          <ng-container *ngIf="profChanged">→ {{ fmtMod(p.newProfBonus) }}</ng-container>
+          <span class="lvl-gain-note" *ngIf="!profChanged">(unchanged)</span>
+        </span>
+      </li>
+    </ul>
+
+    <!-- A commit-time failure (e.g. raced to max level) -->
+    <div *ngIf="error && preview" class="modal-sub" style="color: var(--crimson);">
+      {{ error }}
+    </div>
+
+    <div class="modal-actions">
+      <button class="btn" type="button" (click)="cancel()" [disabled]="submitting">Not Yet</button>
+      <button class="btn" type="button" (click)="confirm()" [disabled]="submitting"
+              style="border-color: var(--celestial); color: var(--celestial);">
+        {{ submitting ? 'Ascending…' : 'Level Up' }}
+      </button>
+    </div>
+  </ng-container>
+
+  <!-- Preview failed entirely: only offer a way out -->
+  <div *ngIf="!loading && !preview" class="modal-actions">
+    <button class="btn" type="button" (click)="cancel()">Close</button>
+  </div>
+
+</div>

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -1,0 +1,48 @@
+// Level-specific gain list. The .modal / .modal-title / .modal-sub / .modal-actions
+// / .btn classes are global (shared with the other modals); only the delta rows are
+// styled here.
+
+.lvl-gains {
+  list-style: none;
+  margin: 18px 0 4px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.lvl-gain {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+
+  &.is-bump {
+    border-color: var(--celestial);
+  }
+}
+
+.lvl-gain-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.lvl-gain-value {
+  font-weight: 600;
+  color: var(--text, #fff);
+  text-align: right;
+}
+
+.lvl-gain-note {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -1,0 +1,105 @@
+import { of, throwError } from 'rxjs';
+
+import { LevelUpModalComponent } from './level-up-modal.component';
+import { PCService } from '../../services/pc.service';
+import { PC } from '../../models/pc';
+import { LevelUpPreview } from '../../models/level-up';
+
+/** A SpyObj PCService — the modal only touches levelUpPreview / levelUp. */
+function makePcServiceSpy(): jasmine.SpyObj<PCService> {
+  return jasmine.createSpyObj<PCService>('PCService', ['levelUpPreview', 'levelUp']);
+}
+
+function makePC(overrides: Partial<PC> = {}): PC {
+  return { id: 7, name: 'Throk', clazz: 'Barbarian', level: 4, playerName: 'Ben', ...overrides };
+}
+
+function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
+  return {
+    currentLevel: 4, newLevel: 5, hitDie: 12, conModifier: 1,
+    hpGained: 8, newHpMax: 92, currentProfBonus: 2, newProfBonus: 3,
+    ...overrides,
+  };
+}
+
+describe('LevelUpModalComponent', () => {
+  let component: LevelUpModalComponent;
+  let pcService: jasmine.SpyObj<PCService>;
+
+  beforeEach(() => {
+    pcService = makePcServiceSpy();
+    component = new LevelUpModalComponent(pcService);
+    component.pc = makePC();
+  });
+
+  it('loads the preview on init', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+
+    component.ngOnInit();
+
+    expect(pcService.levelUpPreview).toHaveBeenCalledWith(7);
+    expect(component.loading).toBeFalse();
+    expect(component.preview?.newLevel).toBe(5);
+  });
+
+  it('surfaces a preview error and stops loading', () => {
+    pcService.levelUpPreview.and.returnValue(
+      throwError(() => ({ error: { message: 'Character is already at the maximum level (20)' } }))
+    );
+
+    component.ngOnInit();
+
+    expect(component.loading).toBeFalse();
+    expect(component.preview).toBeNull();
+    expect(component.error).toContain('maximum level');
+  });
+
+  it('reports a proficiency-bonus bump', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentProfBonus: 2, newProfBonus: 3 })));
+    component.ngOnInit();
+    expect(component.profChanged).toBeTrue();
+  });
+
+  it('reports no proficiency change within a band', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentProfBonus: 2, newProfBonus: 2 })));
+    component.ngOnInit();
+    expect(component.profChanged).toBeFalse();
+  });
+
+  it('commits the level-up and emits close on success', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    const closeSpy = jasmine.createSpy('close');
+    component.close.subscribe(closeSpy);
+
+    component.ngOnInit();
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7);
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('keeps the modal open and shows an error if the commit fails', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+    pcService.levelUp.and.returnValue(throwError(() => ({ error: { message: 'Level-up failed.' } })));
+    const closeSpy = jasmine.createSpy('close');
+    component.close.subscribe(closeSpy);
+
+    component.ngOnInit();
+    component.confirm();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(component.submitting).toBeFalse();
+    expect(component.error).toBe('Level-up failed.');
+  });
+
+  it('does not commit while one is already in flight', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+    component.ngOnInit();
+
+    component.submitting = true; // simulate a commit already running
+    component.confirm();
+
+    expect(pcService.levelUp).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -1,0 +1,82 @@
+import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
+import { PC } from '../../models/pc';
+import { LevelUpPreview } from '../../models/level-up';
+import { PCService } from '../../services/pc.service';
+import { fmtMod } from '../../utils/character-math';
+
+/**
+ * Focused, single-level "Level Up" modal — mirrors the create wizard's pattern of applying
+ * one well-scoped set of gains at a time. It is a thin presenter: it loads the server-computed
+ * {@link LevelUpPreview} to show the deltas, then on confirm commits the advance via PCService
+ * (the backend is the rules authority). PCService pushes the updated PC into activePC$, so the
+ * character sheet refreshes itself — the modal only has to close.
+ *
+ * <p>Phase 1 covers HP + proficiency bonus. Later phases (spell slots, subclass, ASI/feat,
+ * features) extend this with additional choice steps; the load-preview → confirm flow stays.
+ */
+@Component({
+  selector: 'app-level-up-modal',
+  templateUrl: './level-up-modal.component.html',
+  styleUrls: ['./level-up-modal.component.scss'],
+})
+export class LevelUpModalComponent implements OnInit {
+  @Input() pc!: PC;
+  @Output() close = new EventEmitter<void>();
+
+  preview: LevelUpPreview | null = null;
+  loading = true;
+  submitting = false;
+  error: string | null = null;
+
+  constructor(private pcService: PCService) {}
+
+  ngOnInit(): void {
+    this.pcService.levelUpPreview(this.pc.id).subscribe({
+      next: preview => {
+        this.preview = preview;
+        this.loading = false;
+      },
+      error: err => {
+        this.error = this.messageFrom(err, 'Could not work out this level-up.');
+        this.loading = false;
+      },
+    });
+  }
+
+  fmtMod(value: number): string {
+    return fmtMod(value);
+  }
+
+  /** Whether the proficiency bonus changes on this level (drives a highlight). */
+  get profChanged(): boolean {
+    return !!this.preview && this.preview.newProfBonus !== this.preview.currentProfBonus;
+  }
+
+  confirm(): void {
+    if (!this.preview || this.submitting) return;
+    this.submitting = true;
+    this.error = null;
+    this.pcService.levelUp(this.pc.id).subscribe({
+      next: () => this.close.emit(),
+      error: err => {
+        this.error = this.messageFrom(err, 'Level-up failed. Please try again.');
+        this.submitting = false;
+      },
+    });
+  }
+
+  cancel(): void {
+    if (this.submitting) return;
+    this.close.emit();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    this.cancel();
+  }
+
+  private messageFrom(err: unknown, fallback: string): string {
+    const maybe = err as { error?: { message?: string } };
+    return maybe?.error?.message ?? fallback;
+  }
+}

--- a/src/app/charactermanager/components/main-content/main-content.component.html
+++ b/src/app/charactermanager/components/main-content/main-content.component.html
@@ -4,7 +4,8 @@
   *ngIf="pc"
   [pc]="pc"
   (deleteRequested)="openDeleteModal()"
-  (rollRequested)="openRollModal()">
+  (rollRequested)="openRollModal()"
+  (levelUpRequested)="openLevelUpModal()">
 </app-character-sheet>
 
 <app-empty-state
@@ -33,4 +34,15 @@
     (click)="$event.stopPropagation()"
     (close)="closeRollModal()">
   </app-dice-roller-modal>
+</div>
+
+<!-- Level-up overlay -->
+<div *ngIf="isLevelUpModalOpen && pc"
+     class="modal-backdrop"
+     (click)="closeLevelUpModal()">
+  <app-level-up-modal
+    [pc]="pc"
+    (click)="$event.stopPropagation()"
+    (close)="closeLevelUpModal()">
+  </app-level-up-modal>
 </div>

--- a/src/app/charactermanager/components/main-content/main-content.component.ts
+++ b/src/app/charactermanager/components/main-content/main-content.component.ts
@@ -14,6 +14,7 @@ export class MainContentComponent implements OnInit, OnDestroy {
   pc: PC | null = null;
   isDeleteModalOpen = false;
   isRollModalOpen = false;
+  isLevelUpModalOpen = false;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -46,6 +47,13 @@ export class MainContentComponent implements OnInit, OnDestroy {
 
   openRollModal(): void  { this.isRollModalOpen = true;  }
   closeRollModal(): void { this.isRollModalOpen = false; }
+
+  // ── Level-up modal ─────────────────────────────────────────────────────────
+  // The modal owns the preview→confirm→commit flow; PCService pushes the updated PC
+  // into activePC$, so the sheet refreshes itself. Here we only toggle visibility.
+
+  openLevelUpModal(): void  { this.isLevelUpModalOpen = true;  }
+  closeLevelUpModal(): void { this.isLevelUpModalOpen = false; }
 
   onDeleteConfirm(): void {
     if (!this.pc) return;

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -1,0 +1,17 @@
+/**
+ * What advancing one level grants, computed server-side and rendered by the SPA.
+ *
+ * The level-up rules engine is server-authoritative (manager-service LevelUpService);
+ * the frontend never computes these values from progression tables — it only displays
+ * this preview and then commits. Shape mirrors the backend `LevelUpPreview` record.
+ */
+export interface LevelUpPreview {
+  currentLevel: number;
+  newLevel: number;
+  hitDie: number;
+  conModifier: number;
+  hpGained: number;
+  newHpMax: number;
+  currentProfBonus: number;
+  newProfBonus: number;
+}

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -191,6 +191,68 @@ describe('PCService', () => {
     });
   });
 
+  // ── level-up (server-authoritative) ─────────────────────────────────────────
+
+  describe('levelUpPreview', () => {
+    it('GETs the preview endpoint and returns the server deltas', (done) => {
+      service.levelUpPreview(42).subscribe(preview => {
+        expect(preview.newLevel).toBe(5);
+        expect(preview.hpGained).toBe(7);
+        expect(preview.newProfBonus).toBe(3);
+        done();
+      });
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up/preview');
+      expect(req.request.method).toBe('GET');
+      req.flush({
+        currentLevel: 4, newLevel: 5, hitDie: 8, conModifier: 2,
+        hpGained: 7, newHpMax: 39, currentProfBonus: 2, newProfBonus: 3,
+      });
+    });
+  });
+
+  describe('levelUp', () => {
+    it('POSTs to the level-up endpoint and deserializes the updated PC', (done) => {
+      service.levelUp(42).subscribe(updated => {
+        expect(updated.level).toBe(5);
+        expect(updated.hp?.max).toBe(39);
+        expect(updated.prof).toBe(3);
+        done();
+      });
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up');
+      expect(req.request.method).toBe('POST');
+      req.flush({
+        id: 42, name: 'Aelindra', clazz: 'Wizard', level: 5,
+        hpMax: 39, hpCurrent: 39, hpTemp: 0, profBonus: 3,
+        abilityStr: 8, abilityDex: 12, abilityCon: 14,
+        abilityInt: 16, abilityWis: 14, abilityCha: 10,
+        spells: '[]', spellSlots: '{}', saves: '[]', skills: '{}',
+        conditions: '[]', coins: '{}', weapons: '[]', gear: '[]',
+        features: '[]', languages: '[]', toolProfs: '[]',
+      });
+    });
+
+    it('pushes the updated PC into the active stream when it is the active PC', (done) => {
+      service.setActivePC(makePC({ id: 42, level: 4 }));
+
+      service.levelUp(42).subscribe(() => {
+        service.activePC$.subscribe(active => {
+          expect(active?.level).toBe(5);
+          done();
+        });
+      });
+
+      httpMock.expectOne(service.pcUrl + '42/level-up').flush({
+        id: 42, name: 'Aelindra', clazz: 'Wizard', level: 5,
+        hpMax: 39, hpCurrent: 39, hpTemp: 0, profBonus: 3,
+        spells: '[]', spellSlots: '{}', saves: '[]', skills: '{}',
+        conditions: '[]', coins: '{}', weapons: '[]', gear: '[]',
+        features: '[]', languages: '[]', toolProfs: '[]',
+      });
+    });
+  });
+
   // ── deletePC ────────────────────────────────────────────────────────────────
 
   describe('deletePC', () => {

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -1,9 +1,11 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PC } from '../models/pc';
+import { LevelUpPreview } from '../models/level-up';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
+import { hitDieFor, modFromScore } from '../utils/character-math';
 
 // ---------------------------------------------------------------------------
 // Demo seed data — 3 fully-detailed PCs covering both parties.
@@ -302,6 +304,90 @@ export class PCService {
         }
       })
     );
+  }
+
+  // ── Level-up (server-authoritative) ────────────────────────────────────────
+  // The D&D rules engine lives in the backend (manager-service LevelUpService). These
+  // methods are a thin client: preview fetches the computed deltas to show before the
+  // user commits; levelUp commits and mirrors the returned PC into the reactive streams.
+
+  /** Fetch the server-computed gains of advancing this PC one level (no mutation). */
+  levelUpPreview(id: number): Observable<LevelUpPreview> {
+    if (environment.demoMode) {
+      return of(this.computeDemoPreview(id)).pipe(delay(200));
+    }
+    return this.http.get<LevelUpPreview>(`${this.pcUrl}${id}/level-up/preview`);
+  }
+
+  /** Commit a one-level advance server-side, then sync the updated PC into pcs$/activePC$. */
+  levelUp(id: number): Observable<PC> {
+    if (environment.demoMode) {
+      return this.applyDemoLevelUp(id).pipe(delay(150));
+    }
+    return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, {}).pipe(
+      map(raw => this.deserializePC(raw)),
+      tap(updated => {
+        this.pcs = this.pcs.map(p => p.id === updated.id ? updated : p);
+        this.pcsSubject.next(this.pcs);
+        const active = this.activePCSubject.getValue();
+        if (active && active.id === updated.id) {
+          this.activePCSubject.next(updated);
+        }
+      })
+    );
+  }
+
+  // --- Demo-mode level-up shim -------------------------------------------------
+  // UI-only mock so the modal can be exercised without a backend. This is NOT the
+  // rules engine — the authoritative D&D math lives server-side. It mirrors just
+  // enough (fixed-average HP + proficiency bonus) to render a believable demo, and
+  // reuses the existing display-math helpers rather than holding its own tables.
+
+  private demoProfBonus(level: number): number {
+    return Math.floor((level - 1) / 4) + 2;
+  }
+
+  private demoLevelUpFields(pc: PC) {
+    const current = pc.level ?? 1;
+    const hitDie = hitDieFor(pc.clazz);
+    const conMod = modFromScore(pc.stats?.CON ?? 10);
+    const hpGained = Math.max(1, Math.floor(hitDie / 2) + 1 + conMod);
+    return { current, newLevel: current + 1, hitDie, conMod, hpGained };
+  }
+
+  private computeDemoPreview(id: number): LevelUpPreview {
+    const pc = this.pcs.find(p => p.id === id)!;
+    const { current, newLevel, hitDie, conMod, hpGained } = this.demoLevelUpFields(pc);
+    return {
+      currentLevel: current,
+      newLevel,
+      hitDie,
+      conModifier: conMod,
+      hpGained,
+      newHpMax: (pc.hp?.max ?? 0) + hpGained,
+      currentProfBonus: this.demoProfBonus(current),
+      newProfBonus: this.demoProfBonus(newLevel),
+    };
+  }
+
+  private applyDemoLevelUp(id: number): Observable<PC> {
+    const existing = this.pcs.find(p => p.id === id)!;
+    const { newLevel, hpGained } = this.demoLevelUpFields(existing);
+    const updated: PC = {
+      ...existing,
+      level: newLevel,
+      prof: this.demoProfBonus(newLevel),
+      hp: existing.hp
+        ? { ...existing.hp, max: existing.hp.max + hpGained, cur: existing.hp.cur + hpGained }
+        : { max: hpGained, cur: hpGained, temp: 0 },
+    };
+    this.pcs = this.pcs.map(p => p.id === id ? updated : p);
+    this.pcsSubject.next(this.pcs);
+    const active = this.activePCSubject.getValue();
+    if (active && active.id === id) {
+      this.activePCSubject.next(updated);
+    }
+    return of(updated);
   }
 
   addPC(newPC: PC) {


### PR DESCRIPTION
Phase 1 frontend for the level-up feature. The SPA is a thin presenter over the server-authoritative rules engine: a new "Level Up" button in the character-sheet header opens a focused modal that fetches the server-computed LevelUpPreview, shows the HP and proficiency-bonus deltas, and on confirm commits via the new PCService.levelUp(). The updated PC is pushed into activePC$, so the sheet refreshes itself.

- pc.service.ts: levelUpPreview()/levelUp() calling the new backend endpoints, plus a clearly-marked demo-mode shim (UI-only mock, NOT a rules engine) that reuses character-math helpers so the modal is demoable without a backend.
- level-up-modal component (+ spec), models/level-up.ts (LevelUpPreview), and character-sheet @Output() levelUpRequested wired through main-content.

Verified: build green; 214 unit tests pass; end-to-end demo (demoMode) leveled a Barbarian 7->8 with +10 HP and unchanged +3 prof. demoMode reverted to false.