### PR TITLE
feat: render spell-slot progression in level-up modal (Phase 2)

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -37,6 +37,21 @@
           <span class="lvl-gain-note" *ngIf="!profChanged">(unchanged)</span>
         </span>
       </li>
+
+      <li class="lvl-gain" *ngIf="slotRows.length" [class.is-bump]="hasSlotChanges">
+        <span class="lvl-gain-label">Spell Slots</span>
+        <span class="lvl-gain-value">
+          <span class="slot-grid">
+            <span class="slot-pip" *ngFor="let s of slotRows" [class.slot-up]="s.gained">
+              <span class="slot-lvl">L{{ s.level }}</span>
+              <span class="slot-count">
+                <ng-container *ngIf="s.gained">{{ s.current }}→</ng-container>{{ s.next }}
+              </span>
+            </span>
+          </span>
+          <span class="lvl-gain-note" *ngIf="!hasSlotChanges">(unchanged)</span>
+        </span>
+      </li>
     </ul>
 
     <!-- A commit-time failure (e.g. raced to max level) -->

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -46,3 +46,45 @@
   font-weight: 400;
   color: var(--text-dim, rgba(255, 255, 255, 0.6));
 }
+
+// ── Spell-slot pips ───────────────────────────────────────────────────────────
+
+.slot-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.slot-pip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 34px;
+  padding: 3px 6px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  line-height: 1.2;
+
+  &.slot-up {
+    border-color: var(--celestial);
+    color: var(--celestial);
+  }
+}
+
+.slot-lvl {
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.slot-up .slot-lvl {
+  color: inherit;
+}
+
+.slot-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -18,6 +18,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
   return {
     currentLevel: 4, newLevel: 5, hitDie: 12, conModifier: 1,
     hpGained: 8, newHpMax: 92, currentProfBonus: 2, newProfBonus: 3,
+    currentSpellSlots: {}, newSpellSlots: {},
     ...overrides,
   };
 }
@@ -64,6 +65,28 @@ describe('LevelUpModalComponent', () => {
     pcService.levelUpPreview.and.returnValue(of(makePreview({ currentProfBonus: 2, newProfBonus: 2 })));
     component.ngOnInit();
     expect(component.profChanged).toBeFalse();
+  });
+
+  it('builds sorted spell-slot rows and flags gained slots (caster)', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      currentSpellSlots: { 1: 4, 2: 3, 3: 3, 4: 1 },
+      newSpellSlots: { 1: 4, 2: 3, 3: 3, 4: 2 }, // bard 7 -> 8: +1 level-4 slot
+    })));
+    component.ngOnInit();
+
+    expect(component.slotRows.map(r => r.level)).toEqual([1, 2, 3, 4]);
+    expect(component.hasSlotChanges).toBeTrue();
+    const lvl4 = component.slotRows.find(r => r.level === 4)!;
+    expect(lvl4.current).toBe(1);
+    expect(lvl4.next).toBe(2);
+    expect(lvl4.gained).toBeTrue();
+  });
+
+  it('has no slot rows for a non-caster', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentSpellSlots: {}, newSpellSlots: {} })));
+    component.ngOnInit();
+    expect(component.slotRows.length).toBe(0);
+    expect(component.hasSlotChanges).toBeFalse();
   });
 
   it('commits the level-up and emits close on success', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -52,6 +52,25 @@ export class LevelUpModalComponent implements OnInit {
     return !!this.preview && this.preview.newProfBonus !== this.preview.currentProfBonus;
   }
 
+  /** Per-spell-level slot picture for casters: { level, current, next, gained }. Empty otherwise. */
+  get slotRows(): { level: number; current: number; next: number; gained: boolean }[] {
+    const p = this.preview;
+    if (!p || !p.newSpellSlots) return [];
+    return Object.keys(p.newSpellSlots)
+      .map(k => Number(k))
+      .sort((a, b) => a - b)
+      .map(level => {
+        const next = p.newSpellSlots[level] ?? 0;
+        const current = p.currentSpellSlots?.[level] ?? 0;
+        return { level, current, next, gained: next > current };
+      });
+  }
+
+  /** True when this level grants new or additional spell slots (shows the slots row). */
+  get hasSlotChanges(): boolean {
+    return this.slotRows.some(r => r.gained);
+  }
+
   confirm(): void {
     if (!this.preview || this.submitting) return;
     this.submitting = true;

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -14,4 +14,8 @@ export interface LevelUpPreview {
   newHpMax: number;
   currentProfBonus: number;
   newProfBonus: number;
+  // Spell slots before/after the level, keyed by spell level (1-9) → max slots.
+  // Empty for non-casters. Server-computed (Phase 2); the SPA only renders them.
+  currentSpellSlots: { [spellLevel: number]: number };
+  newSpellSlots: { [spellLevel: number]: number };
 }

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -199,6 +199,7 @@ describe('PCService', () => {
         expect(preview.newLevel).toBe(5);
         expect(preview.hpGained).toBe(7);
         expect(preview.newProfBonus).toBe(3);
+        expect(preview.newSpellSlots[3]).toBe(2);
         done();
       });
 
@@ -207,6 +208,7 @@ describe('PCService', () => {
       req.flush({
         currentLevel: 4, newLevel: 5, hitDie: 8, conModifier: 2,
         hpGained: 7, newHpMax: 39, currentProfBonus: 2, newProfBonus: 3,
+        currentSpellSlots: { 1: 4, 2: 3 }, newSpellSlots: { 1: 4, 2: 3, 3: 2 },
       });
     });
   });

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -355,6 +355,41 @@ export class PCService {
     return { current, newLevel: current + 1, hitDie, conMod, hpGained };
   }
 
+  // DEMO-ONLY mirror of the server's ClassProgression spell-slot tables. Lives here purely so
+  // the modal can show slot growth without a backend; production never reads it (the real tables
+  // are server-side). Keep in sync with ClassProgression if you rely on the demo for slot checks.
+  private static readonly DEMO_FULL_CASTERS = new Set(['bard', 'cleric', 'druid', 'sorcerer', 'wizard']);
+  private static readonly DEMO_FULL_CASTER_SLOTS: number[][] = [
+    [2], [3], [4, 2], [4, 3], [4, 3, 2], [4, 3, 3], [4, 3, 3, 1], [4, 3, 3, 2],
+    [4, 3, 3, 3, 1], [4, 3, 3, 3, 2], [4, 3, 3, 3, 2, 1], [4, 3, 3, 3, 2, 1],
+    [4, 3, 3, 3, 2, 1, 1], [4, 3, 3, 3, 2, 1, 1], [4, 3, 3, 3, 2, 1, 1, 1],
+    [4, 3, 3, 3, 2, 1, 1, 1], [4, 3, 3, 3, 2, 1, 1, 1, 1], [4, 3, 3, 3, 3, 1, 1, 1, 1],
+    [4, 3, 3, 3, 3, 2, 1, 1, 1], [4, 3, 3, 3, 3, 2, 2, 1, 1],
+  ];
+  private static readonly DEMO_PACT_SLOTS: [number, number][] = [
+    [1, 1], [1, 2], [2, 2], [2, 2], [3, 2], [3, 2], [4, 2], [4, 2], [5, 2], [5, 2],
+    [5, 3], [5, 3], [5, 3], [5, 3], [5, 3], [5, 3], [5, 4], [5, 4], [5, 4], [5, 4],
+  ];
+
+  private demoSlotsFor(clazz: string, level: number): { [lvl: number]: number } {
+    const key = (clazz ?? '').trim().toLowerCase();
+    const idx = Math.min(Math.max(level, 1), 20) - 1;
+    const out: { [lvl: number]: number } = {};
+    if (PCService.DEMO_FULL_CASTERS.has(key)) {
+      PCService.DEMO_FULL_CASTER_SLOTS[idx].forEach((max, i) => { if (max > 0) out[i + 1] = max; });
+    } else if (key === 'warlock') {
+      const [slotLevel, count] = PCService.DEMO_PACT_SLOTS[idx];
+      out[slotLevel] = count;
+    }
+    return out;
+  }
+
+  private demoCurrentMaxSlots(pc: PC): { [lvl: number]: number } {
+    const out: { [lvl: number]: number } = {};
+    Object.entries(pc.spellSlots ?? {}).forEach(([lvl, slot]) => { out[Number(lvl)] = slot.max; });
+    return out;
+  }
+
   private computeDemoPreview(id: number): LevelUpPreview {
     const pc = this.pcs.find(p => p.id === id)!;
     const { current, newLevel, hitDie, conMod, hpGained } = this.demoLevelUpFields(pc);
@@ -367,12 +402,25 @@ export class PCService {
       newHpMax: (pc.hp?.max ?? 0) + hpGained,
       currentProfBonus: this.demoProfBonus(current),
       newProfBonus: this.demoProfBonus(newLevel),
+      currentSpellSlots: this.demoCurrentMaxSlots(pc),
+      newSpellSlots: this.demoSlotsFor(pc.clazz, newLevel),
     };
   }
 
   private applyDemoLevelUp(id: number): Observable<PC> {
     const existing = this.pcs.find(p => p.id === id)!;
     const { newLevel, hpGained } = this.demoLevelUpFields(existing);
+    // Rebuild slots from the demo table, preserving `used` (clamped) like the server does.
+    const targetSlots = this.demoSlotsFor(existing.clazz, newLevel);
+    let spellSlots = existing.spellSlots;
+    if (Object.keys(targetSlots).length > 0) {
+      spellSlots = {};
+      for (const [lvlStr, max] of Object.entries(targetSlots)) {
+        const lvl = Number(lvlStr);
+        const priorUsed = existing.spellSlots?.[lvl]?.used ?? 0;
+        spellSlots[lvl] = { max, used: Math.min(priorUsed, max) };
+      }
+    }
     const updated: PC = {
       ...existing,
       level: newLevel,
@@ -380,6 +428,7 @@ export class PCService {
       hp: existing.hp
         ? { ...existing.hp, max: existing.hp.max + hpGained, cur: existing.hp.cur + hpGained }
         : { max: hpGained, cur: hpGained, temp: 0 },
+      spellSlots,
     };
     this.pcs = this.pcs.map(p => p.id === id ? updated : p);
     this.pcsSubject.next(this.pcs);


### PR DESCRIPTION
The level-up modal now shows the spell-slot picture for casters: a per-spell- level pip grid driven by the server-computed currentSpellSlots/newSpellSlots on LevelUpPreview, highlighting only the levels that gain a slot (e.g. Bard 7->8 shows L4 1->2). Non-casters show no slot row. The SPA holds no progression tables — it renders what the backend returns.

- models/level-up.ts: LevelUpPreview gains current/new slot maps.
- level-up-modal: slotRows/hasSlotChanges getters + pip grid markup/styles.
- pc.service demo shim: a clearly-labelled DEMO-ONLY mirror of the server slot tables so the modal is demoable without a backend (production reads none of it), rebuilding slots and preserving `used` like the server.

Verified: build green; 216 unit tests pass; demo leveled Bard 7->8 with HP +7, prof +3 unchanged, slots 4/3/3/1 -> 4/3/3/2 and the sheet's spellbook reflected the new L4 slot with used counts preserved. demoMode reverted to false.