### PR TITLE
feat: add subclass picker to level-up modal (Phase 3, gated)

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -54,6 +54,16 @@
       </li>
     </ul>
 
+    <!-- Subclass selection (shown only when a choice is due and options exist) -->
+    <div *ngIf="needsSubclass" class="subclass-pick">
+      <div class="subclass-label">Choose your subclass</div>
+      <label class="subclass-option" *ngFor="let option of p.subclassOptions"
+             [class.is-selected]="selectedSubclass === option">
+        <input type="radio" name="subclass" [value]="option" [(ngModel)]="selectedSubclass">
+        <span>{{ option }}</span>
+      </label>
+    </div>
+
     <!-- A commit-time failure (e.g. raced to max level) -->
     <div *ngIf="error && preview" class="modal-sub" style="color: var(--crimson);">
       {{ error }}
@@ -61,7 +71,7 @@
 
     <div class="modal-actions">
       <button class="btn" type="button" (click)="cancel()" [disabled]="submitting">Not Yet</button>
-      <button class="btn" type="button" (click)="confirm()" [disabled]="submitting"
+      <button class="btn" type="button" (click)="confirm()" [disabled]="submitting || !canConfirm"
               style="border-color: var(--celestial); color: var(--celestial);">
         {{ submitting ? 'Ascending…' : 'Level Up' }}
       </button>

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -88,3 +88,36 @@
   font-size: 0.85rem;
   font-weight: 600;
 }
+
+// ── Subclass picker ───────────────────────────────────────────────────────────
+
+.subclass-pick {
+  margin: 16px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.subclass-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.subclass-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  cursor: pointer;
+  color: var(--text, #fff);
+
+  &.is-selected {
+    border-color: var(--celestial);
+    color: var(--celestial);
+  }
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -19,6 +19,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     currentLevel: 4, newLevel: 5, hitDie: 12, conModifier: 1,
     hpGained: 8, newHpMax: 92, currentProfBonus: 2, newProfBonus: 3,
     currentSpellSlots: {}, newSpellSlots: {},
+    subclassDue: false, subclassOptions: [],
     ...overrides,
   };
 }
@@ -98,8 +99,45 @@ describe('LevelUpModalComponent', () => {
     component.ngOnInit();
     component.confirm();
 
-    expect(pcService.levelUp).toHaveBeenCalledWith(7);
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, undefined);
     expect(closeSpy).toHaveBeenCalled();
+  });
+
+  // --- subclass picker (Phase 3) ---
+
+  it('does not show the subclass picker when options are empty (mechanism dormant)', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ subclassDue: true, subclassOptions: [] })));
+    component.ngOnInit();
+    expect(component.needsSubclass).toBeFalse();
+    expect(component.canConfirm).toBeTrue();
+  });
+
+  it('requires a subclass choice when options are offered', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      subclassDue: true, subclassOptions: ['Life Domain', 'War Domain'],
+    })));
+    component.ngOnInit();
+
+    expect(component.needsSubclass).toBeTrue();
+    expect(component.canConfirm).toBeFalse(); // nothing picked yet
+
+    component.selectedSubclass = 'War Domain';
+    expect(component.canConfirm).toBeTrue();
+  });
+
+  it('blocks confirm until a required subclass is chosen, then sends it', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      subclassDue: true, subclassOptions: ['Life Domain', 'War Domain'],
+    })));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    component.ngOnInit();
+
+    component.confirm(); // no selection -> blocked
+    expect(pcService.levelUp).not.toHaveBeenCalled();
+
+    component.selectedSubclass = 'Life Domain';
+    component.confirm();
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, 'Life Domain');
   });
 
   it('keeps the modal open and shows an error if the commit fails', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -27,6 +27,7 @@ export class LevelUpModalComponent implements OnInit {
   loading = true;
   submitting = false;
   error: string | null = null;
+  selectedSubclass: string | null = null;
 
   constructor(private pcService: PCService) {}
 
@@ -71,11 +72,21 @@ export class LevelUpModalComponent implements OnInit {
     return this.slotRows.some(r => r.gained);
   }
 
+  /** Whether to show the subclass picker: a choice is due AND the server offered options. */
+  get needsSubclass(): boolean {
+    return !!this.preview?.subclassDue && (this.preview?.subclassOptions?.length ?? 0) > 0;
+  }
+
+  /** Confirm is blocked until a subclass is chosen when one is required. */
+  get canConfirm(): boolean {
+    return !this.needsSubclass || !!this.selectedSubclass;
+  }
+
   confirm(): void {
-    if (!this.preview || this.submitting) return;
+    if (!this.preview || this.submitting || !this.canConfirm) return;
     this.submitting = true;
     this.error = null;
-    this.pcService.levelUp(this.pc.id).subscribe({
+    this.pcService.levelUp(this.pc.id, this.selectedSubclass ?? undefined).subscribe({
       next: () => this.close.emit(),
       error: err => {
         this.error = this.messageFrom(err, 'Level-up failed. Please try again.');

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -18,4 +18,9 @@ export interface LevelUpPreview {
   // Empty for non-casters. Server-computed (Phase 2); the SPA only renders them.
   currentSpellSlots: { [spellLevel: number]: number };
   newSpellSlots: { [spellLevel: number]: number };
+  // Phase 3: whether a subclass choice is due at the new level, and the selectable names.
+  // subclassOptions is empty until catalog content is authored server-side, so the SPA
+  // shows the picker only when there is something to choose.
+  subclassDue: boolean;
+  subclassOptions: string[];
 }

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -209,11 +209,21 @@ describe('PCService', () => {
         currentLevel: 4, newLevel: 5, hitDie: 8, conModifier: 2,
         hpGained: 7, newHpMax: 39, currentProfBonus: 2, newProfBonus: 3,
         currentSpellSlots: { 1: 4, 2: 3 }, newSpellSlots: { 1: 4, 2: 3, 3: 2 },
+        subclassDue: false, subclassOptions: [],
       });
     });
   });
 
   describe('levelUp', () => {
+    it('sends the chosen subclass in the POST body when provided', () => {
+      service.levelUp(42, 'Life Domain').subscribe();
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up');
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ subclass: 'Life Domain' });
+      req.flush({ id: 42, name: 'Aelindra', clazz: 'Cleric', level: 3, subclass: 'Life Domain' });
+    });
+
     it('POSTs to the level-up endpoint and deserializes the updated PC', (done) => {
       service.levelUp(42).subscribe(updated => {
         expect(updated.level).toBe(5);

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -319,12 +319,16 @@ export class PCService {
     return this.http.get<LevelUpPreview>(`${this.pcUrl}${id}/level-up/preview`);
   }
 
-  /** Commit a one-level advance server-side, then sync the updated PC into pcs$/activePC$. */
-  levelUp(id: number): Observable<PC> {
+  /**
+   * Commit a one-level advance server-side, then sync the updated PC into pcs$/activePC$.
+   * Pass `subclass` when the level grants a subclass choice (the only client-supplied input).
+   */
+  levelUp(id: number, subclass?: string): Observable<PC> {
     if (environment.demoMode) {
-      return this.applyDemoLevelUp(id).pipe(delay(150));
+      return this.applyDemoLevelUp(id, subclass).pipe(delay(150));
     }
-    return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, {}).pipe(
+    const body = subclass ? { subclass } : {};
+    return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, body).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
         this.pcs = this.pcs.map(p => p.id === updated.id ? updated : p);
@@ -390,6 +394,13 @@ export class PCService {
     return out;
   }
 
+  // DEMO-ONLY mirror of the server subclass grant levels (sorcerer/warlock = 1, else = 3).
+  // The subclass catalog is empty server-side (mechanism only), so the demo offers no options
+  // either — the picker never shows. Kept for parity if catalog content is added later.
+  private demoSubclassLevel(clazz: string): number {
+    return ['sorcerer', 'warlock'].includes((clazz ?? '').trim().toLowerCase()) ? 1 : 3;
+  }
+
   private computeDemoPreview(id: number): LevelUpPreview {
     const pc = this.pcs.find(p => p.id === id)!;
     const { current, newLevel, hitDie, conMod, hpGained } = this.demoLevelUpFields(pc);
@@ -404,10 +415,12 @@ export class PCService {
       newProfBonus: this.demoProfBonus(newLevel),
       currentSpellSlots: this.demoCurrentMaxSlots(pc),
       newSpellSlots: this.demoSlotsFor(pc.clazz, newLevel),
+      subclassDue: newLevel === this.demoSubclassLevel(pc.clazz) && !pc.subclass,
+      subclassOptions: [], // no catalog content (mechanism only)
     };
   }
 
-  private applyDemoLevelUp(id: number): Observable<PC> {
+  private applyDemoLevelUp(id: number, subclass?: string): Observable<PC> {
     const existing = this.pcs.find(p => p.id === id)!;
     const { newLevel, hpGained } = this.demoLevelUpFields(existing);
     // Rebuild slots from the demo table, preserving `used` (clamped) like the server does.
@@ -429,6 +442,7 @@ export class PCService {
         ? { ...existing.hp, max: existing.hp.max + hpGained, cur: existing.hp.cur + hpGained }
         : { max: hpGained, cur: hpGained, temp: 0 },
       spellSlots,
+      subclass: subclass || existing.subclass,
     };
     this.pcs = this.pcs.map(p => p.id === id ? updated : p);
     this.pcsSubject.next(this.pcs);


### PR DESCRIPTION
Frontend half of the subclass-selection mechanism. The modal renders a subclass radio picker — and blocks confirm until a choice is made — but only when the server-computed preview reports a choice is due AND offers options. Because the backend catalog is empty (mechanism only), the picker never shows today and the flow is a no-op; it lights up with no further code change once content exists.

- models/level-up.ts: LevelUpPreview gains subclassDue + subclassOptions.
- level-up-modal: needsSubclass/canConfirm gating, radio picker, sends the choice.
- pc.service.levelUp(id, subclass?) posts an optional { subclass } body; demo shim threads the choice and mirrors the server grant levels (still no options).

Verified: build green; 220 unit tests pass (gating, required-selection, body). Not UI-demoable by design — no catalog content to pick.