### PR TITLE
feat: add ASI allocator to level-up modal (Phase 4)

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -54,6 +54,27 @@
       </li>
     </ul>
 
+    <!-- Ability Score Improvement (shown only when an ASI is due this level) -->
+    <div *ngIf="needsAsi" class="asi-pick">
+      <div class="asi-label">
+        Ability Score Improvement
+        <span class="asi-remaining">{{ asiRemaining }} point{{ asiRemaining === 1 ? '' : 's' }} left</span>
+      </div>
+      <div class="asi-row" *ngFor="let ability of abilities" [class.is-raised]="asiAllocation[ability] > 0">
+        <span class="asi-ability">{{ ability }}</span>
+        <span class="asi-score">
+          {{ currentScore(ability) }}
+          <ng-container *ngIf="asiAllocation[ability] > 0">→ {{ newScore(ability) }}</ng-container>
+        </span>
+        <span class="asi-steppers">
+          <button type="button" class="asi-step" (click)="decAsi(ability)" [disabled]="!canDec(ability)">−</button>
+          <span class="asi-alloc">+{{ asiAllocation[ability] }}</span>
+          <button type="button" class="asi-step" (click)="incAsi(ability)" [disabled]="!canInc(ability)">+</button>
+        </span>
+      </div>
+      <div class="asi-note" *ngIf="asiRaisesCon">Raising Constitution will increase your hit points further.</div>
+    </div>
+
     <!-- Subclass selection (shown only when a choice is due and options exist) -->
     <div *ngIf="needsSubclass" class="subclass-pick">
       <div class="subclass-label">Choose your subclass</div>

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -121,3 +121,93 @@
     color: var(--celestial);
   }
 }
+
+// ── Ability Score Improvement allocator ───────────────────────────────────────
+
+.asi-pick {
+  margin: 16px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.asi-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.asi-remaining {
+  font-size: 0.72rem;
+  color: var(--celestial);
+}
+
+.asi-row {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+
+  &.is-raised {
+    border-color: var(--celestial);
+  }
+}
+
+.asi-ability {
+  font-weight: 600;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.is-raised .asi-ability {
+  color: var(--celestial);
+}
+
+.asi-score {
+  font-weight: 600;
+  color: var(--text, #fff);
+}
+
+.asi-steppers {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.asi-step {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text, #fff);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+}
+
+.asi-alloc {
+  min-width: 24px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.asi-note {
+  margin-top: 4px;
+  font-size: 0.74rem;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -20,6 +20,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     hpGained: 8, newHpMax: 92, currentProfBonus: 2, newProfBonus: 3,
     currentSpellSlots: {}, newSpellSlots: {},
     subclassDue: false, subclassOptions: [],
+    asiDue: false,
     ...overrides,
   };
 }
@@ -99,7 +100,7 @@ describe('LevelUpModalComponent', () => {
     component.ngOnInit();
     component.confirm();
 
-    expect(pcService.levelUp).toHaveBeenCalledWith(7, undefined);
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, {});
     expect(closeSpy).toHaveBeenCalled();
   });
 
@@ -137,7 +138,64 @@ describe('LevelUpModalComponent', () => {
 
     component.selectedSubclass = 'Life Domain';
     component.confirm();
-    expect(pcService.levelUp).toHaveBeenCalledWith(7, 'Life Domain');
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, { subclass: 'Life Domain' });
+  });
+
+  // --- ASI allocator (Phase 4) ---
+
+  it('does not show the ASI allocator when none is due', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: false })));
+    component.ngOnInit();
+    expect(component.needsAsi).toBeFalse();
+    expect(component.canConfirm).toBeTrue();
+  });
+
+  it('requires exactly 2 ASI points before confirm when an ASI is due', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 16, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+
+    expect(component.needsAsi).toBeTrue();
+    expect(component.canConfirm).toBeFalse();
+
+    component.incAsi('STR');         // +1 -> not enough
+    expect(component.canConfirm).toBeFalse();
+    component.incAsi('STR');         // +2 -> valid
+    expect(component.canConfirm).toBeTrue();
+    expect(component.newScore('STR')).toBe(18);
+  });
+
+  it('caps a single ability at +2 and the total at 2 points', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 16, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+
+    component.incAsi('STR'); component.incAsi('STR');
+    expect(component.canInc('STR')).toBeFalse(); // per-ability cap of +2
+    expect(component.canInc('DEX')).toBeFalse(); // no points left
+  });
+
+  it('does not let an ability exceed 20', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 20, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+    expect(component.canInc('STR')).toBeFalse();
+  });
+
+  it('sends the ASI allocation in the choices', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true })));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 4 })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 16, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+
+    component.incAsi('STR'); component.incAsi('DEX');
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, { abilityIncreases: { STR: 1, DEX: 1 } });
   });
 
   it('keeps the modal open and shows an error if the commit fails', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { PC } from '../../models/pc';
-import { LevelUpPreview } from '../../models/level-up';
+import { LevelUpPreview, LevelUpChoices } from '../../models/level-up';
 import { PCService } from '../../services/pc.service';
 import { fmtMod } from '../../utils/character-math';
 
@@ -28,6 +28,10 @@ export class LevelUpModalComponent implements OnInit {
   submitting = false;
   error: string | null = null;
   selectedSubclass: string | null = null;
+
+  readonly abilities = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+  /** Points allocated this ASI per ability (0/1/2); total must reach 2 to confirm. */
+  asiAllocation: { [ability: string]: number } = { STR: 0, DEX: 0, CON: 0, INT: 0, WIS: 0, CHA: 0 };
 
   constructor(private pcService: PCService) {}
 
@@ -77,22 +81,86 @@ export class LevelUpModalComponent implements OnInit {
     return !!this.preview?.subclassDue && (this.preview?.subclassOptions?.length ?? 0) > 0;
   }
 
-  /** Confirm is blocked until a subclass is chosen when one is required. */
+  // ── Ability Score Improvement allocator ─────────────────────────────────────
+
+  /** Whether an ASI is due this level (server-decided). */
+  get needsAsi(): boolean {
+    return !!this.preview?.asiDue;
+  }
+
+  /** Points spent so far (0–2). */
+  get asiUsed(): number {
+    return this.abilities.reduce((sum, a) => sum + this.asiAllocation[a], 0);
+  }
+
+  get asiRemaining(): number {
+    return 2 - this.asiUsed;
+  }
+
+  /** A valid ASI spends exactly 2 points (= +2 to one ability or +1 to two). */
+  get asiValid(): boolean {
+    return this.asiUsed === 2;
+  }
+
+  /** Whether the pending ASI raises Constitution (HP will increase further on confirm). */
+  get asiRaisesCon(): boolean {
+    return this.asiAllocation['CON'] > 0;
+  }
+
+  currentScore(ability: string): number {
+    return (this.pc.stats as Record<string, number> | undefined)?.[ability] ?? 10;
+  }
+
+  newScore(ability: string): number {
+    return this.currentScore(ability) + this.asiAllocation[ability];
+  }
+
+  canInc(ability: string): boolean {
+    return this.asiRemaining > 0 && this.asiAllocation[ability] < 2 && this.newScore(ability) < 20;
+  }
+
+  canDec(ability: string): boolean {
+    return this.asiAllocation[ability] > 0;
+  }
+
+  incAsi(ability: string): void {
+    if (this.canInc(ability)) this.asiAllocation[ability]++;
+  }
+
+  decAsi(ability: string): void {
+    if (this.canDec(ability)) this.asiAllocation[ability]--;
+  }
+
+  /** Confirm is blocked until any required subclass and ASI choices are made. */
   get canConfirm(): boolean {
-    return !this.needsSubclass || !!this.selectedSubclass;
+    return (!this.needsSubclass || !!this.selectedSubclass) && (!this.needsAsi || this.asiValid);
   }
 
   confirm(): void {
     if (!this.preview || this.submitting || !this.canConfirm) return;
     this.submitting = true;
     this.error = null;
-    this.pcService.levelUp(this.pc.id, this.selectedSubclass ?? undefined).subscribe({
+
+    const choices: LevelUpChoices = {};
+    if (this.selectedSubclass) choices.subclass = this.selectedSubclass;
+    const increases = this.allocatedAbilities();
+    if (Object.keys(increases).length) choices.abilityIncreases = increases;
+
+    this.pcService.levelUp(this.pc.id, choices).subscribe({
       next: () => this.close.emit(),
       error: err => {
         this.error = this.messageFrom(err, 'Level-up failed. Please try again.');
         this.submitting = false;
       },
     });
+  }
+
+  private allocatedAbilities(): { [ability: string]: number } {
+    const out: { [ability: string]: number } = {};
+    for (const a of this.abilities) {
+      if (this.asiAllocation[a] > 0) out[a] = this.asiAllocation[a];
+    }
+    return out;
   }
 
   cancel(): void {

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -23,4 +23,13 @@ export interface LevelUpPreview {
   // shows the picker only when there is something to choose.
   subclassDue: boolean;
   subclassOptions: string[];
+  // Phase 4: whether an Ability Score Improvement is due at the new level (4/8/12/16/19,
+  // plus Fighter 6/14 and Rogue 10). The SPA builds the +2/+1+1 allocator from pc.stats.
+  asiDue: boolean;
+}
+
+/** Player choices sent when committing a level-up (all optional). */
+export interface LevelUpChoices {
+  subclass?: string;
+  abilityIncreases?: { [ability: string]: number };
 }

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -216,12 +216,20 @@ describe('PCService', () => {
 
   describe('levelUp', () => {
     it('sends the chosen subclass in the POST body when provided', () => {
-      service.levelUp(42, 'Life Domain').subscribe();
+      service.levelUp(42, { subclass: 'Life Domain' }).subscribe();
 
       const req = httpMock.expectOne(service.pcUrl + '42/level-up');
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({ subclass: 'Life Domain' });
       req.flush({ id: 42, name: 'Aelindra', clazz: 'Cleric', level: 3, subclass: 'Life Domain' });
+    });
+
+    it('sends the ASI allocation in the POST body when provided', () => {
+      service.levelUp(42, { abilityIncreases: { STR: 1, DEX: 1 } }).subscribe();
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up');
+      expect(req.request.body).toEqual({ abilityIncreases: { STR: 1, DEX: 1 } });
+      req.flush({ id: 42, name: 'Throk', clazz: 'Fighter', level: 4 });
     });
 
     it('POSTs to the level-up endpoint and deserializes the updated PC', (done) => {

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PC } from '../models/pc';
-import { LevelUpPreview } from '../models/level-up';
+import { LevelUpPreview, LevelUpChoices } from '../models/level-up';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -321,13 +321,16 @@ export class PCService {
 
   /**
    * Commit a one-level advance server-side, then sync the updated PC into pcs$/activePC$.
-   * Pass `subclass` when the level grants a subclass choice (the only client-supplied input).
+   * `choices` carries the only client-supplied inputs (subclass, ASI allocation); the server
+   * computes and validates everything else.
    */
-  levelUp(id: number, subclass?: string): Observable<PC> {
+  levelUp(id: number, choices?: LevelUpChoices): Observable<PC> {
     if (environment.demoMode) {
-      return this.applyDemoLevelUp(id, subclass).pipe(delay(150));
+      return this.applyDemoLevelUp(id, choices).pipe(delay(150));
     }
-    const body = subclass ? { subclass } : {};
+    const body: LevelUpChoices = {};
+    if (choices?.subclass) body.subclass = choices.subclass;
+    if (choices?.abilityIncreases) body.abilityIncreases = choices.abilityIncreases;
     return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, body).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
@@ -401,6 +404,15 @@ export class PCService {
     return ['sorcerer', 'warlock'].includes((clazz ?? '').trim().toLowerCase()) ? 1 : 3;
   }
 
+  // DEMO-ONLY mirror of the server ASI levels (default 4/8/12/16/19; Fighter +6/14; Rogue +10).
+  private demoIsAsiLevel(clazz: string, level: number): boolean {
+    const key = (clazz ?? '').trim().toLowerCase();
+    const levels = key === 'fighter' ? [4, 6, 8, 12, 14, 16, 19]
+      : key === 'rogue' ? [4, 8, 10, 12, 16, 19]
+        : [4, 8, 12, 16, 19];
+    return levels.includes(level);
+  }
+
   private computeDemoPreview(id: number): LevelUpPreview {
     const pc = this.pcs.find(p => p.id === id)!;
     const { current, newLevel, hitDie, conMod, hpGained } = this.demoLevelUpFields(pc);
@@ -417,12 +429,31 @@ export class PCService {
       newSpellSlots: this.demoSlotsFor(pc.clazz, newLevel),
       subclassDue: newLevel === this.demoSubclassLevel(pc.clazz) && !pc.subclass,
       subclassOptions: [], // no catalog content (mechanism only)
+      asiDue: this.demoIsAsiLevel(pc.clazz, newLevel),
     };
   }
 
-  private applyDemoLevelUp(id: number, subclass?: string): Observable<PC> {
+  private applyDemoLevelUp(id: number, choices?: LevelUpChoices): Observable<PC> {
     const existing = this.pcs.find(p => p.id === id)!;
-    const { newLevel, hpGained } = this.demoLevelUpFields(existing);
+    const current = existing.level ?? 1;
+    const newLevel = current + 1;
+    const hitDie = hitDieFor(existing.clazz);
+
+    // Apply the ASI to a copy of the ability scores, then recompute HP with the new CON and
+    // grant retroactive HP for prior levels when CON's modifier rises (mirrors the server).
+    const stats: { [k: string]: number } = {
+      STR: 10, DEX: 10, CON: 10, INT: 10, WIS: 10, CHA: 10, ...(existing.stats ?? {}),
+    };
+    const oldConMod = modFromScore(stats['CON']);
+    if (choices?.abilityIncreases) {
+      for (const [ability, pts] of Object.entries(choices.abilityIncreases)) {
+        stats[ability] = Math.min(20, (stats[ability] ?? 10) + pts);
+      }
+    }
+    const newConMod = modFromScore(stats['CON']);
+    const hpGained = Math.max(1, Math.floor(hitDie / 2) + 1 + newConMod);
+    const hpDelta = hpGained + (newLevel - 1) * (newConMod - oldConMod);
+
     // Rebuild slots from the demo table, preserving `used` (clamped) like the server does.
     const targetSlots = this.demoSlotsFor(existing.clazz, newLevel);
     let spellSlots = existing.spellSlots;
@@ -438,11 +469,12 @@ export class PCService {
       ...existing,
       level: newLevel,
       prof: this.demoProfBonus(newLevel),
+      stats: stats as PC['stats'],
       hp: existing.hp
-        ? { ...existing.hp, max: existing.hp.max + hpGained, cur: existing.hp.cur + hpGained }
-        : { max: hpGained, cur: hpGained, temp: 0 },
+        ? { ...existing.hp, max: existing.hp.max + hpDelta, cur: existing.hp.cur + hpDelta }
+        : { max: hpDelta, cur: hpDelta, temp: 0 },
       spellSlots,
-      subclass: subclass || existing.subclass,
+      subclass: choices?.subclass || existing.subclass,
     };
     this.pcs = this.pcs.map(p => p.id === id ? updated : p);
     this.pcsSubject.next(this.pcs);


### PR DESCRIPTION
When the server reports an ASI is due, the modal shows a per-ability allocator (+/- steppers) that spends exactly 2 points — +2 to one ability or +1 to two — capped at 20, and blocks confirm until valid. The chosen allocation is sent as abilityIncreases; the server validates and applies it (including retroactive HP when CON rises). A note appears when Constitution is being raised.

- models/level-up.ts: LevelUpPreview gains asiDue; new LevelUpChoices type.
- pc.service.levelUp(id, choices) posts { subclass?, abilityIncreases? }; demo shim applies the ASI to stats with retroactive HP and reports asiDue.
- level-up-modal: allocator state/getters, gating, markup, styles.

Verified: build green; 226 unit tests pass (allocator gating, +2/+1+1, per-ability and 20 caps, allocation payload). Live browser demo deferred for momentum; ASI is covered end-to-end by unit tests on both repos.