### PR TITLE
feat: add ASI-or-Feat choice to level-up modal

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -54,25 +54,44 @@
       </li>
     </ul>
 
-    <!-- Ability Score Improvement (shown only when an ASI is due this level) -->
+    <!-- Milestone choice: Ability Score Improvement OR a feat (shown at ASI levels) -->
     <div *ngIf="needsAsi" class="asi-pick">
-      <div class="asi-label">
-        Ability Score Improvement
-        <span class="asi-remaining">{{ asiRemaining }} point{{ asiRemaining === 1 ? '' : 's' }} left</span>
+      <div class="milestone-toggle">
+        <button type="button" class="milestone-tab" [class.is-active]="milestoneMode === 'asi'"
+                (click)="milestoneMode = 'asi'">Ability Scores</button>
+        <button type="button" class="milestone-tab" [class.is-active]="milestoneMode === 'feat'"
+                (click)="milestoneMode = 'feat'">Feat</button>
       </div>
-      <div class="asi-row" *ngFor="let ability of abilities" [class.is-raised]="asiAllocation[ability] > 0">
-        <span class="asi-ability">{{ ability }}</span>
-        <span class="asi-score">
-          {{ currentScore(ability) }}
-          <ng-container *ngIf="asiAllocation[ability] > 0">→ {{ newScore(ability) }}</ng-container>
-        </span>
-        <span class="asi-steppers">
-          <button type="button" class="asi-step" (click)="decAsi(ability)" [disabled]="!canDec(ability)">−</button>
-          <span class="asi-alloc">+{{ asiAllocation[ability] }}</span>
-          <button type="button" class="asi-step" (click)="incAsi(ability)" [disabled]="!canInc(ability)">+</button>
-        </span>
-      </div>
-      <div class="asi-note" *ngIf="asiRaisesCon">Raising Constitution will increase your hit points further.</div>
+
+      <ng-container *ngIf="milestoneMode === 'asi'">
+        <div class="asi-label">
+          <span class="asi-remaining">{{ asiRemaining }} point{{ asiRemaining === 1 ? '' : 's' }} left</span>
+        </div>
+        <div class="asi-row" *ngFor="let ability of abilities" [class.is-raised]="asiAllocation[ability] > 0">
+          <span class="asi-ability">{{ ability }}</span>
+          <span class="asi-score">
+            {{ currentScore(ability) }}
+            <ng-container *ngIf="asiAllocation[ability] > 0">→ {{ newScore(ability) }}</ng-container>
+          </span>
+          <span class="asi-steppers">
+            <button type="button" class="asi-step" (click)="decAsi(ability)" [disabled]="!canDec(ability)">−</button>
+            <span class="asi-alloc">+{{ asiAllocation[ability] }}</span>
+            <button type="button" class="asi-step" (click)="incAsi(ability)" [disabled]="!canInc(ability)">+</button>
+          </span>
+        </div>
+        <div class="asi-note" *ngIf="asiRaisesCon">Raising Constitution will increase your hit points further.</div>
+      </ng-container>
+
+      <ng-container *ngIf="milestoneMode === 'feat'">
+        <label class="subclass-option" *ngFor="let option of featOptions"
+               [class.is-selected]="selectedFeat === option">
+          <input type="radio" name="feat" [value]="option" [(ngModel)]="selectedFeat">
+          <span class="feat-text">
+            <span class="feat-name">{{ option }}</span>
+            <span class="feat-desc">{{ featDescription(option) }}</span>
+          </span>
+        </label>
+      </ng-container>
     </div>
 
     <!-- Subclass selection (shown only when a choice is due and options exist) -->

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -211,3 +211,43 @@
   font-size: 0.74rem;
   color: var(--text-dim, rgba(255, 255, 255, 0.6));
 }
+
+// ── ASI / Feat toggle ─────────────────────────────────────────────────────────
+
+.milestone-toggle {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.milestone-tab {
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.12));
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+
+  &.is-active {
+    border-color: var(--celestial);
+    color: var(--celestial);
+  }
+}
+
+.feat-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.feat-name {
+  font-weight: 600;
+}
+
+.feat-desc {
+  font-size: 0.74rem;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { of, throwError } from 'rxjs';
 
 import { LevelUpModalComponent } from './level-up-modal.component';
 import { PCService } from '../../services/pc.service';
+import { DndResourcesService } from '../../services/dnd-resources.service';
 import { PC } from '../../models/pc';
 import { LevelUpPreview } from '../../models/level-up';
 
@@ -20,7 +21,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     hpGained: 8, newHpMax: 92, currentProfBonus: 2, newProfBonus: 3,
     currentSpellSlots: {}, newSpellSlots: {},
     subclassDue: false, subclassOptions: [],
-    asiDue: false,
+    asiDue: false, featOptions: [],
     ...overrides,
   };
 }
@@ -28,10 +29,13 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
 describe('LevelUpModalComponent', () => {
   let component: LevelUpModalComponent;
   let pcService: jasmine.SpyObj<PCService>;
+  let dndResources: jasmine.SpyObj<DndResourcesService>;
 
   beforeEach(() => {
     pcService = makePcServiceSpy();
-    component = new LevelUpModalComponent(pcService);
+    dndResources = jasmine.createSpyObj<DndResourcesService>('DndResourcesService', ['getFeatDescription']);
+    dndResources.getFeatDescription.and.returnValue('A mighty feat.');
+    component = new LevelUpModalComponent(pcService, dndResources);
     component.pc = makePC();
   });
 
@@ -196,6 +200,44 @@ describe('LevelUpModalComponent', () => {
     component.confirm();
 
     expect(pcService.levelUp).toHaveBeenCalledWith(7, { abilityIncreases: { STR: 1, DEX: 1 } });
+  });
+
+  // --- Feat as the ASI alternative ---
+
+  it('can switch to feat mode and confirm requires a feat selection', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      asiDue: true, featOptions: ['Sentinel', 'Sharpshooter'],
+    })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 16, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+
+    component.milestoneMode = 'feat';
+    expect(component.canConfirm).toBeFalse();   // no feat picked
+    component.selectedFeat = 'Sentinel';
+    expect(component.canConfirm).toBeTrue();
+  });
+
+  it('sends the chosen feat (and no ASI) when in feat mode', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      asiDue: true, featOptions: ['Sentinel', 'Sharpshooter'],
+    })));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 4 })));
+    component.pc = { id: 7, name: 'Throk', clazz: 'Fighter', level: 3, playerName: 'Ben',
+                     stats: { STR: 16, DEX: 13, CON: 14, INT: 10, WIS: 11, CHA: 8 } };
+    component.ngOnInit();
+
+    component.milestoneMode = 'feat';
+    component.selectedFeat = 'Sharpshooter';
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, { feat: 'Sharpshooter' });
+  });
+
+  it('exposes featOptions from the preview', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true, featOptions: ['Sentinel'] })));
+    component.ngOnInit();
+    expect(component.featOptions).toEqual(['Sentinel']);
   });
 
   it('keeps the modal open and shows an error if the commit fails', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@a
 import { PC } from '../../models/pc';
 import { LevelUpPreview, LevelUpChoices } from '../../models/level-up';
 import { PCService } from '../../services/pc.service';
+import { DndResourcesService } from '../../services/dnd-resources.service';
 import { fmtMod } from '../../utils/character-math';
 
 /**
@@ -33,7 +34,11 @@ export class LevelUpModalComponent implements OnInit {
   /** Points allocated this ASI per ability (0/1/2); total must reach 2 to confirm. */
   asiAllocation: { [ability: string]: number } = { STR: 0, DEX: 0, CON: 0, INT: 0, WIS: 0, CHA: 0 };
 
-  constructor(private pcService: PCService) {}
+  /** At an ASI level, whether the player is taking an ASI or a feat. */
+  milestoneMode: 'asi' | 'feat' = 'asi';
+  selectedFeat: string | null = null;
+
+  constructor(private pcService: PCService, private dndResources: DndResourcesService) {}
 
   ngOnInit(): void {
     this.pcService.levelUpPreview(this.pc.id).subscribe({
@@ -131,9 +136,25 @@ export class LevelUpModalComponent implements OnInit {
     if (this.canDec(ability)) this.asiAllocation[ability]--;
   }
 
-  /** Confirm is blocked until any required subclass and ASI choices are made. */
+  // ── Feat option (the ASI alternative) ───────────────────────────────────────
+
+  get featOptions(): string[] {
+    return this.preview?.featOptions ?? [];
+  }
+
+  featDescription(name: string): string {
+    return this.dndResources.getFeatDescription(name);
+  }
+
+  /** Whether the milestone choice (ASI or feat) is satisfied. */
+  get milestoneSatisfied(): boolean {
+    if (!this.needsAsi) return true;
+    return this.milestoneMode === 'asi' ? this.asiValid : !!this.selectedFeat;
+  }
+
+  /** Confirm is blocked until any required subclass and milestone (ASI/feat) choices are made. */
   get canConfirm(): boolean {
-    return (!this.needsSubclass || !!this.selectedSubclass) && (!this.needsAsi || this.asiValid);
+    return (!this.needsSubclass || !!this.selectedSubclass) && this.milestoneSatisfied;
   }
 
   confirm(): void {
@@ -143,8 +164,14 @@ export class LevelUpModalComponent implements OnInit {
 
     const choices: LevelUpChoices = {};
     if (this.selectedSubclass) choices.subclass = this.selectedSubclass;
-    const increases = this.allocatedAbilities();
-    if (Object.keys(increases).length) choices.abilityIncreases = increases;
+    if (this.needsAsi) {
+      if (this.milestoneMode === 'asi') {
+        const increases = this.allocatedAbilities();
+        if (Object.keys(increases).length) choices.abilityIncreases = increases;
+      } else if (this.selectedFeat) {
+        choices.feat = this.selectedFeat;
+      }
+    }
 
     this.pcService.levelUp(this.pc.id, choices).subscribe({
       next: () => this.close.emit(),

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -26,10 +26,15 @@ export interface LevelUpPreview {
   // Phase 4: whether an Ability Score Improvement is due at the new level (4/8/12/16/19,
   // plus Fighter 6/14 and Rogue 10). The SPA builds the +2/+1+1 allocator from pc.stats.
   asiDue: boolean;
+  // Feats: selectable General feat names (the ASI alternative). Server-authoritative;
+  // non-empty only at an ASI level. Descriptions are looked up locally for display.
+  featOptions: string[];
 }
 
-/** Player choices sent when committing a level-up (all optional). */
+/** Player choices sent when committing a level-up (all optional). At an ASI level, exactly
+ *  one of abilityIncreases / feat is sent. */
 export interface LevelUpChoices {
   subclass?: string;
   abilityIncreases?: { [ability: string]: number };
+  feat?: string;
 }

--- a/src/app/charactermanager/services/dnd-resources.service.ts
+++ b/src/app/charactermanager/services/dnd-resources.service.ts
@@ -168,6 +168,28 @@ export const FEAT_DESCRIPTIONS: Record<string, string> = {
     'You are proficient with improvised weapons. Your unarmed strikes deal 1d4 + Strength or Dexterity. Once per turn you can attempt to grapple or shove a creature you hit unarmed.',
   'Tough':
     'Your Hit Point maximum increases by 2, and it increases by 2 again each time you gain a level.',
+  // ── General feats (level 4+; the alternative to an ASI). Names are validated
+  //    server-side; these descriptions are for display only. ───────────────────
+  'Great Weapon Master':
+    'On a melee weapon attack, you can take a -5 penalty to hit for +10 damage. Scoring a critical hit or downing a creature lets you make another melee attack as a Bonus Action.',
+  'Sharpshooter':
+    'Your ranged attacks ignore half and three-quarters cover, and you can take a -5 to hit for +10 damage. Long range does not impose disadvantage.',
+  'Sentinel':
+    'When you hit a creature with an Opportunity Attack, its speed becomes 0 for the turn. Creatures provoke Opportunity Attacks even when they Disengage, and you can react when an ally nearby is attacked.',
+  'War Caster':
+    'You have advantage on Concentration saves, can perform somatic components while wielding weapons or a shield, and can cast a spell as an Opportunity Attack.',
+  'Resilient':
+    'Increase one ability score by 1 (max 20) and gain proficiency in saving throws using that ability.',
+  'Speedy':
+    'Your Speed increases by 10 feet, Difficult Terrain no longer slows your Dash, and Opportunity Attacks have disadvantage against you.',
+  'Mage Slayer':
+    'When a creature within 5 feet casts a spell you can react to attack it. You impose disadvantage on Concentration saves of creatures you damage, and gain advantage on saves against their spells.',
+  'Polearm Master':
+    'When you attack with a glaive, halberd, quarterstaff, or spear you can make a Bonus Action strike with the butt end (1d4). Creatures entering your reach provoke an Opportunity Attack.',
+  'Inspiring Leader':
+    'Spend 10 minutes to bolster allies, granting each a number of Temporary Hit Points equal to your level + your Charisma modifier.',
+  'Skill Expert':
+    'Increase one ability score by 1 (max 20), gain proficiency in one skill, and gain Expertise in one skill you are proficient with.',
 };
 
 /** Standard languages available for the background language bonus */

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -232,6 +232,14 @@ describe('PCService', () => {
       req.flush({ id: 42, name: 'Throk', clazz: 'Fighter', level: 4 });
     });
 
+    it('sends the chosen feat in the POST body when provided', () => {
+      service.levelUp(42, { feat: 'Sentinel' }).subscribe();
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up');
+      expect(req.request.body).toEqual({ feat: 'Sentinel' });
+      req.flush({ id: 42, name: 'Throk', clazz: 'Fighter', level: 4 });
+    });
+
     it('POSTs to the level-up endpoint and deserializes the updated PC', (done) => {
       service.levelUp(42).subscribe(updated => {
         expect(updated.level).toBe(5);

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -331,6 +331,7 @@ export class PCService {
     const body: LevelUpChoices = {};
     if (choices?.subclass) body.subclass = choices.subclass;
     if (choices?.abilityIncreases) body.abilityIncreases = choices.abilityIncreases;
+    if (choices?.feat) body.feat = choices.feat;
     return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, body).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
@@ -413,6 +414,12 @@ export class PCService {
     return levels.includes(level);
   }
 
+  // DEMO-ONLY mirror of the server general-feat catalog (FeatCatalog), sorted.
+  private static readonly DEMO_GENERAL_FEATS = [
+    'Great Weapon Master', 'Inspiring Leader', 'Mage Slayer', 'Polearm Master', 'Resilient',
+    'Sentinel', 'Sharpshooter', 'Skill Expert', 'Speedy', 'War Caster',
+  ];
+
   private computeDemoPreview(id: number): LevelUpPreview {
     const pc = this.pcs.find(p => p.id === id)!;
     const { current, newLevel, hitDie, conMod, hpGained } = this.demoLevelUpFields(pc);
@@ -430,6 +437,7 @@ export class PCService {
       subclassDue: newLevel === this.demoSubclassLevel(pc.clazz) && !pc.subclass,
       subclassOptions: [], // no catalog content (mechanism only)
       asiDue: this.demoIsAsiLevel(pc.clazz, newLevel),
+      featOptions: this.demoIsAsiLevel(pc.clazz, newLevel) ? [...PCService.DEMO_GENERAL_FEATS] : [],
     };
   }
 
@@ -465,6 +473,12 @@ export class PCService {
         spellSlots[lvl] = { max, used: Math.min(priorUsed, max) };
       }
     }
+    // A chosen feat is recorded among the character's features (matches the server).
+    let features = existing.features;
+    if (choices?.feat) {
+      features = [...(existing.features ?? []),
+        { name: choices.feat, source: `Feat (Level ${newLevel})`, desc: '' }];
+    }
     const updated: PC = {
       ...existing,
       level: newLevel,
@@ -475,6 +489,7 @@ export class PCService {
         : { max: hpDelta, cur: hpDelta, temp: 0 },
       spellSlots,
       subclass: choices?.subclass || existing.subclass,
+      features,
     };
     this.pcs = this.pcs.map(p => p.id === id ? updated : p);
     this.pcsSubject.next(this.pcs);


### PR DESCRIPTION
At an ASI level the modal now offers a toggle between an Ability Score Improvement and a General feat. Feat mode lists the server-provided featOptions with descriptions (looked up locally from FEAT_DESCRIPTIONS) and blocks confirm until one is chosen; the choice is sent as { feat } and recorded in the character's features.

- models/level-up.ts: LevelUpPreview gains featOptions; LevelUpChoices gains feat.
- dnd-resources: added concise descriptions for the 10 General feats (display only).
- level-up-modal: ASI/Feat tabs, feat radio list, milestoneSatisfied gating, injects DndResourcesService for descriptions.
- pc.service.levelUp posts feat; demo shim offers the feat list and appends the chosen feat to features.

Verified: build green; 230 unit tests pass (toggle, feat-required gating, feat payload, featOptions). Sheet shows feat entries by name (desc blank from server — minor, descriptions are shown at selection time).