### PR TITLE
feat: show auto-granted class features in level-up modal

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -104,6 +104,15 @@
       </label>
     </div>
 
+    <!-- Class features automatically gained this level (read-only) -->
+    <div *ngIf="featuresGained.length" class="features-gained">
+      <div class="features-label">New Features</div>
+      <div class="feature-item" *ngFor="let f of featuresGained">
+        <span class="feature-name">{{ f.name }}</span>
+        <span class="feature-desc">{{ f.desc }}</span>
+      </div>
+    </div>
+
     <!-- A commit-time failure (e.g. raced to max level) -->
     <div *ngIf="error && preview" class="modal-sub" style="color: var(--crimson);">
       {{ error }}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -251,3 +251,40 @@
   font-size: 0.74rem;
   color: var(--text-dim, rgba(255, 255, 255, 0.6));
 }
+
+// ── Auto-granted class features ───────────────────────────────────────────────
+
+.features-gained {
+  margin: 16px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.features-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.feature-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-left: 2px solid var(--celestial);
+  border-radius: 6px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+}
+
+.feature-name {
+  font-weight: 600;
+  color: var(--text, #fff);
+}
+
+.feature-desc {
+  font-size: 0.76rem;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -22,6 +22,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     currentSpellSlots: {}, newSpellSlots: {},
     subclassDue: false, subclassOptions: [],
     asiDue: false, featOptions: [],
+    featuresGained: [],
     ...overrides,
   };
 }
@@ -238,6 +239,21 @@ describe('LevelUpModalComponent', () => {
     pcService.levelUpPreview.and.returnValue(of(makePreview({ asiDue: true, featOptions: ['Sentinel'] })));
     component.ngOnInit();
     expect(component.featOptions).toEqual(['Sentinel']);
+  });
+
+  // --- auto-granted class features ---
+
+  it('exposes auto-granted class features from the preview', () => {
+    const feats = [{ name: 'Reckless Attack', desc: 'Attack with advantage.' }];
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ featuresGained: feats })));
+    component.ngOnInit();
+    expect(component.featuresGained).toEqual(feats);
+  });
+
+  it('has no class features when none are granted', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ featuresGained: [] })));
+    component.ngOnInit();
+    expect(component.featuresGained.length).toBe(0);
   });
 
   it('keeps the modal open and shows an error if the commit fails', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -142,6 +142,11 @@ export class LevelUpModalComponent implements OnInit {
     return this.preview?.featOptions ?? [];
   }
 
+  /** Class features automatically granted at this level (read-only). */
+  get featuresGained(): { name: string; desc: string }[] {
+    return this.preview?.featuresGained ?? [];
+  }
+
   featDescription(name: string): string {
     return this.dndResources.getFeatDescription(name);
   }

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -29,6 +29,9 @@ export interface LevelUpPreview {
   // Feats: selectable General feat names (the ASI alternative). Server-authoritative;
   // non-empty only at an ASI level. Descriptions are looked up locally for display.
   featOptions: string[];
+  // Class features automatically gained at the new level (name + server-owned description).
+  // Empty when the class/level has no seeded features. Read-only — no choice involved.
+  featuresGained: { name: string; desc: string }[];
 }
 
 /** Player choices sent when committing a level-up (all optional). At an ASI level, exactly

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -438,6 +438,8 @@ export class PCService {
       subclassOptions: [], // no catalog content (mechanism only)
       asiDue: this.demoIsAsiLevel(pc.clazz, newLevel),
       featOptions: this.demoIsAsiLevel(pc.clazz, newLevel) ? [...PCService.DEMO_GENERAL_FEATS] : [],
+      // Class-feature content is server-owned; the demo shim doesn't mirror it.
+      featuresGained: [],
     };
   }
 


### PR DESCRIPTION
The modal now lists the class features gained at the new level (name + description) as a read-only "New Features" section, from the server-computed preview. No choice involved — they are granted automatically and recorded in the character's features on commit.

- models/level-up.ts: LevelUpPreview gains featuresGained ({name, desc}[]).
- level-up-modal: featuresGained getter + read-only section + styles.
- pc.service demo shim reports featuresGained: [] (class-feature content is server-owned and not mirrored in demo mode).

Verified: build green; 232 unit tests pass.