### PR TITLE
feat: show cantrips-known row in level-up modal

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -38,6 +38,15 @@
         </span>
       </li>
 
+      <li class="lvl-gain" *ngIf="showCantrips" [class.is-bump]="cantripsChanged">
+        <span class="lvl-gain-label">Cantrips Known</span>
+        <span class="lvl-gain-value">
+          {{ p.currentCantripsKnown }}
+          <ng-container *ngIf="cantripsChanged">→ {{ p.newCantripsKnown }}</ng-container>
+          <span class="lvl-gain-note" *ngIf="!cantripsChanged">(unchanged)</span>
+        </span>
+      </li>
+
       <li class="lvl-gain" *ngIf="slotRows.length" [class.is-bump]="hasSlotChanges">
         <span class="lvl-gain-label">Spell Slots</span>
         <span class="lvl-gain-value">

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -23,6 +23,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     subclassDue: false, subclassOptions: [],
     asiDue: false, featOptions: [],
     featuresGained: [],
+    currentCantripsKnown: 0, newCantripsKnown: 0,
     ...overrides,
   };
 }
@@ -254,6 +255,21 @@ describe('LevelUpModalComponent', () => {
     pcService.levelUpPreview.and.returnValue(of(makePreview({ featuresGained: [] })));
     component.ngOnInit();
     expect(component.featuresGained.length).toBe(0);
+  });
+
+  // --- cantrips known ---
+
+  it('shows a cantrips-known increase for casters', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentCantripsKnown: 3, newCantripsKnown: 4 })));
+    component.ngOnInit();
+    expect(component.showCantrips).toBeTrue();
+    expect(component.cantripsChanged).toBeTrue();
+  });
+
+  it('hides the cantrips row for non-casters', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentCantripsKnown: 0, newCantripsKnown: 0 })));
+    component.ngOnInit();
+    expect(component.showCantrips).toBeFalse();
   });
 
   it('keeps the modal open and shows an error if the commit fails', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -81,6 +81,16 @@ export class LevelUpModalComponent implements OnInit {
     return this.slotRows.some(r => r.gained);
   }
 
+  /** Whether to show the cantrips-known row (caster). */
+  get showCantrips(): boolean {
+    return (this.preview?.newCantripsKnown ?? 0) > 0;
+  }
+
+  /** Whether cantrips known increases this level. */
+  get cantripsChanged(): boolean {
+    return !!this.preview && this.preview.newCantripsKnown > this.preview.currentCantripsKnown;
+  }
+
   /** Whether to show the subclass picker: a choice is due AND the server offered options. */
   get needsSubclass(): boolean {
     return !!this.preview?.subclassDue && (this.preview?.subclassOptions?.length ?? 0) > 0;

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -32,6 +32,9 @@ export interface LevelUpPreview {
   // Class features automatically gained at the new level (name + server-owned description).
   // Empty when the class/level has no seeded features. Read-only — no choice involved.
   featuresGained: { name: string; desc: string }[];
+  // Cantrips known before/after the level (caster classes; 0 for non-casters). Informational.
+  currentCantripsKnown: number;
+  newCantripsKnown: number;
 }
 
 /** Player choices sent when committing a level-up (all optional). At an ASI level, exactly

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -440,7 +440,19 @@ export class PCService {
       featOptions: this.demoIsAsiLevel(pc.clazz, newLevel) ? [...PCService.DEMO_GENERAL_FEATS] : [],
       // Class-feature content is server-owned; the demo shim doesn't mirror it.
       featuresGained: [],
+      currentCantripsKnown: this.demoCantripsKnown(pc.clazz, current),
+      newCantripsKnown: this.demoCantripsKnown(pc.clazz, newLevel),
     };
+  }
+
+  // DEMO-ONLY mirror of the server cantrips-known formula (base +1 at L4 +1 at L10).
+  private demoCantripsKnown(clazz: string, level: number): number {
+    const base: { [k: string]: number } = {
+      bard: 2, cleric: 3, druid: 2, sorcerer: 4, warlock: 2, wizard: 3,
+    };
+    const b = base[(clazz ?? '').trim().toLowerCase()];
+    if (b === undefined || level < 1) return 0;
+    return b + (level >= 4 ? 1 : 0) + (level >= 10 ? 1 : 0);
   }
 
   private applyDemoLevelUp(id: number, choices?: LevelUpChoices): Observable<PC> {


### PR DESCRIPTION
The modal now displays a "Cantrips Known" row for casters (e.g. 3 → 4), highlighted when it increases, alongside the existing HP / proficiency / spell- slot gains. Driven by the server-computed preview; the demo shim mirrors the base +1@4 +1@10 formula.

- models/level-up.ts: LevelUpPreview gains currentCantripsKnown / newCantripsKnown.
- level-up-modal: showCantrips / cantripsChanged getters + gains row.
- pc.service demo shim: demoCantripsKnown mirror.

Verified: build green; 234 unit tests pass.