### PR TITLE
feat: add spell picker to level-up modal

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -113,6 +113,29 @@
       </label>
     </div>
 
+    <!-- Learn new cantrips/spells (casters who gain them this level) -->
+    <div *ngIf="showSpellPicker" class="spell-pick">
+      <div class="spell-label">
+        Learn Spells
+        <span class="spell-counts">
+          <ng-container *ngIf="cantripDelta">Cantrips {{ selectedCantripCount }}/{{ cantripDelta }}</ng-container>
+          <ng-container *ngIf="cantripDelta && spellDelta"> · </ng-container>
+          <ng-container *ngIf="spellDelta">Spells {{ selectedSpellCount }}/{{ spellDelta }}</ng-container>
+        </span>
+      </div>
+      <input class="spell-search" type="text" [(ngModel)]="spellSearch" placeholder="Search spells…">
+      <div *ngIf="loadingSpells" class="spell-loading">Consulting the grimoire…</div>
+      <div class="spell-list" *ngIf="!loadingSpells">
+        <label class="spell-option" *ngFor="let s of filteredSpells" [class.is-selected]="isSpellSelected(s)">
+          <input type="checkbox" [checked]="isSpellSelected(s)" (change)="toggleSpell(s)">
+          <span class="spell-row">
+            <span class="spell-name">{{ s.name }}</span>
+            <span class="spell-meta">{{ s.level === 0 ? 'Cantrip' : 'Level ' + s.level }} · {{ s.school }}</span>
+          </span>
+        </label>
+      </div>
+    </div>
+
     <!-- Class features automatically gained this level (read-only) -->
     <div *ngIf="featuresGained.length" class="features-gained">
       <div class="features-label">New Features</div>

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -288,3 +288,81 @@
   font-size: 0.76rem;
   color: var(--text-dim, rgba(255, 255, 255, 0.6));
 }
+
+// ── Spell picker ──────────────────────────────────────────────────────────────
+
+.spell-pick {
+  margin: 16px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.spell-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.spell-counts {
+  font-size: 0.72rem;
+  color: var(--celestial);
+}
+
+.spell-search {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.12));
+  border-radius: 7px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  color: var(--text, #fff);
+  font-size: 0.85rem;
+}
+
+.spell-loading {
+  font-size: 0.78rem;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}
+
+.spell-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.spell-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--surface-3, rgba(255, 255, 255, 0.08));
+  border-radius: 7px;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  cursor: pointer;
+
+  &.is-selected {
+    border-color: var(--celestial);
+  }
+}
+
+.spell-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.spell-name {
+  font-weight: 600;
+  color: var(--text, #fff);
+}
+
+.spell-meta {
+  font-size: 0.72rem;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -24,6 +24,7 @@ function makePreview(overrides: Partial<LevelUpPreview> = {}): LevelUpPreview {
     asiDue: false, featOptions: [],
     featuresGained: [],
     currentCantripsKnown: 0, newCantripsKnown: 0,
+    currentSpellsKnown: 0, newSpellsKnown: 0,
     ...overrides,
   };
 }
@@ -35,8 +36,10 @@ describe('LevelUpModalComponent', () => {
 
   beforeEach(() => {
     pcService = makePcServiceSpy();
-    dndResources = jasmine.createSpyObj<DndResourcesService>('DndResourcesService', ['getFeatDescription']);
+    dndResources = jasmine.createSpyObj<DndResourcesService>('DndResourcesService',
+      ['getFeatDescription', 'getSpellsForClass']);
     dndResources.getFeatDescription.and.returnValue('A mighty feat.');
+    dndResources.getSpellsForClass.and.returnValue(of([]));
     component = new LevelUpModalComponent(pcService, dndResources);
     component.pc = makePC();
   });
@@ -294,5 +297,69 @@ describe('LevelUpModalComponent', () => {
     component.confirm();
 
     expect(pcService.levelUp).not.toHaveBeenCalled();
+  });
+
+  // --- spell selection ---
+
+  function dndSpell(level: number, name: string): any {
+    return { level, name, school: 'Evocation', actionType: '1 action', classes: ['bard'] };
+  }
+
+  it('shows the picker and loads spells when the level grants new spells', () => {
+    dndResources.getSpellsForClass.and.returnValue(of(
+      [dndSpell(0, 'Light'), dndSpell(1, 'Heroism'), dndSpell(2, 'Invisibility')] as any));
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      currentCantripsKnown: 2, newCantripsKnown: 2,   // cantrip delta 0
+      currentSpellsKnown: 7, newSpellsKnown: 9,        // spell delta 2
+    })));
+    component.pc = makePC({ clazz: 'Bard', spells: [] });
+    component.ngOnInit();
+
+    expect(component.showSpellPicker).toBeTrue();
+    expect(component.cantripDelta).toBe(0);
+    expect(component.spellDelta).toBe(2);
+    expect(dndResources.getSpellsForClass).toHaveBeenCalledWith('Bard');
+    // cantrips hidden (delta 0), leveled spells shown
+    expect(component.filteredSpells.map(s => s.name)).toEqual(['Heroism', 'Invisibility']);
+  });
+
+  it('caps spell selection at the allowed delta', () => {
+    const spells = [dndSpell(1, 'A'), dndSpell(1, 'B'), dndSpell(1, 'C')];
+    dndResources.getSpellsForClass.and.returnValue(of(spells as any));
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentSpellsKnown: 7, newSpellsKnown: 9 })));
+    component.pc = makePC({ clazz: 'Bard', spells: [] });
+    component.ngOnInit();
+
+    component.toggleSpell(spells[0]);
+    component.toggleSpell(spells[1]);
+    component.toggleSpell(spells[2]); // exceeds delta of 2 -> ignored
+    expect(component.selectedSpellCount).toBe(2);
+  });
+
+  it('excludes already-known spells from the list', () => {
+    const spells = [dndSpell(1, 'Hold Person'), dndSpell(1, 'Heroism')];
+    dndResources.getSpellsForClass.and.returnValue(of(spells as any));
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentSpellsKnown: 7, newSpellsKnown: 9 })));
+    component.pc = makePC({ clazz: 'Bard',
+      spells: [{ lvl: 1, name: 'Heroism', school: 'Ench', time: '1 action', prepared: true }] });
+    component.ngOnInit();
+
+    expect(component.spellList.map(s => s.name)).toEqual(['Hold Person']);
+  });
+
+  it('sends selected spells as newSpells mapped to PcSpell', () => {
+    const spells = [dndSpell(1, 'Hold Person')];
+    dndResources.getSpellsForClass.and.returnValue(of(spells as any));
+    pcService.levelUpPreview.and.returnValue(of(makePreview({ currentSpellsKnown: 7, newSpellsKnown: 9 })));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    component.pc = makePC({ clazz: 'Bard', spells: [] });
+    component.ngOnInit();
+
+    component.toggleSpell(spells[0]);
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, {
+      newSpells: [jasmine.objectContaining({ lvl: 1, name: 'Hold Person', prepared: true })],
+    });
   });
 });

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
-import { PC } from '../../models/pc';
+import { PC, PcSpell } from '../../models/pc';
 import { LevelUpPreview, LevelUpChoices } from '../../models/level-up';
+import { DndSpell } from '../../models/dnd-api.types';
 import { PCService } from '../../services/pc.service';
 import { DndResourcesService } from '../../services/dnd-resources.service';
 import { fmtMod } from '../../utils/character-math';
@@ -38,6 +39,12 @@ export class LevelUpModalComponent implements OnInit {
   milestoneMode: 'asi' | 'feat' = 'asi';
   selectedFeat: string | null = null;
 
+  /** Spell selection (casters who gain cantrips/spells this level). */
+  spellList: DndSpell[] = [];
+  selectedSpells: DndSpell[] = [];
+  loadingSpells = false;
+  spellSearch = '';
+
   constructor(private pcService: PCService, private dndResources: DndResourcesService) {}
 
   ngOnInit(): void {
@@ -45,12 +52,73 @@ export class LevelUpModalComponent implements OnInit {
       next: preview => {
         this.preview = preview;
         this.loading = false;
+        if (this.cantripDelta > 0 || this.spellDelta > 0) this.loadSpells();
       },
       error: err => {
         this.error = this.messageFrom(err, 'Could not work out this level-up.');
         this.loading = false;
       },
     });
+  }
+
+  // ── Spell selection (learning new cantrips/spells) ──────────────────────────
+
+  private loadSpells(): void {
+    this.loadingSpells = true;
+    const known = new Set((this.pc.spells ?? []).map(s => s.name.toLowerCase()));
+    this.dndResources.getSpellsForClass(this.pc.clazz).subscribe({
+      next: spells => {
+        this.spellList = spells.filter(s => !known.has(s.name.toLowerCase()));
+        this.loadingSpells = false;
+      },
+      error: () => { this.loadingSpells = false; },
+    });
+  }
+
+  /** How many new cantrips / leveled spells the player may learn this level. */
+  get cantripDelta(): number {
+    return this.preview ? Math.max(0, this.preview.newCantripsKnown - this.preview.currentCantripsKnown) : 0;
+  }
+
+  get spellDelta(): number {
+    return this.preview ? Math.max(0, this.preview.newSpellsKnown - this.preview.currentSpellsKnown) : 0;
+  }
+
+  /** Show the spell picker when this level grants any new cantrips or spells. */
+  get showSpellPicker(): boolean {
+    return this.cantripDelta > 0 || this.spellDelta > 0;
+  }
+
+  get selectedCantripCount(): number {
+    return this.selectedSpells.filter(s => s.level === 0).length;
+  }
+
+  get selectedSpellCount(): number {
+    return this.selectedSpells.filter(s => s.level > 0).length;
+  }
+
+  /** Available spells, filtered by search and limited to the kinds this level allows. */
+  get filteredSpells(): DndSpell[] {
+    const q = this.spellSearch.trim().toLowerCase();
+    return this.spellList.filter(s => {
+      if (s.level === 0 && this.cantripDelta === 0) return false;
+      if (s.level > 0 && this.spellDelta === 0) return false;
+      return !q || s.name.toLowerCase().includes(q);
+    });
+  }
+
+  isSpellSelected(spell: DndSpell): boolean {
+    return this.selectedSpells.some(s => s.name === spell.name);
+  }
+
+  toggleSpell(spell: DndSpell): void {
+    if (this.isSpellSelected(spell)) {
+      this.selectedSpells = this.selectedSpells.filter(s => s.name !== spell.name);
+      return;
+    }
+    if (spell.level === 0 && this.selectedCantripCount >= this.cantripDelta) return;
+    if (spell.level > 0 && this.selectedSpellCount >= this.spellDelta) return;
+    this.selectedSpells = [...this.selectedSpells, spell];
   }
 
   fmtMod(value: number): string {
@@ -186,6 +254,23 @@ export class LevelUpModalComponent implements OnInit {
       } else if (this.selectedFeat) {
         choices.feat = this.selectedFeat;
       }
+    }
+    if (this.selectedSpells.length) {
+      choices.newSpells = this.selectedSpells.map((s): PcSpell => ({
+        lvl: s.level,
+        name: s.name,
+        school: s.school,
+        time: s.actionType,
+        prepared: true,
+        concentration: s.concentration,
+        ritual: s.ritual,
+        range: s.range,
+        components: s.components,
+        duration: s.duration,
+        description: s.description,
+        material: s.material,
+        higherLevelSlot: s.higherLevelSlot,
+      }));
     }
 
     this.pcService.levelUp(this.pc.id, choices).subscribe({

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -1,3 +1,5 @@
+import { PcSpell } from './pc';
+
 /**
  * What advancing one level grants, computed server-side and rendered by the SPA.
  *
@@ -35,6 +37,10 @@ export interface LevelUpPreview {
   // Cantrips known before/after the level (caster classes; 0 for non-casters). Informational.
   currentCantripsKnown: number;
   newCantripsKnown: number;
+  // Prepared/known spells before/after the level (caster classes; 0 for non-casters). The
+  // level-up delta is how many new spells the player may add.
+  currentSpellsKnown: number;
+  newSpellsKnown: number;
 }
 
 /** Player choices sent when committing a level-up (all optional). At an ASI level, exactly
@@ -43,4 +49,5 @@ export interface LevelUpChoices {
   subclass?: string;
   abilityIncreases?: { [ability: string]: number };
   feat?: string;
+  newSpells?: PcSpell[];
 }

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -240,6 +240,15 @@ describe('PCService', () => {
       req.flush({ id: 42, name: 'Throk', clazz: 'Fighter', level: 4 });
     });
 
+    it('sends newly-learned spells in the POST body when provided', () => {
+      const newSpells = [{ lvl: 1, name: 'Hold Person', school: 'Ench', time: '1 action', prepared: true }];
+      service.levelUp(42, { newSpells }).subscribe();
+
+      const req = httpMock.expectOne(service.pcUrl + '42/level-up');
+      expect(req.request.body).toEqual({ newSpells });
+      req.flush({ id: 42, name: 'Aelindra', clazz: 'Bard', level: 5 });
+    });
+
     it('POSTs to the level-up endpoint and deserializes the updated PC', (done) => {
       service.levelUp(42).subscribe(updated => {
         expect(updated.level).toBe(5);

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -332,6 +332,7 @@ export class PCService {
     if (choices?.subclass) body.subclass = choices.subclass;
     if (choices?.abilityIncreases) body.abilityIncreases = choices.abilityIncreases;
     if (choices?.feat) body.feat = choices.feat;
+    if (choices?.newSpells?.length) body.newSpells = choices.newSpells;
     return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, body).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
@@ -442,6 +443,8 @@ export class PCService {
       featuresGained: [],
       currentCantripsKnown: this.demoCantripsKnown(pc.clazz, current),
       newCantripsKnown: this.demoCantripsKnown(pc.clazz, newLevel),
+      currentSpellsKnown: this.demoPreparedSpells(pc.clazz, current),
+      newSpellsKnown: this.demoPreparedSpells(pc.clazz, newLevel),
     };
   }
 
@@ -453,6 +456,21 @@ export class PCService {
     const b = base[(clazz ?? '').trim().toLowerCase()];
     if (b === undefined || level < 1) return 0;
     return b + (level >= 4 ? 1 : 0) + (level >= 10 ? 1 : 0);
+  }
+
+  // DEMO-ONLY mirror of the server prepared/known-spell tables (full-caster vs warlock pact).
+  private static readonly DEMO_FULL_PREPARED =
+    [4, 5, 6, 7, 9, 10, 11, 12, 14, 15, 16, 16, 17, 17, 18, 18, 19, 20, 21, 22];
+  private static readonly DEMO_PACT_PREPARED =
+    [2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15];
+
+  private demoPreparedSpells(clazz: string, level: number): number {
+    const key = (clazz ?? '').trim().toLowerCase();
+    if (level < 1) return 0;
+    const idx = Math.min(level, 20) - 1;
+    if (['bard', 'cleric', 'druid', 'sorcerer', 'wizard'].includes(key)) return PCService.DEMO_FULL_PREPARED[idx];
+    if (key === 'warlock') return PCService.DEMO_PACT_PREPARED[idx];
+    return 0;
   }
 
   private applyDemoLevelUp(id: number, choices?: LevelUpChoices): Observable<PC> {
@@ -493,6 +511,10 @@ export class PCService {
       features = [...(existing.features ?? []),
         { name: choices.feat, source: `Feat (Level ${newLevel})`, desc: '' }];
     }
+    // Newly-learned spells are appended to the character's spell list.
+    const spells = choices?.newSpells?.length
+      ? [...(existing.spells ?? []), ...choices.newSpells]
+      : existing.spells;
     const updated: PC = {
       ...existing,
       level: newLevel,
@@ -504,6 +526,7 @@ export class PCService {
       spellSlots,
       subclass: choices?.subclass || existing.subclass,
       features,
+      spells,
     };
     this.pcs = this.pcs.map(p => p.id === id ? updated : p);
     this.pcsSubject.next(this.pcs);


### PR DESCRIPTION
When a caster gains cantrips/spells at a level, the modal shows a "Learn Spells" section: a searchable list of class spells (from DndResourcesService, excluding ones already known), with selection capped at the per-kind delta the server reports (cantrips vs leveled spells). Selection is optional. Chosen spells are mapped to PcSpell and sent as newSpells; the server validates the count.

- models/level-up.ts: LevelUpPreview gains current/new spells-known; LevelUpChoices gains newSpells (PcSpell[]).
- level-up-modal: spell-pick state, loader, delta/cap getters, picker markup + styles.
- pc.service: posts newSpells; demo shim mirrors the prepared-spell tables and appends chosen spells to the PC.

Verified: build green; 239 unit tests pass (picker load, cap at delta, exclude-known, payload).