### PR TITLE
fix: show feat descriptions on the character sheet

### DIFF
--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.html
@@ -7,7 +7,7 @@
       <span class="feature-name">{{ f.name }}</span>
       <span class="feature-source">{{ f.source }}</span>
     </div>
-    <div class="feature-desc">{{ f.desc }}</div>
+    <div class="feature-desc">{{ descFor(f) }}</div>
   </div>
   <div *ngIf="!pc.features || pc.features.length === 0"
        style="color: var(--text-dim); font-style: italic; font-size: 13px; padding: 8px 0;">

--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.spec.ts
@@ -1,0 +1,33 @@
+import { FeaturesListComponent } from './features-list.component';
+import { DndResourcesService } from '../../../../services/dnd-resources.service';
+import { PC } from '../../../../models/pc';
+
+describe('FeaturesListComponent', () => {
+  let component: FeaturesListComponent;
+  let dndResources: jasmine.SpyObj<DndResourcesService>;
+
+  beforeEach(() => {
+    dndResources = jasmine.createSpyObj<DndResourcesService>('DndResourcesService', ['getFeatDescription']);
+    dndResources.getFeatDescription.and.returnValue('Looked-up feat text.');
+    component = new FeaturesListComponent(dndResources);
+    component.pc = { id: 1, name: 'X', clazz: 'Fighter', level: 4, playerName: 'P' } as PC;
+  });
+
+  it('uses a class feature\'s own description', () => {
+    const desc = component.descFor({ name: 'Action Surge', source: 'Fighter 2', desc: 'Extra action.' });
+    expect(desc).toBe('Extra action.');
+    expect(dndResources.getFeatDescription).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the feat lookup for a feat with no description', () => {
+    const desc = component.descFor({ name: 'Sentinel', source: 'Feat (Level 4)', desc: '' });
+    expect(desc).toBe('Looked-up feat text.');
+    expect(dndResources.getFeatDescription).toHaveBeenCalledWith('Sentinel');
+  });
+
+  it('returns empty for a non-feat with no description', () => {
+    const desc = component.descFor({ name: 'Mystery', source: 'Background', desc: '' });
+    expect(desc).toBe('');
+    expect(dndResources.getFeatDescription).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.ts
@@ -1,5 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { PC } from '../../../../models/pc';
+import { DndResourcesService } from '../../../../services/dnd-resources.service';
+
+type Feature = { name: string; source: string; desc: string };
 
 @Component({
   selector: 'app-features-list',
@@ -8,4 +11,19 @@ import { PC } from '../../../../models/pc';
 })
 export class FeaturesListComponent {
   @Input() pc!: PC;
+
+  constructor(private dndResources: DndResourcesService) {}
+
+  /**
+   * Description to show for a feature. Feats taken on level-up are stored with a blank desc
+   * (the backend doesn't own feat descriptions — they live in the frontend), so for those we
+   * fall back to the local feat-description lookup. Class features carry their own desc.
+   */
+  descFor(feature: Feature): string {
+    if (feature.desc) return feature.desc;
+    if (feature.source?.toLowerCase().startsWith('feat')) {
+      return this.dndResources.getFeatDescription(feature.name);
+    }
+    return '';
+  }
 }


### PR DESCRIPTION
Feats taken on level-up are stored in the PC's features with a blank desc (the backend doesn't own feat descriptions — they live in the frontend). The sheet's Class Features panel showed those entries with no description. It now falls back to DndResourcesService.getFeatDescription(name) for feat-sourced entries (source starting with "Feat") that have no desc; class features keep their own desc.

Verified: build green; 242 unit tests pass (+3 features-list specs).