### PR TITLE
feat: add display descriptions for the new General feats

### DIFF
--- a/src/app/charactermanager/services/dnd-resources.service.ts
+++ b/src/app/charactermanager/services/dnd-resources.service.ts
@@ -190,6 +190,70 @@ export const FEAT_DESCRIPTIONS: Record<string, string> = {
     'Spend 10 minutes to bolster allies, granting each a number of Temporary Hit Points equal to your level + your Charisma modifier.',
   'Skill Expert':
     'Increase one ability score by 1 (max 20), gain proficiency in one skill, and gain Expertise in one skill you are proficient with.',
+  'Actor':
+    'Increase Charisma by 1 (max 20). You have advantage on Deception and Performance checks to pass as someone else, and can mimic speech or sounds you have heard.',
+  'Athlete':
+    'Increase Strength or Dexterity by 1 (max 20). Climbing costs no extra movement, you stand from prone with only 5 feet, and you can run long/high jumps after moving only 5 feet.',
+  'Charger':
+    'After you take the Dash action, you can make one melee attack or shove as a Bonus Action, dealing extra damage or pushing the target.',
+  'Chef':
+    'Increase Constitution or Wisdom by 1 (max 20). During a rest you can cook food that grants Temporary Hit Points, and bake treats that restore Hit Points.',
+  'Crossbow Expert':
+    'You ignore the Loading property of crossbows, attacking in melee doesn\'t impose disadvantage on your ranged attacks, and you can fire a hand crossbow as a Bonus Action.',
+  'Crusher':
+    'Increase Strength or Constitution by 1 (max 20). Once per turn you can move a creature 5 feet on a bludgeoning hit, and a critical bludgeoning hit gives attackers advantage against it.',
+  'Defensive Duelist':
+    'Increase Dexterity by 1 (max 20). When hit by a melee attack while wielding a finesse weapon, you can use your reaction to add your proficiency bonus to your AC against that attack.',
+  'Dual Wielder':
+    'Increase Strength or Dexterity by 1 (max 20). You gain +1 AC while wielding two weapons, can draw or stow two at once, and can make your bonus-action attack with non-light weapons.',
+  'Durable':
+    'Increase Constitution by 1 (max 20). You regain extra Hit Points from spending Hit Dice, and have advantage on Death Saving Throws.',
+  'Elemental Adept':
+    'Spells you cast ignore resistance to a chosen damage type (acid, cold, fire, lightning, or thunder), and you treat 1s on those damage dice as 2s.',
+  'Fey Touched':
+    'Increase Intelligence, Wisdom, or Charisma by 1 (max 20). You learn Misty Step and one 1st-level Divination or Enchantment spell, casting each once per Long Rest for free.',
+  'Grappler':
+    'Increase Strength or Dexterity by 1 (max 20). You have advantage on attacks against creatures you are grappling and can move them more easily.',
+  'Heavily Armored':
+    'Increase Strength by 1 (max 20) and gain proficiency with Heavy armor.',
+  'Heavy Armor Master':
+    'Increase Strength by 1 (max 20). While wearing Heavy armor, reduce nonmagical bludgeoning, piercing, and slashing damage you take.',
+  'Keen Mind':
+    'Increase Intelligence by 1 (max 20). You always know which way is north and the hours until sunrise or sunset, and can take the Study action as a Bonus Action.',
+  'Lightly Armored':
+    'Increase Strength or Dexterity by 1 (max 20) and gain proficiency with Light armor.',
+  'Martial Weapon Training':
+    'Increase Strength or Dexterity by 1 (max 20) and gain proficiency with Martial weapons.',
+  'Medium Armor Master':
+    'Increase Strength or Dexterity by 1 (max 20). Medium armor doesn\'t impose disadvantage on Stealth and lets you add up to +3 Dexterity to your AC.',
+  'Moderately Armored':
+    'Increase Strength or Dexterity by 1 (max 20) and gain proficiency with Medium armor and Shields.',
+  'Mounted Combatant':
+    'Increase Strength, Dexterity, or Wisdom by 1 (max 20). You have advantage against unmounted creatures smaller than your mount and can redirect attacks aimed at your mount to yourself.',
+  'Observant':
+    'Increase Intelligence or Wisdom by 1 (max 20). You can read lips and take the Search action as a Bonus Action.',
+  'Piercer':
+    'Increase Strength or Dexterity by 1 (max 20). Once per turn you can reroll one piercing damage die, and a critical piercing hit deals an extra damage die.',
+  'Poisoner':
+    'Your weapon and unarmed strike damage ignores resistance to poison, and you can coat a weapon to deal extra poison damage and poison the target.',
+  'Ritual Caster':
+    'Increase Intelligence or Wisdom by 1 (max 20). You learn ritual spells from a chosen class and can cast them as rituals from your ritual book.',
+  'Shadow Touched':
+    'Increase Intelligence, Wisdom, or Charisma by 1 (max 20). You learn Invisibility and one 1st-level Illusion or Necromancy spell, casting each once per Long Rest for free.',
+  'Shield Master':
+    'You can shove with your shield as a Bonus Action, add your shield\'s AC to Dexterity saves against effects targeting only you, and use a reaction to take no damage on a successful Dexterity save.',
+  'Skulker':
+    'Increase Dexterity by 1 (max 20). You can Hide when only lightly obscured, missing with a ranged attack doesn\'t reveal your position, and dim light doesn\'t impose disadvantage on your Perception checks.',
+  'Slasher':
+    'Increase Strength or Dexterity by 1 (max 20). Once per turn you can reduce a creature\'s speed by 10 feet on a slashing hit, and a critical slashing hit imposes disadvantage on its attacks.',
+  'Spell Sniper':
+    'The range of your attack-roll spells doubles, those spells ignore half and three-quarters cover, and you learn one attack cantrip.',
+  'Telekinetic':
+    'Increase Intelligence, Wisdom, or Charisma by 1 (max 20). You learn Mage Hand and can telekinetically shove a creature 5 feet as a Bonus Action.',
+  'Telepathic':
+    'Increase Intelligence, Wisdom, or Charisma by 1 (max 20). You can speak telepathically to creatures within 60 feet and always have Detect Thoughts prepared, casting it once per Long Rest for free.',
+  'Weapon Master':
+    'Increase Strength or Dexterity by 1 (max 20). You gain the Weapon Mastery property of two kinds of weapons you are proficient with.',
 };
 
 /** Standard languages available for the background language bonus */


### PR DESCRIPTION
Adds FEAT_DESCRIPTIONS entries for the 2024 General feats newly added to the backend FeatCatalog (Actor, Athlete, Charger, … Weapon Master). The modal's feat picker looks these up via getFeatDescription; names are server-authoritative, descriptions are presentation only.

Verified: build green; 242 unit tests pass.