### PR TITLE
feat: add average/roll HP toggle to level-up modal

### DIFF
--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.html
@@ -23,8 +23,24 @@
         <span class="lvl-gain-label">Hit Points</span>
         <span class="lvl-gain-value">
           +{{ p.hpGained }}
-          <span class="lvl-gain-note">
+          <span class="lvl-gain-note" *ngIf="hpMode === 'AVERAGE'">
             (d{{ p.hitDie }} avg {{ fmtMod(p.conModifier) }} CON) → max {{ p.newHpMax }}
+          </span>
+          <span class="lvl-gain-note" *ngIf="hpMode === 'ROLL'">
+            (roll d{{ p.hitDie }} {{ fmtMod(p.conModifier) }} CON, rolled on confirm — avg {{ p.hpGained }} shown)
+          </span>
+        </span>
+      </li>
+
+      <!-- HP mode: take the fixed average (default) or roll the hit die (server rolls on confirm) -->
+      <li class="lvl-gain">
+        <span class="lvl-gain-label">HP Method</span>
+        <span class="lvl-gain-value">
+          <span class="milestone-toggle hp-mode-toggle">
+            <button type="button" class="milestone-tab" [class.is-active]="hpMode === 'AVERAGE'"
+                    (click)="hpMode = 'AVERAGE'">Average</button>
+            <button type="button" class="milestone-tab" [class.is-active]="hpMode === 'ROLL'"
+                    (click)="hpMode = 'ROLL'">Roll</button>
           </span>
         </span>
       </li>

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.scss
@@ -237,6 +237,17 @@
   }
 }
 
+// Compact variant of the toggle when it sits inside an HP-gain value cell.
+.hp-mode-toggle {
+  display: inline-flex;
+  margin-bottom: 0;
+
+  .milestone-tab {
+    flex: 0 0 auto;
+    padding: 4px 12px;
+  }
+}
+
 .feat-text {
   display: flex;
   flex-direction: column;

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.spec.ts
@@ -113,6 +113,45 @@ describe('LevelUpModalComponent', () => {
     expect(closeSpy).toHaveBeenCalled();
   });
 
+  // --- HP mode toggle (average vs roll) ---
+
+  it('defaults to AVERAGE HP mode and omits it from the choices', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    component.ngOnInit();
+
+    expect(component.hpMode).toBe('AVERAGE');
+
+    component.confirm();
+    // AVERAGE is implied — nothing extra is sent (server defaults to it).
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, {});
+  });
+
+  it('sends hpMode ROLL when the player picks Roll', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview()));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    component.ngOnInit();
+
+    component.hpMode = 'ROLL';
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, { hpMode: 'ROLL' });
+  });
+
+  it('combines the ROLL mode with other choices', () => {
+    pcService.levelUpPreview.and.returnValue(of(makePreview({
+      subclassDue: true, subclassOptions: ['Life Domain', 'War Domain'],
+    })));
+    pcService.levelUp.and.returnValue(of(makePC({ level: 5 })));
+    component.ngOnInit();
+
+    component.selectedSubclass = 'War Domain';
+    component.hpMode = 'ROLL';
+    component.confirm();
+
+    expect(pcService.levelUp).toHaveBeenCalledWith(7, { hpMode: 'ROLL', subclass: 'War Domain' });
+  });
+
   // --- subclass picker (Phase 3) ---
 
   it('does not show the subclass picker when options are empty (mechanism dormant)', () => {

--- a/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
+++ b/src/app/charactermanager/components/level-up-modal/level-up-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, HostListener, Input, OnInit, Output } from '@angular/core';
 import { PC, PcSpell } from '../../models/pc';
-import { LevelUpPreview, LevelUpChoices } from '../../models/level-up';
+import { LevelUpPreview, LevelUpChoices, HpMode } from '../../models/level-up';
 import { DndSpell } from '../../models/dnd-api.types';
 import { PCService } from '../../services/pc.service';
 import { DndResourcesService } from '../../services/dnd-resources.service';
@@ -30,6 +30,13 @@ export class LevelUpModalComponent implements OnInit {
   submitting = false;
   error: string | null = null;
   selectedSubclass: string | null = null;
+
+  /**
+   * HP mode for this level: take the fixed average (default) or roll the hit die. In 'ROLL' the
+   * server does the rolling on confirm — the preview keeps showing the average, so the displayed
+   * "+HP" is an estimate until committed. Only sent to the server when 'ROLL' (AVERAGE is implied).
+   */
+  hpMode: HpMode = 'AVERAGE';
 
   readonly abilities = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
   /** Points allocated this ASI per ability (0/1/2); total must reach 2 to confirm. */
@@ -246,6 +253,8 @@ export class LevelUpModalComponent implements OnInit {
     this.error = null;
 
     const choices: LevelUpChoices = {};
+    // Only send the mode when rolling — omitting it lets the server default to AVERAGE.
+    if (this.hpMode === 'ROLL') choices.hpMode = 'ROLL';
     if (this.selectedSubclass) choices.subclass = this.selectedSubclass;
     if (this.needsAsi) {
       if (this.milestoneMode === 'asi') {

--- a/src/app/charactermanager/models/level-up.ts
+++ b/src/app/charactermanager/models/level-up.ts
@@ -43,11 +43,20 @@ export interface LevelUpPreview {
   newSpellsKnown: number;
 }
 
+/**
+ * How this level's hit points are determined. Mirrors the backend `HpMode` enum — the JSON value
+ * must be the enum name ('AVERAGE' | 'ROLL'). In ROLL mode the *server* rolls the hit die; the
+ * client only chooses the mode, never the result. 'AVERAGE' is the default everywhere.
+ */
+export type HpMode = 'AVERAGE' | 'ROLL';
+
 /** Player choices sent when committing a level-up (all optional). At an ASI level, exactly
- *  one of abilityIncreases / feat is sent. */
+ *  one of abilityIncreases / feat is sent. hpMode is only sent when the player picks 'ROLL'
+ *  (omitting it lets the server default to 'AVERAGE'). */
 export interface LevelUpChoices {
   subclass?: string;
   abilityIncreases?: { [ability: string]: number };
   feat?: string;
   newSpells?: PcSpell[];
+  hpMode?: HpMode;
 }

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -333,6 +333,8 @@ export class PCService {
     if (choices?.abilityIncreases) body.abilityIncreases = choices.abilityIncreases;
     if (choices?.feat) body.feat = choices.feat;
     if (choices?.newSpells?.length) body.newSpells = choices.newSpells;
+    // Only forward ROLL — the server treats an absent mode as AVERAGE (and does the rolling).
+    if (choices?.hpMode === 'ROLL') body.hpMode = 'ROLL';
     return this.http.post<PC>(`${this.pcUrl}${id}/level-up`, body).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
@@ -510,7 +512,12 @@ export class PCService {
       }
     }
     const newConMod = modFromScore(stats['CON']);
-    const hpGained = Math.max(1, Math.floor(hitDie / 2) + 1 + newConMod);
+    // DEMO-ONLY: in ROLL mode roll the die client-side so the mock HP varies. Production never
+    // rolls here — the server is the rules authority and performs the roll. Average otherwise.
+    const dieValue = choices?.hpMode === 'ROLL'
+      ? Math.floor(Math.random() * hitDie) + 1
+      : Math.floor(hitDie / 2) + 1;
+    const hpGained = Math.max(1, dieValue + newConMod);
     const hpDelta = hpGained + (newLevel - 1) * (newConMod - oldConMod);
 
     // Rebuild slots from the demo table, preserving `used` (clamped) like the server does.


### PR DESCRIPTION
Adds an Average/Roll toggle to the level-up modal. The mode is sent to the server only when ROLL is picked (an absent mode means AVERAGE), since the server is the rules authority and performs the roll. The preview keeps showing the average, so the displayed +HP is an estimate in roll mode.

The DEMO-ONLY pc.service shim rolls the die client-side so the mock varies; production never rolls here. Adds component specs for the toggle.