### PR TITLE
feat: make character creator mobile-friendly

### DIFF
--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.html
@@ -26,6 +26,10 @@
     </div>
   </div>
 
+  <!-- Scrollable step body (on mobile this scrolls between the sticky step
+       header and the sticky action bar; on desktop it's a plain wrapper). -->
+  <div class="wizard-body">
+
   <!-- ── Step 1: Identity ─────────────────────────────────────────────── -->
   <ng-container *ngIf="step === 1">
     <div class="modal-title">Forge a New Hero</div>
@@ -677,6 +681,8 @@
 
     </div><!-- end .review-scroll -->
   </ng-container>
+
+  </div><!-- end .wizard-body -->
 
   <!-- ── Actions ─────────────────────────────────────────────────────── -->
   <div class="modal-actions">

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.scss
@@ -1058,3 +1058,85 @@
   color: #a78bfa;
   font-style: italic;
 }
+
+// ── Mobile: full-screen, TurboTax-style step sheet ────────────────────────
+// On phones the centered modal becomes a full-screen flow: a pinned progress
+// header, a scrolling body, and a sticky action bar so Back/Next are always
+// thumb-reachable (they used to get pushed off-screen on tall steps).
+// Scoped to this component, so it overrides the global .modal rules from
+// styles.css without editing that shared file.
+@media (max-width: 820px) {
+
+  :host ::ng-deep .modal.wizard {
+    width: 100vw;
+    height: 100dvh;
+    max-width: none;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    animation: wizard-slide-up 0.22s ease-out;
+
+    // The decorative inset border assumes padding that no longer exists.
+    &::before { display: none; }
+  }
+
+  // Pinned progress header.
+  .wizard-steps {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    margin: 0;
+    padding: 14px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-soft);
+  }
+
+  .ruleset-bar {
+    margin: 0;
+    padding: 12px 16px;
+    background: var(--surface);
+  }
+
+  // Scrolling step body between the two sticky bars.
+  .wizard-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 18px 16px;
+  }
+
+  // Sticky bottom action bar with full-width, finger-sized buttons.
+  :host ::ng-deep .modal-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    margin: 0;
+    padding: 12px 16px;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+
+    .btn {
+      flex: 1;
+      min-height: 48px;
+      font-size: 13px;
+    }
+  }
+
+  // Bigger tap targets for the in-wizard choices.
+  :host ::ng-deep .step-dot {
+    width: 34px;
+    height: 34px;
+  }
+  :host ::ng-deep .class-pick {
+    min-height: 46px;
+    font-size: 12px;
+  }
+}
+
+@keyframes wizard-slide-up {
+  from { transform: translateY(24px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}

--- a/src/app/charactermanager/components/sidenav/sidenav.component.html
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.html
@@ -3,7 +3,7 @@
   <!-- ═══════════════════════════════════════════════
        SIDEBAR
        ═══════════════════════════════════════════════ -->
-  <aside class="sidebar">
+  <aside class="sidebar" [class.open]="drawerOpen">
 
     <!-- Brand block (constant across both modes) -->
     <div class="brand">
@@ -138,10 +138,32 @@
 
   </aside>
 
+  <!-- Mobile-only scrim: tap to dismiss the drawer (no effect at desktop widths) -->
+  <div class="drawer-scrim" [class.show]="drawerOpen" (click)="closeDrawer()"></div>
+
   <!-- ═══════════════════════════════════════════════
        MAIN CONTENT
        ═══════════════════════════════════════════════ -->
   <main class="main">
+
+    <!-- Mobile-only top bar: hamburger + brand + active hero name (hidden at >=821px via CSS) -->
+    <div class="mobile-topbar">
+      <button class="mobile-menu-btn" (click)="toggleDrawer()" aria-label="Open party menu">
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+          <path d="M3 6h18M3 12h18M3 18h18"/>
+        </svg>
+      </button>
+      <div class="mobile-topbar-brand">
+        <svg class="brand-mark" viewBox="0 0 48 48" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.2">
+          <circle cx="24" cy="24" r="22" opacity="0.35"/>
+          <circle cx="24" cy="24" r="14"/>
+          <polygon points="24,6 28,20 42,22 30,30 34,44 24,36 14,44 18,30 6,22 20,20" stroke-linejoin="round"/>
+          <circle cx="24" cy="24" r="3" fill="currentColor"/>
+        </svg>
+        <span class="mobile-topbar-title">{{ (activePC$ | async)?.name || 'Table Mimic' }}</span>
+      </div>
+    </div>
+
     <div class="main-inner">
       <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
         <router-outlet></router-outlet>

--- a/src/app/charactermanager/components/sidenav/sidenav.component.scss
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.scss
@@ -1,1 +1,105 @@
-/* All layout rules live in src/styles.css — nothing component-scoped needed here. */
+/* Desktop layout lives in src/styles.css. Everything below is mobile-only:
+   it turns the always-on party pane into a slide-in drawer with a hamburger
+   top bar + scrim. These rules are view-encapsulated (scoped to this
+   component's template) so they win over the global .app/.sidebar/.main
+   rules without touching styles.css. */
+
+/* The mobile top bar and scrim are hidden by default (desktop). */
+.mobile-topbar { display: none; }
+.drawer-scrim { display: none; }
+
+@media (max-width: 820px) {
+
+  /* Shell collapses to a single column; the sidebar comes out of flow and
+     overlays as a drawer. 100dvh tracks the real visible height as mobile
+     browser chrome shows/hides (plain 100vh over-shoots and clips). */
+  .app {
+    grid-template-columns: 1fr;
+    height: 100dvh;
+  }
+
+  /* The party pane becomes an off-canvas drawer. */
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(86vw, 340px);
+    z-index: 120;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    box-shadow: none;
+  }
+  .sidebar.open {
+    transform: translateX(0);
+    box-shadow: 0 0 40px rgba(0, 0, 0, 0.6);
+  }
+
+  /* Dim layer behind the open drawer; tap to dismiss. */
+  .drawer-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+  .drawer-scrim.show {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* Sticky top bar gives the sheet a hamburger + context title. */
+  .mobile-topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    position: sticky;
+    top: 0;
+    z-index: 90;
+    padding: 10px 14px;
+    background: color-mix(in oklch, var(--surface) 92%, transparent);
+    border-bottom: 1px solid var(--border);
+    backdrop-filter: blur(8px);
+  }
+  .mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    color: var(--text);
+    cursor: pointer;
+  }
+  .mobile-menu-btn:active { border-color: var(--gold); color: var(--gold); }
+  .mobile-topbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .mobile-topbar-brand .brand-mark {
+    flex-shrink: 0;
+    color: var(--gold);
+    filter: drop-shadow(var(--glow-gold));
+  }
+  .mobile-topbar-title {
+    font-family: 'Cinzel', serif;
+    font-weight: 600;
+    font-size: 14px;
+    letter-spacing: 0.08em;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  /* (.main already has overflow-y:auto globally, so the sticky bar above
+     scrolls correctly with the sheet — no extra rule needed.) */
+}

--- a/src/app/charactermanager/components/sidenav/sidenav.component.ts
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.ts
@@ -26,6 +26,8 @@ export class SidenavComponent implements OnInit, OnDestroy {
 
   query = '';
   collapsedParties = new Set<string>();
+  /** Mobile only: whether the party pane is slid in over the sheet. Ignored at desktop widths. */
+  drawerOpen = false;
   activePC$ = this.pcService.activePC$;
   role$ = this.uiState.role$;
   user = this.currentUser.getUser();
@@ -69,8 +71,14 @@ export class SidenavComponent implements OnInit, OnDestroy {
       .filter(g => g.members.length > 0);
   }
 
+  /** Mobile drawer controls — no-ops visually at desktop widths (drawer CSS only applies <=820px). */
+  toggleDrawer(): void { this.drawerOpen = !this.drawerOpen; }
+  closeDrawer(): void { this.drawerOpen = false; }
+
   setActivePC(pc: PC): void {
     this.pcService.setActivePC(pc);
+    // On mobile, picking a hero should reveal their sheet, so dismiss the drawer.
+    this.closeDrawer();
   }
 
   toggleCollapse(party: string): void {
@@ -92,14 +100,14 @@ export class SidenavComponent implements OnInit, OnDestroy {
     return (pc.portraitInitials || pc.name.slice(0, 2)).toUpperCase();
   }
 
-  forgeHero(): void { this.characterModal.openCreateModal(); }
+  forgeHero(): void { this.closeDrawer(); this.characterModal.openCreateModal(); }
 
-  newCampaign(): void { this.campaignModal.openCreateModal(); }
+  newCampaign(): void { this.closeDrawer(); this.campaignModal.openCreateModal(); }
 
-  joinCampaign(): void { this.joinModal.open(); }
+  joinCampaign(): void { this.closeDrawer(); this.joinModal.open(); }
 
   /** Account-row tint, reusing the shared portrait util. */
   get userTint(): string { return tintFor({ portraitTint: this.user.tint } as any); }
 
-  openSettings(): void { this.uiState.openSettings(); }
+  openSettings(): void { this.closeDrawer(); this.uiState.openSettings(); }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1767,3 +1767,34 @@ app-root { display: block; height: 100vh; width: 100vw; }
   color: var(--celestial-2);
   font-weight: 600;
 }
+
+/* ════════════════════════════════════════════════════════════════════════
+   MOBILE POLISH (<=820px)
+   Single appended block (keeps merge-conflict surface small). Pairs with the
+   slide-in drawer in sidenav.component.scss and the full-screen wizard in
+   create-character-modal.component.scss. Bumps interactive controls toward the
+   44px touch-target guideline and lets the sheet breathe full-width.
+   ════════════════════════════════════════════════════════════════════════ */
+@media (max-width: 820px) {
+  /* HP +/- steppers were 22px — too small to tap reliably. */
+  .hp-btn { width: 32px; height: 32px; font-size: 13px; }
+
+  /* Generic buttons get a comfortable minimum height. */
+  .btn { min-height: 44px; }
+
+  /* Sheet header action buttons share the row evenly and grow finger-sized. */
+  .sheet-actions { gap: 8px; }
+  .sheet-actions .btn {
+    flex: 1 1 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .sheet-actions .btn.icon { flex: 0 0 auto; }
+
+  /* Roster rows in the drawer become easy tap targets. */
+  .roster-item { min-height: 48px; }
+
+  /* The account row at the drawer footer is also a tap target. */
+  .account-row { min-height: 48px; }
+}


### PR DESCRIPTION
On phones the fixed sidebar column squeezed the character sheet to ~115px. Add a mobile experience (all gated behind @media max-width:820px; desktop layout unchanged):

- Party menu becomes a slide-in drawer with a hamburger top bar + tap-to- dismiss scrim; selecting a hero or opening a modal closes it.
- "Forge Hero" wizard becomes a full-screen, TurboTax-style step sheet: pinned progress header, scrollable body, sticky bottom action bar so Back/Next stay thumb-reachable.
- Bump interactive controls (HP steppers, buttons, roster rows) toward the 44-48px touch-target guideline.

Drawer CSS lives in the previously-empty sidenav.component.scss; wizard CSS in create-character-modal.component.scss; one appended block in styles.css.