### PR TITLE
feat: add Session Mode screen with live initiative panel

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -32,6 +32,10 @@ import { PartyTreasuryComponent } from './components/campaign-dashboard/party-tr
 import { CreateCampaignModalComponent } from './components/create-campaign-modal/create-campaign-modal.component';
 import { JoinCampaignModalComponent } from './components/join-campaign-modal/join-campaign-modal.component';
 
+// ── Session Mode ───────────────────────────────────────────────────────────
+import { SessionModeComponent } from './components/session-mode/session-mode.component';
+import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
+
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MaterialModule } from '../shared/material.module';
 import { HttpClientModule } from '@angular/common/http';
@@ -81,6 +85,8 @@ const routes: Routes = [
     PartyTreasuryComponent,
     CreateCampaignModalComponent,
     JoinCampaignModalComponent,
+    SessionModeComponent,
+    InitiativePanelComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -22,7 +22,7 @@
           </svg>
           Manage Party
         </button>
-        <button class="btn">
+        <button class="btn" (click)="rollInitiative(vm.campaign)">
           <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
                style="margin-right: 6px; vertical-align: -2px;">
             <path d="M8 1l6 3.5v7L8 15l-6-3.5v-7L8 1z"/><path d="M8 1v14M2 4.5l6 3.5 6-3.5"/>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -5,6 +5,7 @@ import { Campaign } from '../../models/campaign';
 import { PC } from '../../models/pc';
 import { CampaignService } from '../../services/campaign.service';
 import { PCService } from '../../services/pc.service';
+import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
 import { passiveScore, tintFor } from '../../utils/character-math';
 
@@ -53,8 +54,21 @@ export class CampaignDashboardComponent {
   constructor(
     private campaignService: CampaignService,
     private pcService: PCService,
+    private sessionService: SessionService,
     private uiState: UiStateService,
   ) {}
+
+  /**
+   * Open a live Session Mode lobby for this campaign and switch the main view to
+   * the initiative tracker. The session is server-authoritative; we just store
+   * its id so the sidenav overlay takes over.
+   */
+  rollInitiative(campaign: Campaign): void {
+    this.sessionService.createSession(campaign.id).subscribe({
+      next: state => this.uiState.openSession(String(state.sessionId)),
+      error: err => console.error('Failed to start session', err),
+    });
+  }
 
   private buildVm(campaign: Campaign, members: PC[]): DashboardVm {
     const avgLevel = members.length

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
@@ -1,0 +1,59 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Initiative Order</span>
+    <span style="font-family: 'EB Garamond', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      turn order is set by the table
+    </span>
+  </div>
+
+  <div class="board">
+    <div class="board-row head" [style.grid-template-columns]="columns">
+      <span class="num">Init</span>
+      <span>Combatant</span>
+      <span>Hit Points</span>
+      <span class="num">AC</span>
+      <span>Conditions</span>
+    </div>
+
+    <div *ngIf="participants.length === 0"
+         style="padding: 18px 8px; color: var(--text-dim); font-style: italic;">
+      No combatants yet — players join to take their place in the order.
+    </div>
+
+    <div
+      *ngFor="let p of participants; trackBy: trackByParticipant"
+      class="board-row member"
+      [class.current-turn]="p.currentTurn"
+      [style.grid-template-columns]="columns"
+      style="cursor: default;"
+    >
+      <div class="board-num lit numeric">{{ p.initRolled ? p.initiative : '—' }}</div>
+
+      <div class="board-hero">
+        <div class="portrait" [style.background]="tintFor(p)">{{ initialsFor(p) }}</div>
+        <div style="min-width: 0;">
+          <div class="board-hero-name">{{ p.name }}</div>
+          <div class="board-hero-sub">
+            <ng-container *ngIf="!p.npc; else npcTag">{{ p.clazz }} {{ p.level }}</ng-container>
+            <ng-template #npcTag>NPC</ng-template>
+          </div>
+        </div>
+      </div>
+
+      <div class="board-hp" [class.bloodied]="bloodied(p)">
+        <div class="hp-text">
+          <span>{{ p.hpCurrent }}/{{ p.hpMax }}<ng-container *ngIf="p.hpTemp"> +{{ p.hpTemp }}</ng-container></span>
+          <span>{{ hpPct(p) | number:'1.0-0' }}%</span>
+        </div>
+        <div class="vital-bar"><span [style.width.%]="hpPct(p)"></span></div>
+      </div>
+
+      <div class="board-num lit">{{ p.ac }}</div>
+
+      <div class="board-conditions">
+        <span *ngIf="!p.conditions?.length" class="board-cond calm">steady</span>
+        <span *ngFor="let c of p.conditions" class="board-cond">{{ c }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
@@ -1,0 +1,5 @@
+// Highlight the combatant whose turn it is. Uses the global celestial accent.
+.board-row.current-turn {
+  background: rgba(120, 170, 255, 0.10);
+  box-shadow: inset 3px 0 0 var(--celestial);
+}

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { ParticipantView } from '../../../models/session';
+import { tintFor } from '../../../utils/character-math';
+
+/**
+ * Read-only initiative order — one row per combatant in server-computed turn
+ * order, with an Init column, HP bar, AC and conditions. Reuses the Party Vitals
+ * Board markup/classes (party-board.component) and adds a current-turn highlight.
+ * DM inline controls are layered on in a later feature.
+ */
+@Component({
+  selector: 'app-initiative-panel',
+  templateUrl: './initiative-panel.component.html',
+  styleUrls: ['./initiative-panel.component.scss'],
+})
+export class InitiativePanelComponent {
+  @Input() participants: ParticipantView[] = [];
+
+  // Same 5-column grid for the header and each row.
+  readonly columns = '44px minmax(140px, 1.6fr) 150px 56px minmax(110px, 1.2fr)';
+
+  tintFor(p: ParticipantView): string {
+    return tintFor({ portraitTint: p.portraitTint } as any);
+  }
+
+  initialsFor(p: ParticipantView): string {
+    return (p.portraitInitials || p.name.slice(0, 2)).toUpperCase();
+  }
+
+  hpPct(p: ParticipantView): number {
+    const max = p.hpMax ?? 0;
+    const cur = p.hpCurrent ?? 0;
+    return max <= 0 ? 0 : Math.max(0, Math.min(100, (cur / max) * 100));
+  }
+
+  bloodied(p: ParticipantView): boolean {
+    const max = p.hpMax ?? 0;
+    const cur = p.hpCurrent ?? 0;
+    return max > 0 && cur <= max / 2;
+  }
+
+  trackByParticipant(_: number, p: ParticipantView): number {
+    return p.participantId;
+  }
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -1,0 +1,35 @@
+<ng-container *ngIf="state$ | async as state; else loading">
+  <div class="fade-in">
+
+    <!-- Header -->
+    <header class="sheet-header" style="grid-template-columns: 1fr auto;">
+      <div class="sheet-id">
+        <div class="eyebrow">Live Session · {{ state.status | titlecase }} · Round {{ state.round }}</div>
+        <h1 class="sheet-name">Initiative</h1>
+        <div class="sheet-subtitle">
+          {{ state.participants.length }} {{ state.participants.length === 1 ? 'combatant' : 'combatants' }} at the table
+        </div>
+      </div>
+      <div class="sheet-actions">
+        <button class="btn" (click)="close()">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <path d="M4 4l8 8M12 4l-8 8"/>
+          </svg>
+          Close
+        </button>
+      </div>
+    </header>
+
+    <app-initiative-panel [participants]="state.participants"></app-initiative-panel>
+  </div>
+</ng-container>
+
+<ng-template #loading>
+  <div class="empty">
+    <div>
+      <div class="empty-title">Summoning the initiative order…</div>
+      <div class="empty-sub">Reaching the table.</div>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/charactermanager/components/session-mode/session-mode.component.scss
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.scss
@@ -1,0 +1,5 @@
+// Session Mode screen. Layout/colors come from the global design system
+// (styles.css). Only screen-specific spacing lives here.
+:host {
+  display: block;
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -1,0 +1,41 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { SessionService } from '../../services/session.service';
+import { UiStateService } from '../../services/ui-state.service';
+
+/**
+ * Session Mode screen — a full-width overlay (chosen in the sidenav over the
+ * Player/DM views via UiState.activeSessionId$) showing the live initiative
+ * order. Subscribes to the server-authoritative snapshot and polls while open.
+ *
+ * This feature renders the read-only order; DM controls (initiative entry,
+ * damage) arrive in a later feature.
+ */
+@Component({
+  selector: 'app-session-mode',
+  templateUrl: './session-mode.component.html',
+  styleUrls: ['./session-mode.component.scss'],
+})
+export class SessionModeComponent implements OnInit, OnDestroy {
+  @Input() sessionId!: string;
+
+  state$ = this.sessionService.state$;
+
+  constructor(
+    private sessionService: SessionService,
+    private uiState: UiStateService,
+  ) {}
+
+  ngOnInit(): void {
+    this.sessionService.startPolling(this.sessionId);
+  }
+
+  ngOnDestroy(): void {
+    this.sessionService.stopPolling();
+  }
+
+  /** Leave the session screen (does not end the session server-side). */
+  close(): void {
+    this.sessionService.clear();
+    this.uiState.closeSession();
+  }
+}

--- a/src/app/charactermanager/components/sidenav/sidenav.component.html
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.html
@@ -147,11 +147,17 @@
     </div>
 
     <div class="main-inner">
-      <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
-        <router-outlet></router-outlet>
+      <!-- Session Mode overlays both Player and DM views while a session is live -->
+      <ng-container *ngIf="(activeSessionId$ | async) as sessionId; else normalView">
+        <app-session-mode [sessionId]="sessionId"></app-session-mode>
       </ng-container>
-      <ng-template #dmMain>
-        <app-campaign-dashboard></app-campaign-dashboard>
+      <ng-template #normalView>
+        <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
+          <router-outlet></router-outlet>
+        </ng-container>
+        <ng-template #dmMain>
+          <app-campaign-dashboard></app-campaign-dashboard>
+        </ng-template>
       </ng-template>
     </div>
   </main>

--- a/src/app/charactermanager/components/sidenav/sidenav.component.ts
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.ts
@@ -24,6 +24,8 @@ export class SidenavComponent implements OnInit, OnDestroy {
   drawerOpen = false;
   activePC$ = this.pcService.activePC$;
   role$ = this.uiState.role$;
+  // When set, Session Mode takes over the main content area for everyone.
+  activeSessionId$ = this.uiState.activeSessionId$;
   user = this.currentUser.getUser();
 
   private allPcs: PC[] = [];

--- a/src/app/charactermanager/models/session.ts
+++ b/src/app/charactermanager/models/session.ts
@@ -1,0 +1,43 @@
+/**
+ * Live "Session Mode" types — the client mirror of the backend SessionStateView /
+ * ParticipantView DTOs. State is server-authoritative: the client renders what
+ * the snapshot says and never computes turn order itself. `conditions` is parsed
+ * from the backend's JSON string into an array by the SessionService deserializer.
+ */
+
+export type SessionStatus = 'LOBBY' | 'ACTIVE' | 'ENDED';
+
+export interface ParticipantView {
+  participantId: number;
+  pcId: number | null;
+  npc: boolean;
+  ownedByMe: boolean;
+  currentTurn: boolean;
+  name: string;
+  clazz: string | null;
+  level: number | null;
+  portraitTint: string | null;
+  portraitInitials: string | null;
+  initiative: number | null;
+  initRolled: boolean;
+  orderIndex: number;
+  hpMax: number | null;
+  hpCurrent: number | null;
+  hpTemp: number | null;
+  ac: number | null;
+  conditions: string[];
+  deathSaveSuccesses: number;
+  deathSaveFailures: number;
+}
+
+export interface SessionState {
+  // Numeric in real mode; a string sentinel in demo mode.
+  sessionId: number | string;
+  campaignId: number | string;
+  status: SessionStatus;
+  round: number;
+  currentTurnIndex: number;
+  version: number;
+  dm: boolean;
+  participants: ParticipantView[];
+}

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -1,0 +1,193 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, Subscription, of, timer } from 'rxjs';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { ParticipantView, SessionState } from '../models/session';
+import { PC } from '../models/pc';
+import { CampaignService } from './campaign.service';
+
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Live session client. Mirrors the demo/real split every other service uses:
+ * in real mode it talks to the cloud character-manager-service (the same service
+ * that owns PCs, so HP edits stay consistent) and short-polls the snapshot; in
+ * demo mode it builds a single in-memory session from the campaign's members so
+ * the screen is previewable with no backend.
+ *
+ * State is server-authoritative — `state$` always holds the latest snapshot and
+ * components render it directly.
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+  private stateSubject = new BehaviorSubject<SessionState | null>(null);
+  state$ = this.stateSubject.asObservable();
+
+  private readonly sessionBase = `${environment.characterApiUrl}/api/v1/session`;
+  private readonly campaignBase = `${environment.characterApiUrl}/api/v1/campaign`;
+
+  private pollSub?: Subscription;
+
+  constructor(private http: HttpClient, private campaignService: CampaignService) {}
+
+  /** DM opens a lobby for a campaign; stores and returns the initial snapshot. */
+  createSession(campaignId: string): Observable<SessionState> {
+    if (environment.demoMode) {
+      return this.campaignService.getMembers(campaignId).pipe(
+        take(1),
+        map(members => this.demoState(campaignId, members)),
+        tap(state => this.stateSubject.next(state)),
+      );
+    }
+    return this.http.post<unknown>(`${this.campaignBase}/${campaignId}/session`, {}).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
+  /** Fetch the current snapshot once. */
+  getState(sessionId: number | string): Observable<SessionState> {
+    if (environment.demoMode) {
+      const current = this.stateSubject.getValue();
+      return current ? of(current) : of(this.emptyState(sessionId));
+    }
+    return this.http.get<unknown>(`${this.sessionBase}/${sessionId}/state`).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
+  /**
+   * Begin polling the snapshot every 2s, paused while the tab is hidden to save
+   * requests. No-op in demo mode (the single in-memory state is already live).
+   */
+  startPolling(sessionId: number | string): void {
+    this.stopPolling();
+    if (environment.demoMode) return;
+    this.pollSub = timer(0, POLL_INTERVAL_MS).pipe(
+      filter(() => !document.hidden),
+      switchMap(() => this.http.get<unknown>(`${this.sessionBase}/${sessionId}/state`)),
+      map(raw => this.deserialize(raw)),
+    ).subscribe({
+      next: state => this.stateSubject.next(state),
+      error: err => console.error('Session poll failed', err),
+    });
+  }
+
+  stopPolling(): void {
+    this.pollSub?.unsubscribe();
+    this.pollSub = undefined;
+  }
+
+  /** Stop polling and clear local state — used when leaving the session screen. */
+  clear(): void {
+    this.stopPolling();
+    this.stateSubject.next(null);
+  }
+
+  // --- demo helpers ---------------------------------------------------------
+
+  private demoState(campaignId: string, members: PC[]): SessionState {
+    const participants = members
+      .map((pc, i) => this.pcToParticipant(pc, i))
+      .sort((a, b) => (b.initiative ?? -99) - (a.initiative ?? -99));
+    participants.forEach((p, i) => (p.orderIndex = i));
+    return {
+      sessionId: 'demo-session',
+      campaignId,
+      status: 'LOBBY',
+      round: 1,
+      currentTurnIndex: 0,
+      version: 0,
+      dm: true,
+      participants,
+    };
+  }
+
+  private emptyState(sessionId: number | string): SessionState {
+    return {
+      sessionId, campaignId: '', status: 'LOBBY', round: 1,
+      currentTurnIndex: 0, version: 0, dm: true, participants: [],
+    };
+  }
+
+  private pcToParticipant(pc: PC, index: number): ParticipantView {
+    return {
+      participantId: pc.id,
+      pcId: pc.id,
+      npc: false,
+      ownedByMe: true,
+      currentTurn: false,
+      name: pc.name,
+      clazz: pc.clazz ?? null,
+      level: pc.level ?? null,
+      portraitTint: pc.portraitTint ?? null,
+      portraitInitials: pc.portraitInitials ?? null,
+      initiative: pc.init ?? null,
+      initRolled: pc.init != null,
+      orderIndex: index,
+      hpMax: pc.hp?.max ?? null,
+      hpCurrent: pc.hp?.cur ?? null,
+      hpTemp: pc.hp?.temp ?? null,
+      ac: pc.ac ?? null,
+      conditions: pc.conditions ?? [],
+      deathSaveSuccesses: 0,
+      deathSaveFailures: 0,
+    };
+  }
+
+  // --- serialize / deserialize seam ----------------------------------------
+
+  private deserialize(raw: any): SessionState {
+    return {
+      sessionId: raw.sessionId,
+      campaignId: raw.campaignId,
+      status: raw.status,
+      round: raw.round,
+      currentTurnIndex: raw.currentTurnIndex,
+      version: raw.version,
+      dm: !!raw.dm,
+      participants: (raw.participants ?? []).map((p: any) => this.deserializeParticipant(p)),
+    };
+  }
+
+  private deserializeParticipant(p: any): ParticipantView {
+    return {
+      participantId: p.participantId,
+      pcId: p.pcId ?? null,
+      npc: !!p.npc,
+      ownedByMe: !!p.ownedByMe,
+      currentTurn: !!p.currentTurn,
+      name: p.name,
+      clazz: p.clazz ?? null,
+      level: p.level ?? null,
+      portraitTint: p.portraitTint ?? null,
+      portraitInitials: p.portraitInitials ?? null,
+      initiative: p.initiative ?? null,
+      initRolled: !!p.initRolled,
+      orderIndex: p.orderIndex ?? 0,
+      hpMax: p.hpMax ?? null,
+      hpCurrent: p.hpCurrent ?? null,
+      hpTemp: p.hpTemp ?? null,
+      ac: p.ac ?? null,
+      conditions: this.parseConditions(p.conditions),
+      deathSaveSuccesses: p.deathSaveSuccesses ?? 0,
+      deathSaveFailures: p.deathSaveFailures ?? 0,
+    };
+  }
+
+  /** Backend sends conditions as a JSON string (PC.conditions); normalize to an array. */
+  private parseConditions(raw: any): string[] {
+    if (Array.isArray(raw)) return raw;
+    if (typeof raw === 'string' && raw.trim()) {
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }
+}

--- a/src/app/charactermanager/services/ui-state.service.ts
+++ b/src/app/charactermanager/services/ui-state.service.ts
@@ -22,6 +22,11 @@ export class UiStateService {
   private settingsOpenSubject = new BehaviorSubject<boolean>(false);
   settingsOpen$ = this.settingsOpenSubject.asObservable();
 
+  // The live session currently open as a full-screen overlay (null = none).
+  // Drives Session Mode, which layers over both the Player and DM views.
+  private activeSessionIdSubject = new BehaviorSubject<string | null>(null);
+  activeSessionId$ = this.activeSessionIdSubject.asObservable();
+
   get role(): Role { return this.roleSubject.getValue(); }
 
   setRole(role: Role): void { this.roleSubject.next(role); }
@@ -30,4 +35,7 @@ export class UiStateService {
 
   openSettings(): void  { this.settingsOpenSubject.next(true); }
   closeSettings(): void { this.settingsOpenSubject.next(false); }
+
+  openSession(sessionId: string): void { this.activeSessionIdSubject.next(sessionId); }
+  closeSession(): void { this.activeSessionIdSubject.next(null); }
 }


### PR DESCRIPTION
The DM's dormant "Roll Initiative" button now opens a live session and the main view switches to a server-authoritative initiative tracker.

- SessionService (demo + real branches, serialize/deserialize seam): create a session, fetch state, and short-poll the snapshot every 2s, paused while the tab is hidden. Demo mode builds one in-memory session from the campaign's members so the screen is previewable with no backend.
- models/session.ts mirrors the backend SessionStateView/ParticipantView; conditions are parsed from the backend JSON string into an array.
- Session Mode is a UiState-driven overlay (activeSessionId$) layered over both Player and DM views in the sidenav — chosen over a route because the shell gates router-outlet behind the player role.
- New session-mode + read-only initiative-panel components; the panel reuses the party-board markup/classes and adds an Init column and current-turn highlight.
- Wire the Roll Initiative button to create a session and open the overlay.

Verified: ng build green with demoMode false and true; in demo, Roll Initiative opens the screen with the party ordered by initiative (Lyra 4, Throk 2), HP bars and conditions rendered, no console errors. Player join, DM initiative entry, and damage controls follow in later features.