### PR TITLE
feat: add player join flow for live sessions

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -35,6 +35,7 @@ import { JoinCampaignModalComponent } from './components/join-campaign-modal/joi
 // ── Session Mode ───────────────────────────────────────────────────────────
 import { SessionModeComponent } from './components/session-mode/session-mode.component';
 import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
+import { SessionLiveBannerComponent } from './components/session-live-banner/session-live-banner.component';
 
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MaterialModule } from '../shared/material.module';
@@ -87,6 +88,7 @@ const routes: Routes = [
     JoinCampaignModalComponent,
     SessionModeComponent,
     InitiativePanelComponent,
+    SessionLiveBannerComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/charactermanager/components/session-live-banner/session-live-banner.component.html
+++ b/src/app/charactermanager/components/session-live-banner/session-live-banner.component.html
@@ -1,0 +1,52 @@
+<!-- Live-session banner (player view). Hidden when no session is live. -->
+<div class="session-banner" *ngIf="live">
+  <div class="session-banner-glyph" aria-hidden="true">
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.4">
+      <path d="M8 1l6 3.5v7L8 15l-6-3.5v-7L8 1z"/><path d="M8 1v14M2 4.5l6 3.5 6-3.5"/>
+    </svg>
+  </div>
+  <div class="session-banner-text">
+    <span class="session-banner-title">A session is live</span>
+    <span class="session-banner-sub">{{ live.campaignName }} · take your place in the order</span>
+  </div>
+  <button class="btn primary" (click)="openPicker()">Join Session</button>
+</div>
+
+<!-- PC picker (reuses the join-campaign-modal pattern) -->
+<div *ngIf="pickerOpen" class="modal-backdrop" (click)="closePicker()">
+  <div class="modal" style="border-color: var(--celestial);" (click)="$event.stopPropagation()">
+    <div class="modal-title" style="color: var(--celestial-2);">Join the Session</div>
+    <div class="modal-sub">
+      Choose which hero takes the field in
+      <em style="color: var(--text); font-style: normal;">{{ live?.campaignName }}</em>.
+    </div>
+
+    <div class="field" *ngIf="eligiblePcs.length; else noHeroes">
+      <label>Character</label>
+      <select [(ngModel)]="selectedPcId">
+        <option *ngFor="let pc of eligiblePcs" [ngValue]="pc.id">
+          {{ pc.name }} — {{ pc.race }} {{ pc.clazz }}
+        </option>
+      </select>
+    </div>
+
+    <ng-template #noHeroes>
+      <div class="modal-sub" style="color: var(--text-dim); font-style: italic;">
+        None of your heroes are seated at this campaign yet. Join the campaign first.
+      </div>
+    </ng-template>
+
+    <div class="login-error" *ngIf="error" style="margin-top: 8px;">{{ error }}</div>
+
+    <div class="modal-actions">
+      <button class="btn" (click)="closePicker()">Cancel</button>
+      <button
+        class="btn primary"
+        (click)="join()"
+        [disabled]="selectedPcId == null || joining"
+      >
+        {{ joining ? 'Joining…' : 'Take the Field' }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/charactermanager/components/session-live-banner/session-live-banner.component.scss
+++ b/src/app/charactermanager/components/session-live-banner/session-live-banner.component.scss
@@ -1,0 +1,48 @@
+// Live-session call-to-action bar. Colors come from the global design system.
+.session-banner {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 20px;
+  padding: 14px 18px;
+  border: 1px solid var(--celestial, #6f8cff);
+  border-radius: 12px;
+  background: rgba(120, 170, 255, 0.08);
+
+  .session-banner-glyph {
+    flex: none;
+    color: var(--celestial-2, #9db4ff);
+  }
+
+  .session-banner-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .session-banner-title {
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  .session-banner-sub {
+    font-size: 13px;
+    color: var(--text-dim);
+  }
+
+  .btn {
+    flex: none;
+  }
+}
+
+// Mobile: stack the text above a full-width button.
+@media (max-width: 560px) {
+  .session-banner {
+    flex-wrap: wrap;
+
+    .btn {
+      flex: 1 0 100%;
+    }
+  }
+}

--- a/src/app/charactermanager/components/session-live-banner/session-live-banner.component.ts
+++ b/src/app/charactermanager/components/session-live-banner/session-live-banner.component.ts
@@ -1,0 +1,120 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription, combineLatest, of, timer } from 'rxjs';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
+import { PC } from '../../models/pc';
+import { SessionState } from '../../models/session';
+import { CampaignService } from '../../services/campaign.service';
+import { PCService } from '../../services/pc.service';
+import { SessionService } from '../../services/session.service';
+import { UiStateService } from '../../services/ui-state.service';
+
+interface LiveSession {
+  session: SessionState;
+  campaignId: string;
+  campaignName: string;
+}
+
+/**
+ * Player-facing "a session is live — join" banner. Polls the campaigns the
+ * player's characters belong to and, when the DM has a session open, offers a
+ * picker to seat one of their member PCs. Hidden entirely in demo mode (no
+ * multi-client discovery there) and whenever no session is live.
+ */
+@Component({
+  selector: 'app-session-live-banner',
+  templateUrl: './session-live-banner.component.html',
+  styleUrls: ['./session-live-banner.component.scss'],
+})
+export class SessionLiveBannerComponent implements OnInit, OnDestroy {
+  live: LiveSession | null = null;
+
+  pickerOpen = false;
+  eligiblePcs: PC[] = [];
+  selectedPcId: number | null = null;
+  joining = false;
+  error: string | null = null;
+
+  private allPcs: PC[] = [];
+  private sub?: Subscription;
+
+  constructor(
+    private pcService: PCService,
+    private campaignService: CampaignService,
+    private sessionService: SessionService,
+    private uiState: UiStateService,
+  ) {}
+
+  ngOnInit(): void {
+    // Re-check whenever the roster changes and on a 5s heartbeat (paused while
+    // the tab is hidden). Show the first campaign that has a live session.
+    this.sub = combineLatest([this.pcService.pcs$, timer(0, 5000)]).pipe(
+      filter(() => !document.hidden),
+      switchMap(([pcs]) => {
+        this.allPcs = pcs;
+        const campaignIds = this.distinctCampaignIds(pcs);
+        if (!campaignIds.length) return of(null);
+        return combineLatest(
+          campaignIds.map(id =>
+            this.sessionService.getActiveForCampaign(id).pipe(
+              map(session => (session ? { id, session } : null)),
+              catchError(() => of(null)),
+            ),
+          ),
+        ).pipe(map(results => results.find(r => r != null) ?? null));
+      }),
+    ).subscribe(found => {
+      this.live = found
+        ? {
+            session: found.session,
+            campaignId: found.id,
+            campaignName: this.campaignService.getById(found.id)?.name ?? 'your campaign',
+          }
+        : null;
+      // If the live session went away while the picker was open, close it.
+      if (!found) this.pickerOpen = false;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  openPicker(): void {
+    if (!this.live) return;
+    this.error = null;
+    this.eligiblePcs = this.allPcs.filter(
+      pc => pc.campaignId != null && String(pc.campaignId) === this.live!.campaignId,
+    );
+    this.selectedPcId = this.eligiblePcs[0]?.id ?? null;
+    this.pickerOpen = true;
+  }
+
+  closePicker(): void {
+    this.pickerOpen = false;
+  }
+
+  join(): void {
+    if (!this.live || this.selectedPcId == null) return;
+    this.joining = true;
+    this.error = null;
+    this.sessionService.joinSession(this.live.session.sessionId, this.selectedPcId).subscribe({
+      next: state => {
+        this.joining = false;
+        this.pickerOpen = false;
+        this.uiState.openSession(String(state.sessionId));
+      },
+      error: () => {
+        this.joining = false;
+        this.error = 'Could not join the session. Try again.';
+      },
+    });
+  }
+
+  private distinctCampaignIds(pcs: PC[]): string[] {
+    const ids = pcs
+      .map(pc => pc.campaignId)
+      .filter((id): id is number | string => id != null)
+      .map(id => String(id));
+    return Array.from(new Set(ids));
+  }
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -11,6 +11,17 @@
         </div>
       </div>
       <div class="sheet-actions">
+        <button
+          *ngIf="!state.dm && myParticipantId(state) != null"
+          class="btn"
+          (click)="leave(state)"
+        >
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <path d="M6 2H3v12h3M10 11l3-3-3-3M13 8H6"/>
+          </svg>
+          Leave
+        </button>
         <button class="btn" (click)="close()">
           <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"
                style="margin-right: 6px; vertical-align: -2px;">

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { SessionState } from '../../models/session';
 import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
 
@@ -37,5 +38,24 @@ export class SessionModeComponent implements OnInit, OnDestroy {
   close(): void {
     this.sessionService.clear();
     this.uiState.closeSession();
+  }
+
+  /** The requesting player's own participant id in this session, if any. */
+  myParticipantId(state: SessionState): number | null {
+    const mine = state.participants.find(p => p.ownedByMe);
+    return mine ? mine.participantId : null;
+  }
+
+  /** A player removes their own PC from the session, then exits the screen. */
+  leave(state: SessionState): void {
+    const id = this.myParticipantId(state);
+    if (id == null) {
+      this.close();
+      return;
+    }
+    this.sessionService.leave(state.sessionId, id).subscribe({
+      next: () => this.close(),
+      error: () => this.close(),
+    });
   }
 }

--- a/src/app/charactermanager/components/sidenav/sidenav.component.html
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.html
@@ -153,6 +153,7 @@
       </ng-container>
       <ng-template #normalView>
         <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
+          <app-session-live-banner></app-session-live-banner>
           <router-outlet></router-outlet>
         </ng-container>
         <ng-template #dmMain>

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subscription, of, timer } from 'rxjs';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { ParticipantView, SessionState } from '../models/session';
 import { PC } from '../models/pc';
@@ -84,6 +84,39 @@ export class SessionService {
   clear(): void {
     this.stopPolling();
     this.stateSubject.next(null);
+  }
+
+  /**
+   * The campaign's current live session, or null if none — used to show players a
+   * "session live — join" prompt. Demo mode has no multi-client discovery, so it
+   * returns null (the screen is reachable from the DM's Roll Initiative instead).
+   */
+  getActiveForCampaign(campaignId: string): Observable<SessionState | null> {
+    if (environment.demoMode) return of(null);
+    return this.http.get<unknown>(`${this.campaignBase}/${campaignId}/session`).pipe(
+      map(raw => (raw ? this.deserialize(raw) : null)),
+      catchError(() => of(null)),
+    );
+  }
+
+  /** Seat one of the player's PCs in a live session; stores the resulting state. */
+  joinSession(sessionId: number | string, pcId: number): Observable<SessionState> {
+    if (environment.demoMode) return this.getState(sessionId).pipe(take(1));
+    return this.http.post<unknown>(`${this.sessionBase}/${sessionId}/join`, { pcId }).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
+  /** Remove a participant — a player leaving their own PC, or the DM removing one. */
+  leave(sessionId: number | string, participantId: number): Observable<SessionState> {
+    if (environment.demoMode) return this.getState(sessionId).pipe(take(1));
+    return this.http.delete<unknown>(
+      `${this.sessionBase}/${sessionId}/participants/${participantId}`,
+    ).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
   }
 
   // --- demo helpers ---------------------------------------------------------


### PR DESCRIPTION
Players can now discover and join a live session from their own device.

- SessionService: getActiveForCampaign (discovery), joinSession, and leave.
- session-live-banner: polls the campaigns the player's characters belong to (5s, paused while hidden) and shows a "session is live — join" bar when the DM has one open; an inline PC picker (reusing the join-campaign-modal pattern) lists only the player's member PCs and seats the chosen one, then opens the session overlay. Mounted in the player view in the sidenav.
- session-mode: a non-DM participant gets a "Leave" button that removes their PC (DELETE participant) and exits the screen.
- Demo mode has no multi-client discovery, so the banner stays hidden (getActiveForCampaign returns null) and both builds stay green.

Pairs with the backend GET /api/v1/campaign/{id}/session discovery endpoint.