### PR TITLE
feat: add DM initiative and damage controls to the session panel

### DIFF
--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
@@ -13,6 +13,7 @@
       <span>Hit Points</span>
       <span class="num">AC</span>
       <span>Conditions</span>
+      <span *ngIf="dm" class="num">Adjust</span>
     </div>
 
     <div *ngIf="participants.length === 0"
@@ -27,7 +28,17 @@
       [style.grid-template-columns]="columns"
       style="cursor: default;"
     >
-      <div class="board-num lit numeric">{{ p.initRolled ? p.initiative : '—' }}</div>
+      <div class="board-num lit numeric">
+        <input
+          *ngIf="dm; else initRead"
+          type="number"
+          class="init-input"
+          [ngModel]="p.initiative"
+          (change)="onInitiative(p, $any($event.target).value)"
+          aria-label="Initiative"
+        />
+        <ng-template #initRead>{{ p.initRolled ? p.initiative : '—' }}</ng-template>
+      </div>
 
       <div class="board-hero">
         <div class="portrait" [style.background]="tintFor(p)">{{ initialsFor(p) }}</div>
@@ -53,6 +64,19 @@
       <div class="board-conditions">
         <span *ngIf="!p.conditions?.length" class="board-cond calm">steady</span>
         <span *ngFor="let c of p.conditions" class="board-cond">{{ c }}</span>
+      </div>
+
+      <div *ngIf="dm" class="dm-adjust" (click)="$event.stopPropagation()">
+        <input
+          type="number"
+          class="dmg-input"
+          min="0"
+          placeholder="0"
+          [(ngModel)]="amounts[p.participantId]"
+          aria-label="Amount"
+        />
+        <button class="btn-mini dmg" (click)="adjustHp(p, 1)" title="Apply damage">−</button>
+        <button class="btn-mini heal" (click)="adjustHp(p, -1)" title="Apply healing">+</button>
       </div>
     </div>
   </div>

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
@@ -3,3 +3,51 @@
   background: rgba(120, 170, 255, 0.10);
   box-shadow: inset 3px 0 0 var(--celestial);
 }
+
+// DM inline controls -------------------------------------------------------
+.init-input {
+  width: 40px;
+  padding: 2px 4px;
+  text-align: center;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 6px;
+}
+
+.dm-adjust {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .dmg-input {
+    width: 48px;
+    padding: 2px 4px;
+    text-align: center;
+    font: inherit;
+    color: var(--text);
+    background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+    border-radius: 6px;
+  }
+
+  .btn-mini {
+    width: 26px;
+    height: 26px;
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    border-radius: 6px;
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+    background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+    color: var(--text);
+
+    &.dmg:hover { border-color: var(--crimson, #d9534f); color: var(--crimson, #d9534f); }
+    &.heal:hover { border-color: var(--emerald, #4caf7d); color: var(--emerald, #4caf7d); }
+  }
+}

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
@@ -1,12 +1,16 @@
 import { Component, Input } from '@angular/core';
 import { ParticipantView } from '../../../models/session';
+import { SessionService } from '../../../services/session.service';
 import { tintFor } from '../../../utils/character-math';
 
 /**
- * Read-only initiative order — one row per combatant in server-computed turn
- * order, with an Init column, HP bar, AC and conditions. Reuses the Party Vitals
- * Board markup/classes (party-board.component) and adds a current-turn highlight.
- * DM inline controls are layered on in a later feature.
+ * Initiative order — one row per combatant in server-computed turn order, with
+ * an Init column, HP bar, AC and conditions. Reuses the Party Vitals Board
+ * markup/classes (party-board.component) and adds a current-turn highlight.
+ *
+ * When the viewer is the DM, the Init cell becomes editable and a per-row
+ * damage/heal control appears; both call the server (state stays
+ * authoritative — the service updates the snapshot the panel re-renders from).
  */
 @Component({
   selector: 'app-initiative-panel',
@@ -15,9 +19,37 @@ import { tintFor } from '../../../utils/character-math';
 })
 export class InitiativePanelComponent {
   @Input() participants: ParticipantView[] = [];
+  @Input() sessionId!: number | string;
+  @Input() dm = false;
 
-  // Same 5-column grid for the header and each row.
-  readonly columns = '44px minmax(140px, 1.6fr) 150px 56px minmax(110px, 1.2fr)';
+  /** Per-row amount typed into the DM's damage/heal box, keyed by participant id. */
+  amounts: { [participantId: number]: number | null } = {};
+
+  constructor(private sessionService: SessionService) {}
+
+  // 5 columns read-only; a 6th DM "Adjust" column appears for the DM.
+  get columns(): string {
+    const base = '44px minmax(140px, 1.6fr) 150px 56px minmax(110px, 1.2fr)';
+    return this.dm ? `${base} 168px` : base;
+  }
+
+  onInitiative(p: ParticipantView, raw: string): void {
+    const value = parseInt(raw, 10);
+    if (isNaN(value)) return;
+    this.sessionService.setInitiative(this.sessionId, p.participantId, value).subscribe({
+      error: err => console.error('Failed to set initiative', err),
+    });
+  }
+
+  /** Apply the row's typed amount as damage (sign +1) or healing (sign -1). */
+  adjustHp(p: ParticipantView, sign: 1 | -1): void {
+    const amt = this.amounts[p.participantId];
+    if (amt == null || amt <= 0) return;
+    this.sessionService.applyDamage(this.sessionId, p.participantId, sign * amt).subscribe({
+      next: () => (this.amounts[p.participantId] = null),
+      error: err => console.error('Failed to adjust HP', err),
+    });
+  }
 
   tintFor(p: ParticipantView): string {
     return tintFor({ portraitTint: p.portraitTint } as any);

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -32,7 +32,11 @@
       </div>
     </header>
 
-    <app-initiative-panel [participants]="state.participants"></app-initiative-panel>
+    <app-initiative-panel
+      [participants]="state.participants"
+      [sessionId]="state.sessionId"
+      [dm]="state.dm"
+    ></app-initiative-panel>
   </div>
 </ng-container>
 

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -119,7 +119,63 @@ export class SessionService {
     );
   }
 
+  /** DM enters a combatant's initiative; the server (or demo) re-sorts the order. */
+  setInitiative(sessionId: number | string, participantId: number, value: number): Observable<SessionState> {
+    if (environment.demoMode) return of(this.demoSetInitiative(participantId, value));
+    return this.http.put<unknown>(
+      `${this.sessionBase}/${sessionId}/participants/${participantId}/initiative`, { value },
+    ).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
+  /** DM damages (positive) or heals (negative) a combatant; PC HP writes through. */
+  applyDamage(sessionId: number | string, participantId: number, amount: number): Observable<SessionState> {
+    if (environment.demoMode) return of(this.demoDamage(participantId, amount));
+    return this.http.post<unknown>(
+      `${this.sessionBase}/${sessionId}/participants/${participantId}/damage`, { amount },
+    ).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
   // --- demo helpers ---------------------------------------------------------
+
+  /** Demo: set a participant's initiative and re-sort the order locally. */
+  private demoSetInitiative(participantId: number, value: number): SessionState {
+    const state = this.stateSubject.getValue() ?? this.emptyState('demo-session');
+    const participants = state.participants
+      .map(p => (p.participantId === participantId ? { ...p, initiative: value, initRolled: true } : p))
+      .sort((a, b) => (b.initiative ?? -99) - (a.initiative ?? -99));
+    participants.forEach((p, i) => (p.orderIndex = i));
+    const next = { ...state, participants, version: state.version + 1 };
+    this.stateSubject.next(next);
+    return next;
+  }
+
+  /** Demo: apply an HP delta to a participant locally (temp absorbs, floor 0, heal caps at max). */
+  private demoDamage(participantId: number, amount: number): SessionState {
+    const state = this.stateSubject.getValue() ?? this.emptyState('demo-session');
+    const participants = state.participants.map(p => {
+      if (p.participantId !== participantId) return p;
+      let cur = p.hpCurrent ?? 0;
+      let temp = p.hpTemp ?? 0;
+      if (amount > 0) {
+        const absorbed = Math.min(temp, amount);
+        temp -= absorbed;
+        cur = Math.max(0, cur - (amount - absorbed));
+      } else if (amount < 0) {
+        cur += -amount;
+        if (p.hpMax != null) cur = Math.min(cur, p.hpMax);
+      }
+      return { ...p, hpCurrent: cur, hpTemp: temp };
+    });
+    const next = { ...state, participants, version: state.version + 1 };
+    this.stateSubject.next(next);
+    return next;
+  }
 
   private demoState(campaignId: string, members: PC[]): SessionState {
     const participants = members


### PR DESCRIPTION
Completes the Session Mode MVP: the DM can now run the encounter from the initiative panel.

- SessionService: setInitiative and applyDamage call the F3/F4 endpoints; their demo branches mutate the in-memory snapshot (initiative re-sorts the order; damage absorbs temp HP first and floors at 0, healing caps at max) so the controls are exercisable without a backend.
- initiative-panel: for the DM, the Init cell becomes an editable input and a per-row damage/heal control (amount + − / + buttons) appears in a new Adjust column; players still see the read-only order. State stays authoritative — the service updates the snapshot the panel re-renders from.
- session-mode passes sessionId and dm into the panel.

Verified in demo: set Throk's initiative to 10 and the order re-sorted him above Lyra; hit Lyra (42/52 +4 temp) for 10 and HP became 36/52 with temp consumed — the 5e temp-HP rule — no console errors. ng build green in both modes.