### PR TITLE
feat: session entry buttons on sheet and dashboard; DM-only HP edits

### DIFF
--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -22,12 +22,12 @@
           </svg>
           Manage Party
         </button>
-        <button class="btn" (click)="rollInitiative(vm.campaign)">
-          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
+        <button class="btn play" (click)="startSession(vm.campaign)">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"
                style="margin-right: 6px; vertical-align: -2px;">
-            <path d="M8 1l6 3.5v7L8 15l-6-3.5v-7L8 1z"/><path d="M8 1v14M2 4.5l6 3.5 6-3.5"/>
+            <path d="M4 2.5v11l9-5.5z"/>
           </svg>
-          Roll Initiative
+          Start Session
         </button>
       </div>
     </header>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -61,9 +61,10 @@ export class CampaignDashboardComponent {
   /**
    * Open a live Session Mode lobby for this campaign and switch the main view to
    * the initiative tracker. The session is server-authoritative; we just store
-   * its id so the sidenav overlay takes over.
+   * its id so the sidenav overlay takes over. (Initiative is then entered inside
+   * the session via the DM controls.)
    */
-  rollInitiative(campaign: Campaign): void {
+  startSession(campaign: Campaign): void {
     this.sessionService.createSession(campaign.id).subscribe({
       next: state => this.uiState.openSession(String(state.sessionId)),
       error: err => console.error('Failed to start session', err),

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -42,6 +42,18 @@
 
     <!-- Action buttons -->
     <div class="sheet-actions">
+      <button
+        *ngIf="inCampaign"
+        class="btn play"
+        title="Connect to your campaign's live session"
+        (click)="connectRequested.emit()"
+      >
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"
+             style="margin-right: 6px; vertical-align: -2px;">
+          <path d="M4 2.5v11l9-5.5z"/>
+        </svg>
+        Connect
+      </button>
       <button class="btn" title="Roll dice" (click)="rollRequested.emit()">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
              style="margin-right: 6px; vertical-align: -2px;">
@@ -76,7 +88,7 @@
   <!-- ═══════════════════════════════════════════════
        VITALS STRIP
        ═══════════════════════════════════════════════ -->
-  <app-vitals-strip [pc]="pc" (hpChange)="updateHP($event)"></app-vitals-strip>
+  <app-vitals-strip [pc]="pc"></app-vitals-strip>
 
   <!-- ═══════════════════════════════════════════════
        SHEET GRID

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -13,6 +13,13 @@ export class CharacterSheetComponent implements OnChanges {
   @Output() deleteRequested = new EventEmitter<void>();
   @Output() rollRequested = new EventEmitter<void>();
   @Output() levelUpRequested = new EventEmitter<void>();
+  /** Player asks to connect to their campaign's live session. */
+  @Output() connectRequested = new EventEmitter<void>();
+
+  /** Only show the session-connect button when this PC belongs to a campaign. */
+  get inCampaign(): boolean {
+    return this.pc?.campaignId != null;
+  }
 
   editingName = false;
   nameDraft = '';
@@ -56,14 +63,6 @@ export class CharacterSheetComponent implements OnChanges {
   cancelNameEdit(): void {
     this.editingName = false;
     this.nameDraft = this.pc.name;
-  }
-
-  // ── HP ───────────────────────────────────────────────────────────────────────
-
-  updateHP(delta: number): void {
-    if (!this.pc.hp) return;
-    const cur = Math.max(0, Math.min(this.pc.hp.max, this.pc.hp.cur + delta));
-    this.pcService.updatePC({ ...this.pc, hp: { ...this.pc.hp, cur } }).subscribe();
   }
 
   // ── Conditions (wired fully in Phase 5) ─────────────────────────────────────

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
@@ -8,12 +8,6 @@
       <span *ngIf="pc.hp?.temp && pc.hp!.temp > 0" class="sub" style="color: var(--celestial)"> +{{ pc.hp!.temp }}</span>
     </div>
     <div class="vital-bar"><span [style.width.%]="hpPct"></span></div>
-    <div class="hp-controls">
-      <button class="hp-btn dmg" (click)="hpChange.emit(-1)" title="Take 1 damage">−</button>
-      <button class="hp-btn"     (click)="hpChange.emit(+1)" title="Heal 1">+</button>
-      <button class="hp-btn dmg" (click)="hpChange.emit(-5)" title="Take 5 damage">−5</button>
-      <button class="hp-btn"     (click)="hpChange.emit(+5)" title="Heal 5">+5</button>
-    </div>
   </div>
 
   <!-- AC -->

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { PC } from '../../../models/pc';
 import { hitDieFor, fmtMod } from '../../../utils/character-math';
 
@@ -9,8 +9,6 @@ import { hitDieFor, fmtMod } from '../../../utils/character-math';
 })
 export class VitalsStripComponent {
   @Input() pc!: PC;
-  /** Emits a signed HP delta (+1, -1, +5, -5). Parent clamps and persists. */
-  @Output() hpChange = new EventEmitter<number>();
 
   get hpPct(): number {
     if (!this.pc.hp) return 0;

--- a/src/app/charactermanager/components/main-content/main-content.component.html
+++ b/src/app/charactermanager/components/main-content/main-content.component.html
@@ -5,7 +5,8 @@
   [pc]="pc"
   (deleteRequested)="openDeleteModal()"
   (rollRequested)="openRollModal()"
-  (levelUpRequested)="openLevelUpModal()">
+  (levelUpRequested)="openLevelUpModal()"
+  (connectRequested)="connectToSession()">
 </app-character-sheet>
 
 <app-empty-state

--- a/src/app/charactermanager/components/main-content/main-content.component.ts
+++ b/src/app/charactermanager/components/main-content/main-content.component.ts
@@ -4,6 +4,8 @@ import { takeUntil } from 'rxjs/operators';
 import { PC } from '../../models/pc';
 import { PCService } from '../../services/pc.service';
 import { CharacterModalService } from '../../services/character-modal.service';
+import { SessionService } from '../../services/session.service';
+import { UiStateService } from '../../services/ui-state.service';
 
 @Component({
   selector: 'app-main-content',
@@ -21,7 +23,26 @@ export class MainContentComponent implements OnInit, OnDestroy {
   constructor(
     private pcService: PCService,
     private characterModal: CharacterModalService,
+    private sessionService: SessionService,
+    private uiState: UiStateService,
   ) {}
+
+  // ── Session connect ────────────────────────────────────────────────────────
+  // Join this character's campaign session if the DM has one live, then open the
+  // session screen. No-op when the PC isn't in a campaign or none is running yet.
+
+  connectToSession(): void {
+    if (!this.pc || this.pc.campaignId == null) return;
+    const campaignId = String(this.pc.campaignId);
+    const pcId = this.pc.id;
+    this.sessionService.getActiveForCampaign(campaignId).subscribe(session => {
+      if (!session) return;
+      this.sessionService.joinSession(session.sessionId, pcId).subscribe({
+        next: joined => this.uiState.openSession(String(joined.sessionId)),
+        error: err => console.error('Failed to join session', err),
+      });
+    });
+  }
 
   ngOnInit(): void {
     this.pcService.getActivePC()

--- a/src/styles.css
+++ b/src/styles.css
@@ -364,6 +364,8 @@ app-root { display: block; height: 100vh; width: 100vw; }
 }
 .btn.danger { color: var(--crimson); border-color: color-mix(in oklch, var(--crimson) 50%, transparent); }
 .btn.danger:hover { background: color-mix(in oklch, var(--crimson) 20%, transparent); border-color: var(--crimson); }
+.btn.play { color: var(--emerald); border-color: color-mix(in oklch, var(--emerald) 55%, transparent); }
+.btn.play:hover { background: color-mix(in oklch, var(--emerald) 22%, transparent); border-color: var(--emerald); color: var(--text); }
 .btn.sm { padding: 6px 10px; font-size: 9px; }
 .btn.icon {
   padding: 8px;
@@ -515,26 +517,6 @@ app-root { display: block; height: 100vh; width: 100vw; }
   border-radius: 2px;
   transition: width .25s ease-out;
 }
-.hp-controls {
-  display: flex;
-  justify-content: center;
-  gap: 4px;
-  margin-top: 8px;
-}
-.hp-btn {
-  width: 22px; height: 22px;
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-2);
-  border-radius: 2px;
-  cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  line-height: 1;
-  padding: 0;
-}
-.hp-btn:hover { border-color: var(--gold); color: var(--gold); }
-.hp-btn.dmg:hover { border-color: var(--crimson); color: var(--crimson); }
 
 /* === GRID === */
 .sheet-grid {
@@ -1776,8 +1758,6 @@ app-root { display: block; height: 100vh; width: 100vw; }
    44px touch-target guideline and lets the sheet breathe full-width.
    ════════════════════════════════════════════════════════════════════════ */
 @media (max-width: 820px) {
-  /* HP +/- steppers were 22px — too small to tap reliably. */
-  .hp-btn { width: 32px; height: 32px; font-size: 13px; }
 
   /* Generic buttons get a comfortable minimum height. */
   .btn { min-height: 44px; }


### PR DESCRIPTION
- Player character sheet: a green "Connect" button (left of Roll) joins the player's campaign session when the DM has one live, then opens the session screen. Shown only when the PC belongs to a campaign.
- DM dashboard: "Roll Initiative" becomes a green "Start Session" button (it already created the session; initiative is entered inside the session).
- Remove the player HP +/- damage/heal controls from the vitals strip — only the DM adjusts HP now, via the session initiative panel. Drops the dead hpChange plumbing and the .hp-controls/.hp-btn styles.
- Add a shared green .btn.play variant; Long Rest stays as an inert placeholder.

Verified in demo: Connect renders first/green on the sheet with HP steppers gone; Start Session replaces Roll Initiative and still opens the session overlay; no console errors. ng build green.