### PR TITLE
feat: resume a live session, and let the DM end one

### DIFF
--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -22,12 +22,19 @@
           </svg>
           Manage Party
         </button>
-        <button class="btn play" (click)="startSession(vm.campaign)">
+        <button *ngIf="!vm.liveSession" class="btn play" (click)="startSession(vm.campaign)">
           <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"
                style="margin-right: 6px; vertical-align: -2px;">
             <path d="M4 2.5v11l9-5.5z"/>
           </svg>
           Start Session
+        </button>
+        <button *ngIf="vm.liveSession" class="btn play" (click)="resumeSession(vm.campaign)">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <path d="M4 2.5v11l9-5.5z"/>
+          </svg>
+          Resume Session
         </button>
       </div>
     </header>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -7,6 +7,7 @@ import { CampaignService } from '../../services/campaign.service';
 import { PCService } from '../../services/pc.service';
 import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
+import { SessionState } from '../../models/session';
 import { passiveScore, tintFor } from '../../utils/character-math';
 
 interface DashboardVm {
@@ -15,6 +16,7 @@ interface DashboardVm {
   avgLevel: string;
   topPassivePerception: number | string;
   activeConditions: number;
+  liveSession: SessionState | null;
 }
 
 /**
@@ -41,8 +43,11 @@ export class CampaignDashboardComponent {
     switchMap(([activeId, campaigns]) => {
       const campaign = campaigns.find(c => c.id === activeId) ?? null;
       if (!campaign) return of(null);
-      return this.campaignService.getMembers(campaign.id).pipe(
-        map(members => this.buildVm(campaign, members)),
+      return combineLatest([
+        this.campaignService.getMembers(campaign.id),
+        this.sessionService.getActiveForCampaign(campaign.id),
+      ]).pipe(
+        map(([members, liveSession]) => this.buildVm(campaign, members, liveSession)),
       );
     })
   );
@@ -67,11 +72,22 @@ export class CampaignDashboardComponent {
   startSession(campaign: Campaign): void {
     this.sessionService.createSession(campaign.id).subscribe({
       next: state => this.uiState.openSession(String(state.sessionId)),
-      error: err => console.error('Failed to start session', err),
+      error: err => {
+        // Lost a race with an existing live session — just resume it.
+        if (err?.status === 409) { this.resumeSession(campaign); return; }
+        console.error('Failed to start session', err);
+      },
     });
   }
 
-  private buildVm(campaign: Campaign, members: PC[]): DashboardVm {
+  /** Re-enter the campaign's existing live session. */
+  resumeSession(campaign: Campaign): void {
+    this.sessionService.getActiveForCampaign(campaign.id).subscribe(session => {
+      if (session) this.uiState.openSession(String(session.sessionId));
+    });
+  }
+
+  private buildVm(campaign: Campaign, members: PC[], liveSession: SessionState | null): DashboardVm {
     const avgLevel = members.length
       ? (members.reduce((s, m) => s + m.level, 0) / members.length).toFixed(1)
       : '—';
@@ -79,7 +95,7 @@ export class CampaignDashboardComponent {
       ? Math.max(...members.map(m => passiveScore(m, 'Perception', 'WIS')))
       : '—';
     const activeConditions = members.reduce((s, m) => s + (m.conditions?.length ?? 0), 0);
-    return { campaign, members, avgLevel, topPassivePerception, activeConditions };
+    return { campaign, members, avgLevel, topPassivePerception, activeConditions, liveSession };
   }
 
   /**

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -12,6 +12,17 @@
       </div>
       <div class="sheet-actions">
         <button
+          *ngIf="state.dm"
+          class="btn danger"
+          (click)="endSession(state)"
+        >
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.5"
+               style="margin-right: 6px; vertical-align: -2px;">
+            <rect x="3" y="3" width="10" height="10" rx="1"/>
+          </svg>
+          End Session
+        </button>
+        <button
           *ngIf="!state.dm && myParticipantId(state) != null"
           class="btn"
           (click)="leave(state)"

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -46,6 +46,14 @@ export class SessionModeComponent implements OnInit, OnDestroy {
     return mine ? mine.participantId : null;
   }
 
+  /** The DM ends the session for everyone, then exits the screen. */
+  endSession(state: SessionState): void {
+    this.sessionService.end(state.sessionId).subscribe({
+      next: () => this.close(),
+      error: () => this.close(),
+    });
+  }
+
   /** A player removes their own PC from the session, then exits the screen. */
   leave(state: SessionState): void {
     const id = this.myParticipantId(state);

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -119,6 +119,22 @@ export class SessionService {
     );
   }
 
+  /** DM ends the session (HP/conditions are already persisted on the PCs). */
+  end(sessionId: number | string): Observable<SessionState> {
+    if (environment.demoMode) {
+      const current = this.stateSubject.getValue();
+      const ended: SessionState = current
+        ? { ...current, status: 'ENDED' }
+        : { ...this.emptyState(sessionId), status: 'ENDED' };
+      this.stateSubject.next(ended);
+      return of(ended);
+    }
+    return this.http.post<unknown>(`${this.sessionBase}/${sessionId}/end`, {}).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.stateSubject.next(state)),
+    );
+  }
+
   /** DM enters a combatant's initiative; the server (or demo) re-sorts the order. */
   setInitiative(sessionId: number | string, participantId: number, value: number): Observable<SessionState> {
     if (environment.demoMode) return of(this.demoSetInitiative(participantId, value));


### PR DESCRIPTION
Fixes the "a session is already live" 409 dead-end: there was no way to rejoin or to end a session, so they piled up and blocked new ones.

- Dashboard button reflects state: shows "Resume Session" (opens the existing one) when the campaign has a live session, "Start Session" otherwise. The check uses the existing getActiveForCampaign discovery endpoint.
- Start Session also catches a 409 (lost race) and resumes instead of erroring.
- Session screen: DM gets an "End Session" button (wires the existing end endpoint) that ends the session for everyone and exits. Close still just leaves the screen with the session live.
- SessionService.end() (demo marks the snapshot ENDED).

Pairs with the backend 4h idle auto-expiry. Verified in demo: End Session closes the screen and the dashboard returns to "Start Session"; no console errors. ng build green both modes.