### PR TITLE
feat: notify+reroute players on session end; initiative input polish

### DIFF
--- a/src/app/charactermanager/charactermanager-app.component.ts
+++ b/src/app/charactermanager/charactermanager-app.component.ts
@@ -48,6 +48,9 @@ import { CampaignDraft } from './models/campaign';
 
     <!-- Settings slide-over (its own fixed backdrop + panel) -->
     <app-settings-panel *ngIf="isSettingsOpen"></app-settings-panel>
+
+    <!-- App-wide transient notifications (e.g. the DM ended the session) -->
+    <app-toast></app-toast>
   `,
   styles: []
 })

--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -36,6 +36,7 @@ import { JoinCampaignModalComponent } from './components/join-campaign-modal/joi
 import { SessionModeComponent } from './components/session-mode/session-mode.component';
 import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
 import { SessionLiveBannerComponent } from './components/session-live-banner/session-live-banner.component';
+import { ToastComponent } from './components/toast/toast.component';
 
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MaterialModule } from '../shared/material.module';
@@ -89,6 +90,7 @@ const routes: Routes = [
     SessionModeComponent,
     InitiativePanelComponent,
     SessionLiveBannerComponent,
+    ToastComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
@@ -33,7 +33,8 @@
           *ngIf="dm; else initRead"
           type="number"
           class="init-input"
-          [ngModel]="p.initiative"
+          placeholder="0"
+          [ngModel]="p.initRolled ? p.initiative : null"
           (change)="onInitiative(p, $any($event.target).value)"
           aria-label="Initiative"
         />

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
@@ -16,6 +16,20 @@
   border-radius: 6px;
 }
 
+// No up/down spinner — DMs just type a number (mobile still gets a numeric keypad).
+.init-input::-webkit-inner-spin-button,
+.init-input::-webkit-outer-spin-button,
+.dmg-input::-webkit-inner-spin-button,
+.dmg-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.init-input,
+.dmg-input {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
 .dm-adjust {
   display: flex;
   align-items: center;

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -1,7 +1,10 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SessionState } from '../../models/session';
 import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
+import { PCService } from '../../services/pc.service';
+import { NotificationService } from '../../services/notification.service';
 
 /**
  * Session Mode screen — a full-width overlay (chosen in the sidenav over the
@@ -21,17 +24,46 @@ export class SessionModeComponent implements OnInit, OnDestroy {
 
   state$ = this.sessionService.state$;
 
+  private stateSub?: Subscription;
+  private handledEnd = false;
+
   constructor(
     private sessionService: SessionService,
     private uiState: UiStateService,
+    private pcService: PCService,
+    private notifications: NotificationService,
   ) {}
 
   ngOnInit(): void {
     this.sessionService.startPolling(this.sessionId);
+    // The DM may end the session from another device; a poll then reports ENDED.
+    this.stateSub = this.sessionService.state$.subscribe(state => {
+      if (state && state.status === 'ENDED') this.onSessionEnded(state);
+    });
   }
 
   ngOnDestroy(): void {
+    this.stateSub?.unsubscribe();
     this.sessionService.stopPolling();
+  }
+
+  /**
+   * The session ended. Players are told and routed back to their own character
+   * sheet; the DM (who ended it) just exits. Guarded so it runs once.
+   */
+  private onSessionEnded(state: SessionState): void {
+    if (this.handledEnd) return;
+    this.handledEnd = true;
+
+    if (!state.dm) {
+      const mine = state.participants.find(p => p.ownedByMe);
+      if (mine?.pcId != null) {
+        const pc = this.pcService.getPCById(mine.pcId);
+        if (pc) this.pcService.setActivePC(pc);
+      }
+      this.notifications.notify('The DM ended the session.');
+    }
+    this.close();
   }
 
   /** Leave the session screen (does not end the session server-side). */

--- a/src/app/charactermanager/components/toast/toast.component.html
+++ b/src/app/charactermanager/components/toast/toast.component.html
@@ -1,0 +1,6 @@
+<div class="toast" *ngIf="message$ | async as message" role="status" (click)="dismiss()" title="Dismiss">
+  <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.4" style="flex: none;">
+    <circle cx="8" cy="8" r="6.5"/><path d="M8 4.8v3.6M8 11h.01"/>
+  </svg>
+  <span>{{ message }}</span>
+</div>

--- a/src/app/charactermanager/components/toast/toast.component.scss
+++ b/src/app/charactermanager/components/toast/toast.component.scss
@@ -1,0 +1,34 @@
+// App-shell toast. Themed to match the app (parchment surface, celestial accent).
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(90vw, 440px);
+  padding: 12px 18px;
+  background: var(--surface-2, #1c1f2b);
+  border: 1px solid var(--celestial, #8fb4ff);
+  border-radius: 10px;
+  color: var(--text, #e8e6e3);
+  font-family: 'EB Garamond', serif;
+  font-size: 15px;
+  line-height: 1.3;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  animation: toast-in 0.2s ease-out;
+
+  svg { color: var(--celestial-2, #c0d4ff); }
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translate(-50%, 10px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+@media (max-width: 560px) {
+  .toast { bottom: 16px; max-width: 92vw; }
+}

--- a/src/app/charactermanager/components/toast/toast.component.ts
+++ b/src/app/charactermanager/components/toast/toast.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { NotificationService } from '../../services/notification.service';
+
+/**
+ * App-shell toast. Renders the current NotificationService message (if any) as a
+ * small themed, dismissible toast. Lives at the shell level so it persists when
+ * the view that raised it closes.
+ */
+@Component({
+  selector: 'app-toast',
+  templateUrl: './toast.component.html',
+  styleUrls: ['./toast.component.scss'],
+})
+export class ToastComponent {
+  message$ = this.notifications.message$;
+
+  constructor(private notifications: NotificationService) {}
+
+  dismiss(): void {
+    this.notifications.dismiss();
+  }
+}

--- a/src/app/charactermanager/services/notification.service.ts
+++ b/src/app/charactermanager/services/notification.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+/**
+ * Tiny app-wide channel for transient, themed toasts — one message at a time,
+ * auto-cleared after a timeout. Rendered by ToastComponent at the app shell so a
+ * toast survives the view it was raised from closing (e.g. a session ending and
+ * routing the player back to their sheet).
+ */
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private messageSubject = new BehaviorSubject<string | null>(null);
+  message$ = this.messageSubject.asObservable();
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  notify(message: string, durationMs = 4000): void {
+    this.messageSubject.next(message);
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => this.messageSubject.next(null), durationMs);
+  }
+
+  dismiss(): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    this.messageSubject.next(null);
+  }
+}


### PR DESCRIPTION
- When the DM ends a session, other clients' next poll reports ENDED. The session screen now reacts: a player is shown a themed toast ("The DM ended the session.") and routed back to their own character sheet (their session PC is set active on the way out); the DM just exits.
- Add a small app-wide NotificationService + ToastComponent rendered at the app shell, so the toast survives the session overlay closing.
- Initiative input: show an empty field with a "0" placeholder until a value is entered (bind to initRolled ? initiative : null), so the 0 is a hint that clears on typing instead of a literal value.
- Hide the number-input spin arrows on the initiative/damage fields (desktop); type="number" stays so phones keep the numeric keypad.

Verified in demo: toast mounts in the shell, init field shows placeholder 0 with spinners gone (appearance: textfield); no console errors. ng build green both modes. (Player end-reroute path is real-mode/multi-client.)