### PR TITLE
fix: show the signed-in user, not the Quill Ashford placeholder

### DIFF
--- a/src/app/charactermanager/charactermanager-app.component.ts
+++ b/src/app/charactermanager/charactermanager-app.component.ts
@@ -8,6 +8,7 @@ import { CharacterModalService } from './services/character-modal.service';
 import { CampaignModalService } from './services/campaign-modal.service';
 import { JoinModalService, JoinRequest } from './services/join-modal.service';
 import { UiStateService } from './services/ui-state.service';
+import { CurrentUserService } from './services/current-user.service';
 import { CampaignDraft } from './models/campaign';
 
 @Component({
@@ -69,10 +70,14 @@ export class CharactermanagerAppComponent implements OnInit, OnDestroy {
     private campaignModal: CampaignModalService,
     private joinModal: JoinModalService,
     private uiState: UiStateService,
+    private currentUser: CurrentUserService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
+    // Reflect the signed-in user (handles re-login without a full reload).
+    this.currentUser.refresh();
+
     this.subs.push(
       this.pcService.pcs$.subscribe(pcs => { this.pcs = pcs; }),
 

--- a/src/app/charactermanager/components/create-character-modal/create-character-modal.component.spec.ts
+++ b/src/app/charactermanager/components/create-character-modal/create-character-modal.component.spec.ts
@@ -68,7 +68,7 @@ describe('CreateCharacterModalComponent — logic', () => {
   beforeEach(() => {
     dndResources = makeMockDndResources();
     auth = jasmine.createSpyObj<AuthService>('AuthService', ['getUsername']);
-    auth.getUsername.and.returnValue('quill');
+    auth.getUsername.and.returnValue('tester');
     component = new CreateCharacterModalComponent(dndResources, auth);
     component.ngOnInit();
   });

--- a/src/app/charactermanager/services/current-user.service.ts
+++ b/src/app/charactermanager/services/current-user.service.ts
@@ -1,24 +1,69 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
 import { CurrentUser } from '../models/campaign';
+import { AuthService } from './auth.service';
 
 /**
- * Source of the signed-in user shown in the account row / settings header.
+ * The signed-in user shown in the account row / settings header.
  *
- * Phase 1 returns a demo DM. The seam is deliberate: Phase 3+ will populate
- * this from the real auth/session (the JWT principal) without any caller change.
+ * The display name is the username captured at login (also the JWT subject); the
+ * email is enriched from the auth service's /authorize endpoint when available.
+ * A single object reference is mutated in place so views that read {@link getUser}
+ * pick up the values via change detection without re-querying.
  */
 @Injectable({ providedIn: 'root' })
 export class CurrentUserService {
   private user: CurrentUser = {
-    name: 'Quill Ashford',
-    email: 'quill@tablemimic.app',
-    initials: 'QA',
+    name: 'Adventurer',
+    email: '',
+    initials: 'AD',
     tint: 'gold',
-    title: 'Keeper of Chronicles',
-    member_since: 'Spring 2023',
   };
+
+  constructor(private http: HttpClient, private auth: AuthService) {
+    this.refresh();
+  }
 
   getUser(): CurrentUser {
     return this.user;
+  }
+
+  /**
+   * Populate the account display from the current session: the username is the
+   * display name immediately; the email (and any fuller name) is filled in from
+   * the auth service. Safe to call again on re-entering the app shell.
+   */
+  refresh(): void {
+    const username = this.auth.getUsername();
+    this.user.name = username || 'Adventurer';
+    this.user.initials = this.initialsOf(this.user.name);
+    this.user.email = '';
+
+    if (environment.demoMode) return;
+
+    const token = this.auth.getToken();
+    if (!token) return;
+    // The auth interceptor skips /api/v1/auth/* URLs, so attach the token here.
+    this.http.get<any>(`${environment.authApiUrl}/api/v1/auth/authorize`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }).subscribe({
+      next: dto => {
+        if (dto?.email) this.user.email = dto.email;
+        const name = dto?.userName ?? dto?.username;
+        if (name) {
+          this.user.name = name;
+          this.user.initials = this.initialsOf(name);
+        }
+      },
+      error: () => { /* keep the username-derived display, no email */ },
+    });
+  }
+
+  /** Up to two uppercase initials from a name ("john smith" → "JS", "dm" → "DM"). */
+  private initialsOf(name: string): string {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    const letters = parts.length >= 2 ? parts[0][0] + parts[1][0] : name.trim().slice(0, 2);
+    return letters.toUpperCase();
   }
 }


### PR DESCRIPTION
The account row / settings header always showed a hardcoded demo user ("Quill Ashford") because CurrentUserService returned a fixed object. Now it reflects the real session:

- Display name = the username captured at login (the JWT subject); initials are derived from it.
- Email is enriched from the auth service's GET /api/v1/auth/authorize (the token is attached explicitly since the interceptor skips /auth/* URLs); blank if unavailable rather than fabricated.
- Dropped the fabricated title/"member since" flavor (the settings header line is already *ngIf-guarded, so it just hides).
- Refresh on entering the app shell so it updates after re-login without a reload. Renamed the leftover 'quill' test mock username.

Verified in demo: logging in as "gandalf" shows gandalf / GA across the account row and settings, no "Quill" anywhere, no console errors. ng build green.