### PR TITLE
feat: make browser Back close in-app overlays instead of logging out

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,13 +10,15 @@ import { RegisterComponent } from './charactermanager/components/register/regist
 import { FormsModule } from '@angular/forms';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { AuthInterceptor } from './interceptors/auth.interceptor';
+import { AuthGuard } from './guards/auth.guard';
+import { GuestGuard } from './guards/guest.guard';
 
 
 const routes: Routes = [
   { path: '',             redirectTo: 'login', pathMatch: 'full' },
-  { path: 'login',        component: LoginComponent },
-  { path: 'register',     component: RegisterComponent },
-  { path: 'charactermanager', loadChildren: () => import('./charactermanager/charactermanager.module').then(m => m.CharactermanagerModule) }
+  { path: 'login',        component: LoginComponent,    canActivate: [GuestGuard] },
+  { path: 'register',     component: RegisterComponent, canActivate: [GuestGuard] },
+  { path: 'charactermanager', canActivate: [AuthGuard], loadChildren: () => import('./charactermanager/charactermanager.module').then(m => m.CharactermanagerModule) }
 ];
 
 @NgModule({

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -106,7 +106,8 @@ export class CampaignDashboardComponent {
   openHero(pc: PC): void {
     const full = this.pcService.getPCById(pc.id) ?? pc;
     this.pcService.setActivePC(full);
-    this.uiState.setRole('player');
+    // Records a history entry so browser Back returns to this dashboard.
+    this.uiState.viewHeroAsDm();
   }
 
   // --- Manage Party (bind/unbind characters) -------------------------------

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -44,7 +44,9 @@ export class SessionModeComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stateSub?.unsubscribe();
-    this.sessionService.stopPolling();
+    // clear() (not just stopPolling) so closing via browser Back tears the
+    // session down exactly like the in-app Close button does.
+    this.sessionService.clear();
   }
 
   /**

--- a/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
+++ b/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
@@ -57,7 +57,9 @@ export class SettingsPanelComponent {
   }
 
   signOut(): void {
-    this.close();
+    // Leaving the app entirely — drop any open overlays without juggling history
+    // (the redirect to /login discards the pushed entries anyway).
+    this.uiState.resetOverlays();
     this.auth.logout();
   }
 }

--- a/src/app/charactermanager/services/ui-state.service.ts
+++ b/src/app/charactermanager/services/ui-state.service.ts
@@ -4,12 +4,26 @@ import { BehaviorSubject } from 'rxjs';
 export type Role = 'player' | 'dm';
 
 /**
+ * In-app, full-screen-ish views that are *not* routes but should still respond
+ * to the browser Back button: the live-session overlay, the settings slide-over,
+ * and a DM cross-linked into a member's sheet. Each one pushes a single history
+ * entry when opened; pressing Back (or an in-app close button) unwinds exactly
+ * one. See the history plumbing at the bottom of this service.
+ */
+type Overlay = 'session' | 'settings' | 'dmHero';
+
+/**
  * Holds app-level UI state that is *not* a route: the Player/DM role, which
  * campaign is selected in DM mode, and whether the settings slide-over is open.
  *
  * The active *character* deliberately stays in PCService (single source of
  * truth); the DM→player cross-link just calls PCService.setActivePC together
- * with setRole('player') here.
+ * with viewHeroAsDm() here.
+ *
+ * Because none of these views are real routes, the browser history would only
+ * ever hold [..., /login, /charactermanager] and Back would jump straight out of
+ * the app. To fix that this service mirrors each open overlay with a real
+ * history entry, so Back closes the overlay instead of leaving the route.
  */
 @Injectable({ providedIn: 'root' })
 export class UiStateService {
@@ -27,15 +41,126 @@ export class UiStateService {
   private activeSessionIdSubject = new BehaviorSubject<string | null>(null);
   activeSessionId$ = this.activeSessionIdSubject.asObservable();
 
+  // Overlays we've pushed a browser-history entry for, oldest first. Mirrors the
+  // history entries we created so that Back and our own close buttons stay in
+  // lock-step.
+  private overlayStack: Overlay[] = [];
+  // Number of upcoming popstate events that we triggered ourselves (via
+  // history.back() from an in-app close) and must therefore ignore.
+  private selfPops = 0;
+
+  constructor() {
+    window.addEventListener('popstate', this.onPopState);
+  }
+
   get role(): Role { return this.roleSubject.getValue(); }
 
   setRole(role: Role): void { this.roleSubject.next(role); }
 
   setActiveCampaign(id: string | null): void { this.activeCampaignIdSubject.next(id); }
 
-  openSettings(): void  { this.settingsOpenSubject.next(true); }
-  closeSettings(): void { this.settingsOpenSubject.next(false); }
+  // ── Settings slide-over ───────────────────────────────────────────────────
+  openSettings(): void {
+    if (this.settingsOpenSubject.getValue()) return;     // guard a double-open
+    this.settingsOpenSubject.next(true);
+    this.pushOverlay('settings');
+  }
 
-  openSession(sessionId: string): void { this.activeSessionIdSubject.next(sessionId); }
-  closeSession(): void { this.activeSessionIdSubject.next(null); }
+  closeSettings(): void {
+    if (!this.settingsOpenSubject.getValue()) return;
+    this.settingsOpenSubject.next(false);
+    this.unwind('settings');
+  }
+
+  // ── Live session overlay ──────────────────────────────────────────────────
+  openSession(sessionId: string): void {
+    const firstOpen = this.activeSessionIdSubject.getValue() === null;
+    this.activeSessionIdSubject.next(sessionId);
+    if (firstOpen) this.pushOverlay('session');          // guard against re-push
+  }
+
+  closeSession(): void {
+    if (this.activeSessionIdSubject.getValue() === null) return;
+    this.activeSessionIdSubject.next(null);
+    this.unwind('session');
+  }
+
+  // ── DM → hero cross-link ──────────────────────────────────────────────────
+  /**
+   * A DM opens one of their campaign members' sheets (which switches the main
+   * view to Player mode). Recorded as an overlay so Back returns the DM to their
+   * campaign dashboard rather than leaving the app.
+   */
+  viewHeroAsDm(): void {
+    this.roleSubject.next('player');
+    if (this.overlayStack[this.overlayStack.length - 1] !== 'dmHero') {
+      this.pushOverlay('dmHero');
+    }
+  }
+
+  /**
+   * Tear down every overlay *without* touching history — used on sign-out, when
+   * we navigate away from the app entirely and the pushed entries get discarded
+   * with the forward history anyway.
+   */
+  resetOverlays(): void {
+    this.overlayStack = [];
+    this.settingsOpenSubject.next(false);
+    this.activeSessionIdSubject.next(null);
+  }
+
+  // ── history plumbing ──────────────────────────────────────────────────────
+  private onPopState = (): void => {
+    // A history.back() that we issued ourselves — the matching close already ran.
+    if (this.selfPops > 0) { this.selfPops--; return; }
+    // The user pressed Back: undo the topmost overlay we own. If we own none,
+    // do nothing and let the router handle it (e.g. leaving the app, where the
+    // auth guard then bounces an authenticated user straight back in).
+    const top = this.overlayStack.pop();
+    if (top) this.applyClose(top);
+  };
+
+  private pushOverlay(kind: Overlay): void {
+    this.overlayStack.push(kind);
+    history.pushState({ tmOverlay: kind }, '');
+  }
+
+  /**
+   * Programmatic close (an in-app Close/Back button already flipped the state):
+   * drop our matching history entry so the browser stays in sync. The popstate
+   * this triggers is ours, so onPopState ignores it (selfPops).
+   */
+  private unwind(kind: Overlay): void {
+    const i = this.overlayStack.lastIndexOf(kind);
+    if (i === -1) return;                       // Back already consumed it
+    if (i === this.overlayStack.length - 1) {
+      // Only the newest entry can be unwound through the browser, since Back
+      // always pops the most recent history entry.
+      this.overlayStack.pop();
+      this.selfPops++;
+      history.back();
+    } else {
+      // Rare: closed out of order (e.g. an overlay underneath a still-open one).
+      // Just forget our record; its stale history entry becomes a harmless no-op.
+      this.overlayStack.splice(i, 1);
+    }
+  }
+
+  /** Reverse an overlay's state. Invoked when the user pressed browser Back. */
+  private applyClose(kind: Overlay): void {
+    switch (kind) {
+      case 'settings':
+        this.settingsOpenSubject.next(false);
+        break;
+      case 'session':
+        // SessionMode's ngOnDestroy stops polling and clears the snapshot when
+        // the overlay leaves the DOM; we only drop the route-level flag here.
+        this.activeSessionIdSubject.next(null);
+        break;
+      case 'dmHero':
+        // Back from a cross-linked hero sheet returns the DM to their dashboard.
+        this.roleSubject.next('dm');
+        break;
+    }
+  }
 }

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../charactermanager/services/auth.service';
+
+/**
+ * Protects the in-app /charactermanager route: a signed-in user is let through,
+ * anyone else is bounced to the login screen. Pairs with GuestGuard so the
+ * browser Back button can never land on a screen the auth state forbids.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    return this.auth.isAuthenticated() ? true : this.router.parseUrl('/login');
+  }
+}

--- a/src/app/guards/guest.guard.ts
+++ b/src/app/guards/guest.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../charactermanager/services/auth.service';
+
+/**
+ * Guards the login/register screens against an already signed-in user. This is
+ * what makes browser Back safe: when Back lands on /login, the guard immediately
+ * redirects an authenticated user back into the app, so the login form is never
+ * shown to someone who is already logged in.
+ */
+@Injectable({ providedIn: 'root' })
+export class GuestGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean | UrlTree {
+    return this.auth.isAuthenticated() ? this.router.parseUrl('/charactermanager') : true;
+  }
+}


### PR DESCRIPTION
Browser Back jumped straight to /login from anywhere in the app because the session/settings/DM-hero views are state-driven (UiStateService), not routes, so history only held [/login, /charactermanager] with no guards.

A — Route guards: AuthGuard redirects /charactermanager to /login when not authenticated; GuestGuard redirects /login and /register to /charactermanager when already signed in, so Back landing on /login bounces an authed user straight back (login never shown) and deep-links are auth-safe.

B — History-sync overlays: UiStateService now pushes one history entry when the session overlay, settings slide-over, or DM->hero cross-link opens and reverses it on popstate, so Back closes the overlay instead of leaving the route. In-app Close/Back buttons unwind the matching entry (history.back) to stay in sync; sign-out clears overlays without history juggling.