### PR TITLE
feat: let a DM edit a campaign member's sheet numbers inline

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -7,6 +7,7 @@ import { MainContentComponent } from './components/main-content/main-content.com
 import { SidenavComponent } from './components/sidenav/sidenav.component';
 import { CharacterSheetComponent } from './components/character-sheet/character-sheet.component';
 import { VitalsStripComponent } from './components/character-sheet/vitals-strip/vitals-strip.component';
+import { EditableNumberComponent } from './components/character-sheet/editable-number/editable-number.component';
 import { EmptyStateComponent } from './components/character-sheet/empty-state/empty-state.component';
 import { AbilityScoresComponent } from './components/character-sheet/panels/ability-scores/ability-scores.component';
 import { SkillsListComponent } from './components/character-sheet/panels/skills-list/skills-list.component';
@@ -68,6 +69,7 @@ const routes: Routes = [
     LevelUpModalComponent,
     CharacterSheetComponent,
     VitalsStripComponent,
+    EditableNumberComponent,
     EmptyStateComponent,
     AbilityScoresComponent,
     SkillsListComponent,

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -99,14 +99,31 @@ export class CampaignDashboardComponent {
   }
 
   /**
-   * Cross-link: open the clicked hero's full sheet in Player mode. For the DM's
-   * own characters we have the full PC locally; for other players' members we
-   * only hold the (privacy-limited) projection, which is all the DM may see.
+   * Cross-link: open the clicked hero's full sheet in Player mode, where the DM
+   * can edit it inline. For the DM's own characters the full PC is already in the
+   * local store. For other players' members we only hold the privacy-limited
+   * projection, so we fetch the complete sheet via the DM-authorized path before
+   * opening (the dashboard only ever lists members the DM is allowed to edit).
    */
   openHero(pc: PC): void {
-    const full = this.pcService.getPCById(pc.id) ?? pc;
-    this.pcService.setActivePC(full);
-    this.uiState.viewHeroAsDm();
+    const owned = this.pcService.getPCById(pc.id);
+    if (owned) {
+      this.pcService.setActivePC(owned);
+      this.uiState.viewHeroAsDm();
+      return;
+    }
+    this.pcService.getPCByIdAsDm(pc.id).subscribe({
+      next: full => {
+        this.pcService.setActivePC(full?.id ? full : pc);
+        this.uiState.viewHeroAsDm();
+      },
+      error: err => {
+        // Fall back to the projection (read-only edits will 403) so the sheet still opens.
+        console.error('Failed to load full character for DM edit', err);
+        this.pcService.setActivePC(pc);
+        this.uiState.viewHeroAsDm();
+      },
+    });
   }
 
   // --- Manage Party (bind/unbind characters) -------------------------------

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -36,7 +36,14 @@
         <span class="dot">✦</span>
         {{ pc.clazz }} <em style="color: var(--text-dim)">({{ pc.subclass }})</em>
         <span class="dot">✦</span>
-        Level {{ pc.level }}
+        Level
+        <app-editable-number
+          [value]="pc.level"
+          [editable]="editable"
+          [min]="1" [max]="20"
+          label="level"
+          (committed)="onLevelCommit($event)"
+        >{{ pc.level }}</app-editable-number>
       </div>
     </div>
 
@@ -95,14 +102,22 @@
   <!-- ═══════════════════════════════════════════════
        VITALS STRIP
        ═══════════════════════════════════════════════ -->
-  <app-vitals-strip [pc]="pc"></app-vitals-strip>
+  <app-vitals-strip
+    [pc]="pc"
+    [editable]="editable"
+    (pcChange)="onPcChange($event)">
+  </app-vitals-strip>
 
   <!-- ═══════════════════════════════════════════════
        SHEET GRID
        ═══════════════════════════════════════════════ -->
   <div class="sheet-grid">
     <div class="col-left">
-      <app-ability-scores [pc]="pc"></app-ability-scores>
+      <app-ability-scores
+        [pc]="pc"
+        [editable]="editable"
+        (pcChange)="onPcChange($event)">
+      </app-ability-scores>
       <app-skills-list    [pc]="pc"></app-skills-list>
     </div>
     <div class="col-right">
@@ -113,10 +128,16 @@
       <app-equipment-panel  [pc]="pc"></app-equipment-panel>
       <app-spellbook-panel
         [pc]="pc"
-        (slotToggled)="onSlotToggle($event.level, $event.index)">
+        [editable]="editable"
+        (slotToggled)="onSlotToggle($event.level, $event.index)"
+        (pcChange)="onPcChange($event)">
       </app-spellbook-panel>
       <app-features-list    [pc]="pc"></app-features-list>
-      <app-coin-purse       [pc]="pc"></app-coin-purse>
+      <app-coin-purse
+        [pc]="pc"
+        [editable]="editable"
+        (pcChange)="onPcChange($event)">
+      </app-coin-purse>
       <app-background-story [pc]="pc"></app-background-story>
     </div>
   </div>

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -10,6 +10,12 @@ import { tintFor } from '../../utils/character-math';
 })
 export class CharacterSheetComponent implements OnChanges {
   @Input() pc!: PC;
+  /**
+   * When true, the sheet's numbers become click-to-edit and changes persist via
+   * the DM-authorized path. Driven by UiState.dmReturn$ — i.e. a DM viewing one
+   * of their campaign members (cross-linked from the dashboard).
+   */
+  @Input() editable = false;
   @Output() deleteRequested = new EventEmitter<void>();
   @Output() rollRequested = new EventEmitter<void>();
   @Output() levelUpRequested = new EventEmitter<void>();
@@ -35,15 +41,37 @@ export class CharacterSheetComponent implements OnChanges {
 
   editingName = false;
   nameDraft = '';
+  editingLevel = false;
+  levelDraft: number | null = null;
 
   constructor(private pcService: PCService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['pc']) {
-      // Reset name edit state whenever a new PC is loaded
+      // Reset edit state whenever a new PC is loaded
       this.editingName = false;
       this.nameDraft = this.pc?.name ?? '';
+      this.editingLevel = false;
+      this.levelDraft = this.pc?.level ?? 1;
     }
+  }
+
+  /**
+   * Persist an updated PC. In editable (DM cross-link) mode this goes through the
+   * DM-authorized path so a DM may save another player's character; otherwise it
+   * uses the owner path. PCService pushes the result into activePC$, so the sheet
+   * refreshes itself.
+   */
+  private persist(updated: PC): void {
+    const save$ = this.editable
+      ? this.pcService.updatePCAsDm(updated)
+      : this.pcService.updatePC(updated);
+    save$.subscribe({ error: err => console.error('Failed to save character', err) });
+  }
+
+  /** A child panel emitted a fully-updated PC (e.g. an ability score changed). */
+  onPcChange(updated: PC): void {
+    this.persist(updated);
   }
 
   // ── Portrait helpers ────────────────────────────────────────────────────────
@@ -66,7 +94,7 @@ export class CharacterSheetComponent implements OnChanges {
     this.editingName = false;
     const trimmed = this.nameDraft.trim();
     if (trimmed && trimmed !== this.pc.name) {
-      this.pcService.updatePC({ ...this.pc, name: trimmed }).subscribe();
+      this.persist({ ...this.pc, name: trimmed });
     } else {
       this.nameDraft = this.pc.name;
     }
@@ -77,6 +105,14 @@ export class CharacterSheetComponent implements OnChanges {
     this.nameDraft = this.pc.name;
   }
 
+  // ── Level editing (DM cross-link) ───────────────────────────────────────────
+  // Level drives proficiency and the hit-dice pool display; editing it here keeps
+  // the header as the single place a level is shown and changed.
+
+  onLevelCommit(level: number): void {
+    this.persist({ ...this.pc, level });
+  }
+
   // ── Conditions (wired fully in Phase 5) ─────────────────────────────────────
 
   onConditionToggle(condition: string): void {
@@ -84,7 +120,7 @@ export class CharacterSheetComponent implements OnChanges {
     const next = conditions.includes(condition)
       ? conditions.filter(c => c !== condition)
       : [...conditions, condition];
-    this.pcService.updatePC({ ...this.pc, conditions: next }).subscribe();
+    this.persist({ ...this.pc, conditions: next });
   }
 
   // ── Spell slots (wired fully in Phase 5) ────────────────────────────────────
@@ -95,6 +131,6 @@ export class CharacterSheetComponent implements OnChanges {
     if (!slot) return;
     const used = index < slot.used ? index : index + 1;
     slots[level] = { ...slot, used: Math.min(slot.max, Math.max(0, used)) };
-    this.pcService.updatePC({ ...this.pc, spellSlots: slots }).subscribe();
+    this.persist({ ...this.pc, spellSlots: slots });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.html
+++ b/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.html
@@ -1,0 +1,26 @@
+<!-- One projection outlet only — multiple <ng-content> would leave the display
+     empty in whichever branch isn't the projection target. The input replaces
+     the value only while actively editing. -->
+<input
+  *ngIf="editable && editing"
+  #input
+  type="number"
+  class="num-edit"
+  [min]="min"
+  [max]="max"
+  [attr.aria-label]="label"
+  [(ngModel)]="draft"
+  (blur)="commit()"
+  (keydown.enter)="commit()"
+  (keydown.escape)="cancel()"
+>
+<span
+  *ngIf="!(editable && editing)"
+  [class.num-editable]="editable"
+  [attr.role]="editable ? 'button' : null"
+  [attr.tabindex]="editable ? 0 : null"
+  [attr.aria-label]="editable ? ('Edit ' + label) : null"
+  [attr.title]="editable ? ('Click to edit ' + label) : null"
+  (click)="start()"
+  (keydown.enter)="start()"
+><ng-content></ng-content></span>

--- a/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.scss
+++ b/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.scss
@@ -1,0 +1,44 @@
+:host {
+  display: inline;
+}
+
+/* Subtle affordance so a DM can tell a number is editable, without shouting. */
+.num-editable {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0 2px;
+  border-bottom: 1px dashed color-mix(in oklch, var(--celestial) 55%, transparent);
+  transition: background 120ms ease;
+}
+
+.num-editable:hover,
+.num-editable:focus-visible {
+  background: color-mix(in oklch, var(--celestial) 16%, transparent);
+  outline: none;
+}
+
+/* Inline input inherits the surrounding font (size/weight/colour) so the value
+   doesn't visually jump between display and edit. Width tracks its content. */
+.num-edit {
+  font: inherit;
+  color: inherit;
+  width: 3.5ch;
+  max-width: 6ch;
+  text-align: center;
+  background: var(--surface-1, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--celestial);
+  border-radius: 4px;
+  padding: 0 2px;
+}
+
+/* Trim the native number spinners — they crowd the inline value. */
+.num-edit::-webkit-outer-spin-button,
+.num-edit::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.num-edit {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}

--- a/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.ts
+++ b/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.ts
@@ -1,0 +1,71 @@
+import {
+  ChangeDetectionStrategy, Component, ElementRef, EventEmitter,
+  Input, Output, ViewChild,
+} from '@angular/core';
+
+/**
+ * A single number shown inline that a DM can click to edit. Mirrors the sheet's
+ * name-edit pattern (click → input → commit on blur/Enter, Escape cancels) but
+ * for numeric values, and keeps the clamping rules in one place.
+ *
+ * Presentational: the parent supplies the display text via content projection
+ * (so it can format freely, e.g. "+4"), passes the raw {@link value} for the
+ * editor, and reacts to {@link committed}. When {@link editable} is false it
+ * renders the projected content unchanged — no affordance, no behaviour.
+ */
+@Component({
+  selector: 'app-editable-number',
+  templateUrl: './editable-number.component.html',
+  styleUrls: ['./editable-number.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EditableNumberComponent {
+  @Input() value: number | null | undefined = 0;
+  @Input() editable = false;
+  /** Inclusive bounds; null = unbounded on that side. */
+  @Input() min: number | null = 0;
+  @Input() max: number | null = null;
+  /** Accessible label, also used for the click hint. */
+  @Input() label = 'value';
+
+  @Output() committed = new EventEmitter<number>();
+
+  @ViewChild('input') inputRef?: ElementRef<HTMLInputElement>;
+
+  editing = false;
+  draft: number | null = null;
+
+  start(): void {
+    if (!this.editable) return;
+    this.draft = this.value ?? 0;
+    this.editing = true;
+    // Input renders after this change-detection pass; focus + select on the next tick.
+    setTimeout(() => {
+      this.inputRef?.nativeElement.focus();
+      this.inputRef?.nativeElement.select();
+    });
+  }
+
+  commit(): void {
+    if (!this.editing) return;
+    this.editing = false;
+    if (this.draft === null || this.draft === undefined || isNaN(Number(this.draft))) {
+      return; // reject blank / non-numeric — keep the existing value
+    }
+    const clamped = this.clamp(Math.round(Number(this.draft)));
+    if (clamped !== (this.value ?? 0)) {
+      this.committed.emit(clamped);
+    }
+  }
+
+  cancel(): void {
+    this.editing = false;
+  }
+
+  private clamp(n: number): number {
+    let v = n;
+    if (this.min !== null) v = Math.max(this.min, v);
+    if (this.max !== null) v = Math.min(this.max, v);
+    return v;
+  }
+}

--- a/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.html
@@ -11,7 +11,10 @@
       <div class="ability-save">save</div>
       <div class="ability-name">{{ row.label }}</div>
       <div class="ability-mod">{{ row.mod }}</div>
-      <div class="ability-score">{{ row.score }}</div>
+      <div class="ability-score"><app-editable-number
+        [value]="row.score" [editable]="editable" [min]="1" [max]="30"
+        [label]="row.label + ' score'" (committed)="setScore(row.key, $event)"
+      >{{ row.score }}</app-editable-number></div>
     </div>
   </div>
 </div>

--- a/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { PC } from '../../../../models/pc';
 import { modFromScore, fmtMod } from '../../../../utils/character-math';
 
@@ -18,6 +18,9 @@ interface AbilityRow {
 })
 export class AbilityScoresComponent implements OnChanges {
   @Input() pc!: PC;
+  /** DM cross-link: makes each ability score click-to-edit. */
+  @Input() editable = false;
+  @Output() pcChange = new EventEmitter<PC>();
 
   rows: AbilityRow[] = [];
 
@@ -38,5 +41,15 @@ export class AbilityScoresComponent implements OnChanges {
         isSaveProf: this.pc.saves?.includes(key as any) ?? false,
       };
     });
+  }
+
+  /** Edit one ability score; the modifier display recomputes on the refresh. */
+  setScore(key: string, value: number): void {
+    const stats = {
+      STR: 10, DEX: 10, CON: 10, INT: 10, WIS: 10, CHA: 10,
+      ...(this.pc.stats ?? {}),
+    } as NonNullable<PC['stats']>;
+    stats[key as keyof typeof stats] = value;
+    this.pcChange.emit({ ...this.pc, stats });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.html
@@ -7,7 +7,10 @@
   </div>
   <div class="currency">
     <div *ngFor="let coin of coinTypes" class="coin {{ coin.key }}">
-      <div class="coin-amt numeric">{{ coinAmt(coin.key) }}</div>
+      <div class="coin-amt numeric"><app-editable-number
+        [value]="coinAmt(coin.key)" [editable]="editable" [min]="0"
+        [label]="coin.label + ' coins'" (committed)="setCoin(coin.key, $event)"
+      >{{ coinAmt(coin.key) }}</app-editable-number></div>
       <div class="coin-name">{{ coin.label }}</div>
     </div>
   </div>

--- a/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PC } from '../../../../models/pc';
 
 @Component({
@@ -8,6 +8,9 @@ import { PC } from '../../../../models/pc';
 })
 export class CoinPurseComponent {
   @Input() pc!: PC;
+  /** DM cross-link: makes each coin amount click-to-edit. */
+  @Input() editable = false;
+  @Output() pcChange = new EventEmitter<PC>();
 
   readonly coinTypes = [
     { key: 'cp', label: 'Copper' },
@@ -25,5 +28,12 @@ export class CoinPurseComponent {
 
   coinAmt(key: string): number {
     return (this.pc.coins as any)?.[key] ?? 0;
+  }
+
+  /** Edit one coin denomination; the gp-equivalent recomputes on the refresh. */
+  setCoin(key: string, value: number): void {
+    const coins = { cp: 0, sp: 0, ep: 0, gp: 0, pp: 0, ...(this.pc.coins ?? {}) };
+    (coins as any)[key] = value;
+    this.pcChange.emit({ ...this.pc, coins });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.html
@@ -18,13 +18,26 @@
       <div class="spell-level-header">
         <span class="spell-level-name">{{ level.label }}</span>
         <div *ngIf="level.slots" class="spell-slots">
-          <button
-            *ngFor="let i of level.slotIndices"
-            class="spell-slot"
-            [class.used]="i < level.slots!.used"
-            (click)="slotToggled.emit({ level: level.lvl, index: i })"
-            [title]="i < level.slots!.used ? 'Restore slot' : 'Expend slot'"
-          ></button>
+          <ng-container *ngIf="!editable">
+            <button
+              *ngFor="let i of level.slotIndices"
+              class="spell-slot"
+              [class.used]="i < level.slots!.used"
+              (click)="slotToggled.emit({ level: level.lvl, index: i })"
+              [title]="i < level.slots!.used ? 'Restore slot' : 'Expend slot'"
+            ></button>
+          </ng-container>
+          <span *ngIf="editable" class="slot-edit">
+            <app-editable-number
+              [value]="level.slots!.used" [editable]="true" [min]="0" [max]="level.slots!.max"
+              label="slots used" (committed)="setSlot(level.lvl, 'used', $event)"
+            >{{ level.slots!.used }}</app-editable-number>
+            <span class="slot-edit-sep">/</span>
+            <app-editable-number
+              [value]="level.slots!.max" [editable]="true" [min]="0"
+              label="slots max" (committed)="setSlot(level.lvl, 'max', $event)"
+            >{{ level.slots!.max }}</app-editable-number>
+          </span>
         </div>
       </div>
 

--- a/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.ts
@@ -17,7 +17,10 @@ export interface SpellLevel {
 })
 export class SpellbookPanelComponent implements OnChanges {
   @Input() pc!: PC;
+  /** DM cross-link: replaces the slot pips with editable used/max numbers. */
+  @Input() editable = false;
   @Output() slotToggled = new EventEmitter<{ level: number; index: number }>();
+  @Output() pcChange = new EventEmitter<PC>();
 
   hasSpells   = false;
   spellsByLevel: SpellLevel[] = [];
@@ -55,5 +58,17 @@ export class SpellbookPanelComponent implements OnChanges {
   toggleExpand(name: string): void {
     // New object reference required for OnPush change detection
     this.expandedSpells = { ...this.expandedSpells, [name]: !this.expandedSpells[name] };
+  }
+
+  // ── DM slot editing ──────────────────────────────────────────────────────
+  // Edit a spell level's used/max slot counts, keeping used within [0, max].
+
+  setSlot(level: number, field: 'used' | 'max', value: number): void {
+    const slots = { ...(this.pc.spellSlots ?? {}) };
+    const existing = slots[level] ?? { max: 0, used: 0 };
+    const next = { ...existing, [field]: value };
+    next.used = Math.max(0, Math.min(next.used, next.max));
+    slots[level] = next;
+    this.pcChange.emit({ ...this.pc, spellSlots: slots });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
@@ -4,8 +4,17 @@
   <div class="vital">
     <span class="eyebrow">Hit Points</span>
     <div class="vital-value numeric">
-      {{ pc.hp?.cur }}<span class="sub">/{{ pc.hp?.max }}</span>
-      <span *ngIf="pc.hp?.temp && pc.hp!.temp > 0" class="sub" style="color: var(--celestial)"> +{{ pc.hp!.temp }}</span>
+      <app-editable-number
+        [value]="pc.hp?.cur" [editable]="editable" [min]="0" [max]="pc.hp?.max ?? null"
+        label="current HP" (committed)="setHp('cur', $event)"
+      >{{ pc.hp?.cur }}</app-editable-number><span class="sub">/<app-editable-number
+        [value]="pc.hp?.max" [editable]="editable" [min]="0"
+        label="max HP" (committed)="setHp('max', $event)"
+      >{{ pc.hp?.max }}</app-editable-number></span>
+      <span *ngIf="editable || (pc.hp?.temp && pc.hp!.temp > 0)" class="sub" style="color: var(--celestial)"> +<app-editable-number
+        [value]="pc.hp?.temp" [editable]="editable" [min]="0"
+        label="temporary HP" (committed)="setHp('temp', $event)"
+      >{{ pc.hp?.temp ?? 0 }}</app-editable-number></span>
     </div>
     <div class="vital-bar"><span [style.width.%]="hpPct"></span></div>
   </div>
@@ -13,28 +22,40 @@
   <!-- AC -->
   <div class="vital">
     <span class="eyebrow">Armor Class</span>
-    <div class="vital-value numeric">{{ pc.ac ?? '—' }}</div>
+    <div class="vital-value numeric"><app-editable-number
+      [value]="pc.ac" [editable]="editable" [min]="0"
+      label="armor class" (committed)="setVital('ac', $event)"
+    >{{ pc.ac ?? '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">plate &amp; shield</div>
   </div>
 
   <!-- Initiative -->
   <div class="vital">
     <span class="eyebrow">Initiative</span>
-    <div class="vital-value numeric">{{ pc.init != null ? fmtMod(pc.init) : '—' }}</div>
+    <div class="vital-value numeric"><app-editable-number
+      [value]="pc.init" [editable]="editable" [min]="null"
+      label="initiative" (committed)="setVital('init', $event)"
+    >{{ pc.init != null ? fmtMod(pc.init) : '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">d20 + mod</div>
   </div>
 
   <!-- Speed -->
   <div class="vital">
     <span class="eyebrow">Speed</span>
-    <div class="vital-value numeric">{{ pc.speed ?? '—' }}<span class="sub" *ngIf="pc.speed">ft</span></div>
+    <div class="vital-value numeric"><app-editable-number
+      [value]="pc.speed" [editable]="editable" [min]="0"
+      label="speed" (committed)="setVital('speed', $event)"
+    >{{ pc.speed ?? '—' }}</app-editable-number><span class="sub" *ngIf="pc.speed">ft</span></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">per round</div>
   </div>
 
   <!-- Proficiency -->
   <div class="vital">
     <span class="eyebrow">Proficiency</span>
-    <div class="vital-value numeric">+{{ pc.prof ?? '—' }}</div>
+    <div class="vital-value numeric">+<app-editable-number
+      [value]="pc.prof" [editable]="editable" [min]="0"
+      label="proficiency bonus" (committed)="setVital('prof', $event)"
+    >{{ pc.prof ?? '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">level {{ pc.level }}</div>
   </div>
 

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PC } from '../../../models/pc';
 import { hitDieFor, fmtMod } from '../../../utils/character-math';
 
@@ -9,6 +9,10 @@ import { hitDieFor, fmtMod } from '../../../utils/character-math';
 })
 export class VitalsStripComponent {
   @Input() pc!: PC;
+  /** DM cross-link: turns the vitals into click-to-edit numbers. */
+  @Input() editable = false;
+  /** Emits the full updated PC for the parent to persist. */
+  @Output() pcChange = new EventEmitter<PC>();
 
   get hpPct(): number {
     if (!this.pc.hp) return 0;
@@ -18,4 +22,19 @@ export class VitalsStripComponent {
   get hitDie(): number { return hitDieFor(this.pc.clazz); }
 
   fmtMod(n: number): string { return fmtMod(n); }
+
+  /** Edit one of the HP fields, keeping current within [0, max]. */
+  setHp(field: 'cur' | 'max' | 'temp', value: number): void {
+    const hp = { cur: 0, max: 0, temp: 0, ...(this.pc.hp ?? {}) };
+    hp[field] = value;
+    if (field === 'max' || field === 'cur') {
+      hp.cur = Math.max(0, Math.min(hp.cur, hp.max));
+    }
+    this.pcChange.emit({ ...this.pc, hp });
+  }
+
+  /** Edit a flat numeric vital (AC, initiative, speed, proficiency bonus). */
+  setVital(field: 'ac' | 'init' | 'speed' | 'prof', value: number): void {
+    this.pcChange.emit({ ...this.pc, [field]: value });
+  }
 }

--- a/src/app/charactermanager/components/main-content/main-content.component.html
+++ b/src/app/charactermanager/components/main-content/main-content.component.html
@@ -3,6 +3,7 @@
 <app-character-sheet
   *ngIf="pc"
   [pc]="pc"
+  [editable]="editable"
   (deleteRequested)="openDeleteModal()"
   (rollRequested)="openRollModal()"
   (levelUpRequested)="openLevelUpModal()"

--- a/src/app/charactermanager/components/main-content/main-content.component.ts
+++ b/src/app/charactermanager/components/main-content/main-content.component.ts
@@ -14,6 +14,8 @@ import { UiStateService } from '../../services/ui-state.service';
 })
 export class MainContentComponent implements OnInit, OnDestroy {
   pc: PC | null = null;
+  /** True while a DM is viewing a campaign member's sheet → numbers are editable. */
+  editable = false;
   isDeleteModalOpen = false;
   isRollModalOpen = false;
   isLevelUpModalOpen = false;
@@ -48,6 +50,10 @@ export class MainContentComponent implements OnInit, OnDestroy {
     this.pcService.getActivePC()
       .pipe(takeUntil(this.destroy$))
       .subscribe(pc => { this.pc = pc; });
+
+    this.uiState.dmReturn$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(isDmViewing => { this.editable = isDmViewing; });
   }
 
   ngOnDestroy(): void {

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -293,6 +293,45 @@ export class PCService {
     );
   }
 
+  /**
+   * Load a campaign member's full PC as the campaign's DM. The dashboard only
+   * holds the privacy-limited member projection for other players' characters;
+   * this fetches the complete sheet so a DM can edit it without losing the
+   * fields the projection omits (spells, gear, notes, …). Demo mode reads the
+   * local store (where the full PC is already present).
+   */
+  getPCByIdAsDm(id: number): Observable<PC> {
+    if (environment.demoMode) {
+      const pc = this.pcs.find(p => p.id === id);
+      return of((pc ?? {}) as PC).pipe(delay(150));
+    }
+    return this.http.get<PC>(`${this.pcUrl}${id}/as-dm`).pipe(
+      map(raw => this.deserializePC(raw))
+    );
+  }
+
+  /**
+   * Persist a DM's edit of a campaign member's PC. Same optimistic local mirror
+   * as {@link updatePC}, but hits the DM-authorized backend path (authorized by
+   * campaign-DM ownership, not PC ownership). Demo mode behaves like updatePC.
+   */
+  updatePCAsDm(pc: PC): Observable<PC> {
+    if (environment.demoMode) {
+      return this.updatePC(pc);
+    }
+    return this.http.put<PC>(`${this.pcUrl}${pc.id}/as-dm`, this.serializePC(pc)).pipe(
+      map(raw => this.deserializePC(raw)),
+      tap(updated => {
+        this.pcs = this.pcs.map(p => p.id === updated.id ? updated : p);
+        this.pcsSubject.next(this.pcs);
+        const active = this.activePCSubject.getValue();
+        if (active && active.id === updated.id) {
+          this.activePCSubject.next(updated);
+        }
+      })
+    );
+  }
+
   // ── Level-up (server-authoritative) ────────────────────────────────────────
   // The D&D rules engine lives in the backend (manager-service LevelUpService). These
   // methods are a thin client: preview fetches the computed deltas to show before the


### PR DESCRIPTION
When a DM cross-links into a member's sheet from the campaign dashboard (UiState.dmReturn$ === true), every number becomes click-to-edit and the change persists. Player self-view is unchanged — no edit affordances.

- EditableNumberComponent: reusable inline number editor mirroring the name-edit pattern (click → input, commit on blur/Enter, Escape cancels) with min/max clamping and blank/non-numeric rejection
- character-sheet: @Input() editable; editable level in the header; one persist() helper that routes to updatePCAsDm when editable, updatePC otherwise (conditions/slots now route through it too)
- vitals-strip / ability-scores / coin-purse / spellbook-panel: editable HP (cur/max/temp), AC, init, speed, prof, six ability scores, coins, and spell slots (used/max); changes bubble up via (pcChange)
- main-content: drives [editable] from dmReturn$
- PCService.getPCByIdAsDm / updatePCAsDm: DM-authorized fetch + save (demo + real branches, same serialize/deserialize seam)
- campaign-dashboard.openHero: fetch the full PC via the DM path for members the DM doesn't own (the projection omits fields a full save needs)