### PR TITLE
refactor: drop next-session date from campaign dialogues

### DIFF
--- a/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.html
+++ b/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.html
@@ -22,7 +22,6 @@
       <div style="min-width: 0;">
         <div class="campaign-name">{{ row.campaign.name }}</div>
         <div class="campaign-meta">{{ row.heroes }} heroes · {{ row.range }}</div>
-        <div class="campaign-next">Next: {{ row.campaign.next }}</div>
       </div>
     </div>
   </div>

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
@@ -13,11 +13,6 @@
   </div>
 
   <div class="field">
-    <label>Next Session</label>
-    <input [(ngModel)]="next" autocomplete="off" placeholder="e.g. Fri · Jun 20">
-  </div>
-
-  <div class="field">
     <label>Banner Hue</label>
     <div class="class-picker" style="grid-template-columns: repeat(5, 1fr);">
       <button

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
@@ -9,7 +9,6 @@ import { CampaignDraft, CampaignTint } from '../../models/campaign';
 export class CreateCampaignModalComponent {
   name = '';
   setting = '';
-  next = '';
   tint: CampaignTint = 'celestial';
 
   readonly tints: CampaignTint[] = ['celestial', 'violet', 'gold', 'crimson', 'emerald'];
@@ -22,7 +21,6 @@ export class CreateCampaignModalComponent {
     this.confirm.emit({
       name: this.name.trim(),
       setting: this.setting.trim(),
-      next: this.next.trim(),
       tint: this.tint,
     });
   }

--- a/src/app/charactermanager/models/campaign.ts
+++ b/src/app/charactermanager/models/campaign.ts
@@ -24,7 +24,6 @@ export type CampaignTint = 'celestial' | 'violet' | 'gold' | 'crimson' | 'emeral
 export interface CampaignDraft {
   name: string;
   setting: string;
-  next: string;
   tint: CampaignTint;
 }
 

--- a/src/app/charactermanager/services/campaign.service.ts
+++ b/src/app/charactermanager/services/campaign.service.ts
@@ -147,7 +147,9 @@ export class CampaignService {
       party: draft.name,
       setting: draft.setting || 'An unwritten realm',
       session: 1,
-      next: draft.next || 'Unscheduled',
+      // Scheduling was removed from the UI; the backend column still exists, so
+      // seed a neutral placeholder for compatibility.
+      next: 'Unscheduled',
       arc: 'A new beginning',
       tint: draft.tint,
       chronicle: 'The chronicle is yet unwritten. Your first session will fill this page.',


### PR DESCRIPTION
Remove the "Next Session" field from the create-campaign modal and the "Next:" line from the campaign sidebar, plus the next field from CampaignDraft. The backend next_session column and Campaign.next mapping are left intact for compatibility; createCampaign now seeds a neutral "Unscheduled" placeholder.