### PR TITLE
feat: add DM session notes (dashboard panel + in-session composer)

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -39,6 +39,7 @@ import { CampaignDashboardComponent } from './components/campaign-dashboard/camp
 import { PartyBoardComponent } from './components/campaign-dashboard/party-board/party-board.component';
 import { CampaignChronicleComponent } from './components/campaign-dashboard/campaign-chronicle/campaign-chronicle.component';
 import { PartyTreasuryComponent } from './components/campaign-dashboard/party-treasury/party-treasury.component';
+import { CampaignNotesComponent } from './components/campaign-dashboard/campaign-notes/campaign-notes.component';
 import { CreateCampaignModalComponent } from './components/create-campaign-modal/create-campaign-modal.component';
 import { JoinCampaignModalComponent } from './components/join-campaign-modal/join-campaign-modal.component';
 
@@ -104,6 +105,7 @@ const routes: Routes = [
     PartyBoardComponent,
     CampaignChronicleComponent,
     PartyTreasuryComponent,
+    CampaignNotesComponent,
     CreateCampaignModalComponent,
     JoinCampaignModalComponent,
     SessionModeComponent,

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -71,6 +71,8 @@
       <app-campaign-chronicle [campaign]="vm.campaign"></app-campaign-chronicle>
       <app-party-treasury [members]="vm.members"></app-party-treasury>
     </div>
+
+    <app-campaign-notes [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-campaign-notes>
   </div>
 
   <!-- Manage Party — bind/unbind your characters to this campaign -->

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.html
@@ -1,0 +1,32 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Session Notes</span>
+    <span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      {{ notes.length }} {{ notes.length === 1 ? 'entry' : 'entries' }}
+    </span>
+  </div>
+
+  <div class="note-compose">
+    <textarea
+      [(ngModel)]="draft"
+      rows="2"
+      placeholder="Jot a note — a ruling, a clue, a thread to pull next time…"
+      (keydown.control.enter)="add()"
+    ></textarea>
+    <button class="btn primary" [disabled]="!draft.trim() || saving" (click)="add()">Add Note</button>
+  </div>
+
+  <div class="note-list" *ngIf="notes.length; else noNotes">
+    <div class="note" *ngFor="let n of notes; trackBy: trackById">
+      <p class="note-body">{{ n.body }}</p>
+      <div class="note-foot">
+        <span class="note-time">{{ n.createdAt | date:'MMM d, y · h:mm a' }}</span>
+        <button class="note-del" (click)="remove(n)" [attr.aria-label]="'Delete note'" title="Delete note">✕</button>
+      </div>
+    </div>
+  </div>
+
+  <ng-template #noNotes>
+    <div class="note-empty">No notes yet. Capture the first ruling or revelation.</div>
+  </ng-template>
+</div>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.scss
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.scss
@@ -1,0 +1,88 @@
+// Session Notes panel. Panel chrome (.panel, .panel-header, .btn) comes from the
+// global design system; only the compose box and note rows are styled here.
+:host {
+  display: block;
+}
+
+.note-compose {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+
+  textarea {
+    flex: 1;
+    resize: vertical;
+    min-height: 44px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+    background: var(--bg-2, rgba(0, 0, 0, 0.2));
+    color: var(--text);
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.4;
+
+    &:focus {
+      outline: none;
+      border-color: var(--celestial);
+    }
+  }
+
+  .btn { flex: none; }
+}
+
+.note-list {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.note {
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: var(--bg-2, rgba(0, 0, 0, 0.15));
+
+  .note-body {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text);
+    white-space: pre-wrap;
+  }
+
+  .note-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 6px;
+  }
+
+  .note-time {
+    font-size: 11px;
+    letter-spacing: 0.02em;
+    color: var(--text-dim);
+  }
+
+  .note-del {
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--text-dim);
+    font-size: 12px;
+    line-height: 1;
+    padding: 2px 4px;
+    border-radius: 4px;
+
+    &:hover { color: var(--crimson); }
+  }
+}
+
+.note-empty {
+  margin-top: 14px;
+  color: var(--text-dim);
+  font-style: italic;
+  font-size: 13px;
+  padding: 8px 0;
+}

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-notes/campaign-notes.component.ts
@@ -1,0 +1,64 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Campaign } from '../../../models/campaign';
+import { SessionNote } from '../../../models/session-note';
+import { CampaignService } from '../../../services/campaign.service';
+
+/**
+ * Session Notes panel on the DM dashboard — the out-of-session surface for the
+ * campaign-scoped note log. Reloads whenever the selected campaign changes; the
+ * in-session composer (Session Mode) writes to the same backend log.
+ */
+@Component({
+  selector: 'app-campaign-notes',
+  templateUrl: './campaign-notes.component.html',
+  styleUrls: ['./campaign-notes.component.scss'],
+})
+export class CampaignNotesComponent implements OnChanges {
+  @Input() campaign!: Campaign;
+
+  notes: SessionNote[] = [];
+  draft = '';
+  saving = false;
+
+  constructor(private campaignService: CampaignService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['campaign']) this.load();
+  }
+
+  private load(): void {
+    if (!this.campaign) { this.notes = []; return; }
+    this.campaignService.getNotes(this.campaign.id).subscribe({
+      next: notes => (this.notes = notes),
+      error: err => console.error('Failed to load session notes', err),
+    });
+  }
+
+  add(): void {
+    const body = this.draft.trim();
+    if (!body || this.saving) return;
+    this.saving = true;
+    this.campaignService.addNote(this.campaign.id, body).subscribe({
+      next: note => {
+        this.notes = [note, ...this.notes];
+        this.draft = '';
+        this.saving = false;
+      },
+      error: err => {
+        console.error('Failed to add session note', err);
+        this.saving = false;
+      },
+    });
+  }
+
+  remove(note: SessionNote): void {
+    this.campaignService.deleteNote(this.campaign.id, note.id).subscribe({
+      next: () => (this.notes = this.notes.filter(n => n !== note)),
+      error: err => console.error('Failed to delete session note', err),
+    });
+  }
+
+  trackById(_index: number, note: SessionNote): number | string {
+    return note.id;
+  }
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -48,6 +48,26 @@
       [sessionId]="state.sessionId"
       [dm]="state.dm"
     ></app-initiative-panel>
+
+    <!-- DM-only: capture a note to the campaign log without leaving the table -->
+    <div *ngIf="state.dm" class="panel session-note">
+      <div class="panel-header">
+        <span class="panel-title">Session Note</span>
+        <span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+          saved to the campaign log
+        </span>
+      </div>
+      <div class="note-compose">
+        <textarea
+          [(ngModel)]="noteDraft"
+          rows="2"
+          placeholder="Log a ruling, a roll, or a moment from this session…"
+          (keydown.control.enter)="addNote(state)"
+        ></textarea>
+        <button class="btn primary" [disabled]="!noteDraft.trim() || savingNote" (click)="addNote(state)">Add Note</button>
+      </div>
+      <div *ngIf="noteSaved" class="note-saved">Saved to the campaign log.</div>
+    </div>
   </div>
 </ng-container>
 

--- a/src/app/charactermanager/components/session-mode/session-mode.component.scss
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.scss
@@ -3,3 +3,42 @@
 :host {
   display: block;
 }
+
+// In-session DM note composer. Panel chrome is global; only the compose box
+// and confirmation line are styled here.
+.session-note {
+  margin-top: 20px;
+
+  .note-compose {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+
+    textarea {
+      flex: 1;
+      resize: vertical;
+      min-height: 44px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+      background: var(--bg-2, rgba(0, 0, 0, 0.2));
+      color: var(--text);
+      font-family: inherit;
+      font-size: 13px;
+      line-height: 1.4;
+
+      &:focus {
+        outline: none;
+        border-color: var(--celestial);
+      }
+    }
+
+    .btn { flex: none; }
+  }
+
+  .note-saved {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--celestial-2, var(--celestial));
+  }
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -5,6 +5,7 @@ import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
 import { PCService } from '../../services/pc.service';
 import { NotificationService } from '../../services/notification.service';
+import { CampaignService } from '../../services/campaign.service';
 
 /**
  * Session Mode screen — a full-width overlay (chosen in the sidenav over the
@@ -24,6 +25,11 @@ export class SessionModeComponent implements OnInit, OnDestroy {
 
   state$ = this.sessionService.state$;
 
+  // In-session DM note composer — writes to the campaign's note log.
+  noteDraft = '';
+  savingNote = false;
+  noteSaved = false;
+
   private stateSub?: Subscription;
   private handledEnd = false;
 
@@ -32,6 +38,7 @@ export class SessionModeComponent implements OnInit, OnDestroy {
     private uiState: UiStateService,
     private pcService: PCService,
     private notifications: NotificationService,
+    private campaignService: CampaignService,
   ) {}
 
   ngOnInit(): void {
@@ -85,6 +92,29 @@ export class SessionModeComponent implements OnInit, OnDestroy {
     this.sessionService.end(state.sessionId).subscribe({
       next: () => this.close(),
       error: () => this.close(),
+    });
+  }
+
+  /**
+   * The DM captures a note mid-session; it is appended to the campaign's note
+   * log (the same log shown on the dashboard's Session Notes panel), tagged with
+   * this session's id.
+   */
+  addNote(state: SessionState): void {
+    const body = this.noteDraft.trim();
+    if (!body || this.savingNote) return;
+    this.savingNote = true;
+    this.noteSaved = false;
+    this.campaignService.addNote(String(state.campaignId), body, state.sessionId).subscribe({
+      next: () => {
+        this.noteDraft = '';
+        this.savingNote = false;
+        this.noteSaved = true;
+      },
+      error: err => {
+        console.error('Failed to add session note', err);
+        this.savingNote = false;
+      },
     });
   }
 

--- a/src/app/charactermanager/models/session-note.ts
+++ b/src/app/charactermanager/models/session-note.ts
@@ -1,0 +1,12 @@
+/**
+ * A DM session note — a campaign-scoped log entry. Mirrors the backend
+ * SessionNoteView DTO. `id` is numeric in real mode and a string sentinel in
+ * demo mode (like SessionState.sessionId). `sessionId` is set when the note was
+ * captured live during a session, null when added from the campaign menu.
+ */
+export interface SessionNote {
+  id: number | string;
+  body: string;
+  createdAt: string;                       // ISO-8601 timestamp
+  sessionId?: number | string | null;
+}

--- a/src/app/charactermanager/services/campaign.service.ts
+++ b/src/app/charactermanager/services/campaign.service.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, Observable, combineLatest, of, throwError } from 'rxjs
 import { delay, map, take, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { Campaign, CampaignDraft } from '../models/campaign';
+import { SessionNote } from '../models/session-note';
 import { PC } from '../models/pc';
 import { PCService } from './pc.service';
 
@@ -55,6 +56,33 @@ const DEMO_CAMPAIGNS: Campaign[] = [
 ];
 
 const STORAGE_KEY = 'tm_campaigns';
+
+// Demo session notes, keyed by campaign id. Mirrors the tm_campaigns demo store.
+const NOTES_KEY = 'tm_notes';
+const DEMO_NOTES: Record<string, SessionNote[]> = {
+  veiled: [
+    {
+      id: 'n-veiled-1',
+      body: "Throk voiced his suspicion about the Lantern's patron at the table — I let it simmer rather than confirm.",
+      createdAt: '2024-06-05T02:00:00.000Z',
+      sessionId: null,
+    },
+    {
+      id: 'n-veiled-2',
+      body: "The party still hasn't opened Aldric's orphanage letter. Dangle it again before the Lantern reveal.",
+      createdAt: '2024-06-08T02:00:00.000Z',
+      sessionId: null,
+    },
+  ],
+  tomb: [
+    {
+      id: 'n-tomb-1',
+      body: 'Pip nearly tripped the bronze ward; Zarev felt the blood-call again. The tomb knows his line.',
+      createdAt: '2024-06-10T02:00:00.000Z',
+      sessionId: null,
+    },
+  ],
+};
 
 @Injectable({ providedIn: 'root' })
 export class CampaignService {
@@ -231,5 +259,82 @@ export class CampaignService {
       // fall through to demo seed
     }
     return [...DEMO_CAMPAIGNS];
+  }
+
+  // --- DM session notes -----------------------------------------------------
+  // Campaign-scoped log the DM appends to from the campaign menu or in-session.
+  // Real mode hits the DM-only /campaign/{id}/notes endpoints; demo mode keeps a
+  // per-campaign list in localStorage (tm_notes), like tm_campaigns.
+
+  /** A campaign's notes, newest first. */
+  getNotes(campaignId: string): Observable<SessionNote[]> {
+    if (environment.demoMode) {
+      return of(this.loadDemoNotes()[campaignId] ?? []).pipe(delay(50));
+    }
+    return this.http.get<unknown[]>(`${this.campaignUrl}/${campaignId}/notes`).pipe(
+      map(rows => rows.map(r => this.deserializeNote(r))),
+    );
+  }
+
+  /** Append a note. `sessionId` is set when captured live during a session. */
+  addNote(campaignId: string, body: string, sessionId?: number | string | null): Observable<SessionNote> {
+    const trimmed = body.trim();
+    if (environment.demoMode) {
+      const note: SessionNote = {
+        id: 'n-' + Date.now(),
+        body: trimmed,
+        createdAt: new Date().toISOString(),
+        sessionId: sessionId ?? null,
+      };
+      const all = this.loadDemoNotes();
+      all[campaignId] = [note, ...(all[campaignId] ?? [])];
+      this.persistDemoNotes(all);
+      return of(note).pipe(delay(50));
+    }
+    const payload: Record<string, unknown> = { body: trimmed };
+    // Real session ids are numeric; the demo sentinel never reaches this branch.
+    if (sessionId != null) payload['sessionId'] = Number(sessionId);
+    return this.http.post<unknown>(`${this.campaignUrl}/${campaignId}/notes`, payload).pipe(
+      map(r => this.deserializeNote(r)),
+    );
+  }
+
+  /** Remove a note from a campaign. */
+  deleteNote(campaignId: string, noteId: number | string): Observable<void> {
+    if (environment.demoMode) {
+      const all = this.loadDemoNotes();
+      all[campaignId] = (all[campaignId] ?? []).filter(n => String(n.id) !== String(noteId));
+      this.persistDemoNotes(all);
+      return of(void 0).pipe(delay(50));
+    }
+    return this.http.delete<void>(`${this.campaignUrl}/${campaignId}/notes/${noteId}`);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private deserializeNote(raw: any): SessionNote {
+    return {
+      id: raw.id,
+      body: raw.body ?? '',
+      createdAt: raw.createdAt ?? new Date().toISOString(),
+      sessionId: raw.sessionId ?? null,
+    };
+  }
+
+  private loadDemoNotes(): Record<string, SessionNote[]> {
+    try {
+      const raw = localStorage.getItem(NOTES_KEY);
+      if (raw) return JSON.parse(raw) as Record<string, SessionNote[]>;
+    } catch {
+      // fall through to demo seed
+    }
+    return JSON.parse(JSON.stringify(DEMO_NOTES)) as Record<string, SessionNote[]>;
+  }
+
+  private persistDemoNotes(map: Record<string, SessionNote[]>): void {
+    try {
+      localStorage.setItem(NOTES_KEY, JSON.stringify(map));
+    } catch {
+      // Storage unavailable — keep in-memory only.
+    }
   }
 }


### PR DESCRIPTION
DMs can keep a campaign-scoped running log. A Session Notes panel on the campaign dashboard adds, lists, and deletes notes out of session; a DM-only composer in Session Mode appends a note to the same log mid-game, tagged with the live session id.

CampaignService gains getNotes/addNote/deleteNote with the usual demo/real split (demo persists to localStorage under tm_notes with seed notes).