### PR TITLE
feat: Session Mode shop panel — browse & buy weapons (slice A UI)

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -45,6 +45,7 @@ import { JoinCampaignModalComponent } from './components/join-campaign-modal/joi
 // ── Session Mode ───────────────────────────────────────────────────────────
 import { SessionModeComponent } from './components/session-mode/session-mode.component';
 import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
+import { ShopPanelComponent } from './components/session-mode/shop-panel/shop-panel.component';
 import { SessionLiveBannerComponent } from './components/session-live-banner/session-live-banner.component';
 import { ToastComponent } from './components/toast/toast.component';
 
@@ -108,6 +109,7 @@ const routes: Routes = [
     JoinCampaignModalComponent,
     SessionModeComponent,
     InitiativePanelComponent,
+    ShopPanelComponent,
     SessionLiveBannerComponent,
     ToastComponent,
   ],

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -48,6 +48,8 @@
       [sessionId]="state.sessionId"
       [dm]="state.dm"
     ></app-initiative-panel>
+
+    <app-shop-panel [state]="state"></app-shop-panel>
   </div>
 </ng-container>
 

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.html
@@ -1,0 +1,93 @@
+<section class="shop-panel" *ngIf="state && (state.dm || state.shopForMe)">
+
+  <!-- ===================== DM view ===================== -->
+  <ng-container *ngIf="state.dm; else playerView">
+
+    <!-- No shop open yet: the open form -->
+    <div class="shop-card" *ngIf="!shop">
+      <div class="eyebrow">Shop</div>
+      <h2 class="shop-title">Open a weapon shop</h2>
+
+      <label class="field">
+        <span class="field-label">Settlement</span>
+        <input class="text-input" type="text" [(ngModel)]="settlement"
+               placeholder="e.g. Phandalin" />
+      </label>
+
+      <div class="field-label">Who's at the shop?</div>
+      <div class="roster" *ngIf="roster.length; else noRoster">
+        <label class="roster-row" *ngFor="let p of roster">
+          <input type="checkbox" [(ngModel)]="selected[p.pcId!]" />
+          <span>{{ p.name }}</span>
+        </label>
+      </div>
+      <ng-template #noRoster>
+        <div class="muted">No characters are seated in this session yet.</div>
+      </ng-template>
+
+      <button class="btn primary" (click)="openShop()">Open Weapons Shop</button>
+    </div>
+
+    <!-- Shop open: manage attendees + browse the stock -->
+    <div class="shop-card" *ngIf="shop">
+      <div class="shop-head">
+        <div>
+          <div class="eyebrow">Weapon Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
+          <h2 class="shop-title">Stock</h2>
+        </div>
+        <button class="btn danger" (click)="closeShop()">Close Shop</button>
+      </div>
+
+      <div class="field-label">At the shop</div>
+      <div class="roster">
+        <label class="roster-row" *ngFor="let p of roster">
+          <input type="checkbox" [checked]="isAttendee(p.pcId!)" (change)="toggleAttendee(p.pcId!)" />
+          <span>{{ p.name }}</span>
+        </label>
+      </div>
+
+      <ul class="catalog">
+        <li class="catalog-row" *ngFor="let item of shop.items; trackBy: trackByKey">
+          <div class="item-main">
+            <span class="item-name">{{ item.name }}</span>
+            <span class="item-meta">{{ detail(item, 'damage') }}<span
+              *ngIf="detail(item, 'properties')"> · {{ detail(item, 'properties') }}</span></span>
+          </div>
+          <span class="item-price">{{ formatCp(item.costCp) }}</span>
+        </li>
+      </ul>
+    </div>
+  </ng-container>
+
+  <!-- ===================== Player view ===================== -->
+  <ng-template #playerView>
+    <div class="shop-card" *ngIf="shop">
+      <div class="shop-head">
+        <div>
+          <div class="eyebrow">Weapon Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
+          <h2 class="shop-title">Browse &amp; buy</h2>
+        </div>
+        <span class="purse" *ngIf="myPc">{{ formatCp(myCoinsCp) }}</span>
+      </div>
+
+      <ul class="catalog">
+        <li class="catalog-row" *ngFor="let item of shop.items; trackBy: trackByKey">
+          <div class="item-main">
+            <span class="item-name">{{ item.name }}</span>
+            <span class="item-meta">{{ detail(item, 'damage') }}<span
+              *ngIf="detail(item, 'properties')"> · {{ detail(item, 'properties') }}</span></span>
+          </div>
+          <span class="item-price">{{ formatCp(item.costCp) }}</span>
+          <button class="btn buy"
+                  [disabled]="!canAfford(item) || busyItem === item.itemKey"
+                  (click)="buy(item)">
+            {{ busyItem === item.itemKey ? '…' : (canAfford(item) ? 'Buy' : 'Too costly') }}
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <div class="shop-card muted" *ngIf="!shop && loading">Reaching the shop…</div>
+  </ng-template>
+
+</section>

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.scss
@@ -1,0 +1,115 @@
+.shop-panel {
+  margin-top: 20px;
+}
+
+.shop-card {
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+
+.shop-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.shop-title {
+  margin: 2px 0 14px;
+  font-size: 1.15rem;
+}
+
+.field {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  margin-bottom: 6px;
+}
+
+.text-input {
+  width: 100%;
+  max-width: 320px;
+  padding: 8px 10px;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+}
+
+.roster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin-bottom: 16px;
+}
+
+.roster-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+}
+
+.catalog {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.catalog-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 0;
+  border-top: 1px solid var(--border, rgba(255, 255, 255, 0.10));
+}
+
+.item-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.item-name {
+  font-weight: 600;
+}
+
+.item-meta {
+  font-size: 0.8rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+}
+
+.item-price {
+  font-variant-numeric: tabular-nums;
+  color: var(--gold, #d8b46a);
+  white-space: nowrap;
+}
+
+.purse {
+  font-variant-numeric: tabular-nums;
+  color: var(--gold, #d8b46a);
+  font-weight: 600;
+}
+
+.btn.buy {
+  min-width: 84px;
+}
+
+.btn.buy:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.muted {
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
@@ -1,0 +1,132 @@
+import { of, throwError } from 'rxjs';
+import { ShopPanelComponent } from './shop-panel.component';
+import { SessionState, ParticipantView } from '../../../models/session';
+import { ShopItem, ShopView } from '../../../models/shop';
+import { PC } from '../../../models/pc';
+
+/**
+ * Tests the component class directly (no TestBed/DOM) — the convention used by
+ * other components in this app.
+ */
+describe('ShopPanelComponent', () => {
+  let component: ShopPanelComponent;
+  let shopService: any;
+  let pcService: any;
+  let notifications: any;
+
+  const longsword: ShopItem = {
+    itemKey: 'longsword', name: 'Longsword', category: 'WEAPON', costCp: 1500,
+    weight: 3, details: { damage: '1d8 slashing', properties: ['versatile (1d10)'] }, stock: null,
+  };
+
+  function participant(over: Partial<ParticipantView>): ParticipantView {
+    return {
+      participantId: 1, pcId: 7, npc: false, ownedByMe: false, currentTurn: false,
+      name: 'Aria', clazz: 'Fighter', level: 3, portraitTint: null, portraitInitials: null,
+      initiative: null, initRolled: false, orderIndex: 0, hpMax: null, hpCurrent: null,
+      hpTemp: null, ac: null, conditions: [], deathSaveSuccesses: 0, deathSaveFailures: 0,
+      ...over,
+    };
+  }
+
+  function state(over: Partial<SessionState>): SessionState {
+    return {
+      sessionId: 1, campaignId: 1, status: 'ACTIVE', round: 1, currentTurnIndex: 0,
+      version: 1, dm: false, shopOpen: false, shopForMe: false, shopCategory: null,
+      participants: [], ...over,
+    };
+  }
+
+  beforeEach(() => {
+    shopService = jasmine.createSpyObj('ShopService',
+      ['openShop', 'setAttendees', 'closeShop', 'getShop', 'purchase']);
+    pcService = jasmine.createSpyObj('PCService', ['getPCById', 'patchLocalPC']);
+    notifications = jasmine.createSpyObj('NotificationService', ['notify']);
+    component = new ShopPanelComponent(shopService, pcService, notifications);
+  });
+
+  it('myCoinsCp sums the purse in copper', () => {
+    pcService.getPCById.and.returnValue({ id: 7, coins: { cp: 5, sp: 0, ep: 0, gp: 2, pp: 0 } } as PC);
+    component.state = state({ participants: [participant({ ownedByMe: true })] });
+    expect(component.myCoinsCp).toBe(205); // 2 gp + 5 cp
+  });
+
+  it('canAfford reflects the purse', () => {
+    pcService.getPCById.and.returnValue({ id: 7, coins: { gp: 10 } } as PC);
+    component.state = state({ participants: [participant({ ownedByMe: true })] });
+    expect(component.canAfford(longsword)).toBeFalse(); // 1000 < 1500
+    pcService.getPCById.and.returnValue({ id: 7, coins: { gp: 20 } } as PC);
+    expect(component.canAfford(longsword)).toBeTrue();
+  });
+
+  it('roster excludes NPCs and missing pcIds', () => {
+    component.state = state({
+      participants: [
+        participant({ participantId: 1, pcId: 7 }),
+        participant({ participantId: 2, pcId: null, npc: true, name: 'Goblin' }),
+      ],
+    });
+    expect(component.roster.map(p => p.name)).toEqual(['Aria']);
+  });
+
+  it('openShop sends the selected roster pcIds', () => {
+    const view: ShopView = { shopId: 10, sessionId: 1, category: 'WEAPON', settlement: 'Phandalin', attendeePcIds: [7], items: [] };
+    shopService.openShop.and.returnValue(of(view));
+    component.state = state({ dm: true, participants: [participant({ pcId: 7 }), participant({ participantId: 2, pcId: 8, name: 'Borin' })] });
+    component.settlement = 'Phandalin';
+    component.selected = { 7: true, 8: false };
+
+    component.openShop();
+
+    expect(shopService.openShop).toHaveBeenCalledWith(1, 'WEAPON', 'Phandalin', [7]);
+    expect(component.shop).toBe(view);
+  });
+
+  it('buy purchases, patches the local PC, and notifies', () => {
+    pcService.getPCById.and.returnValue({ id: 7, coins: { gp: 20 } } as PC);
+    shopService.purchase.and.returnValue(of({
+      coins: { cp: 0, sp: 0, ep: 0, gp: 5, pp: 0 },
+      inventory: [{ catalogKey: 'longsword', name: 'Longsword', category: 'weapon', qty: 1 }],
+      totalCostCp: 1500,
+    }));
+    component.state = state({ participants: [participant({ ownedByMe: true, pcId: 7 })] });
+
+    component.buy(longsword);
+
+    expect(shopService.purchase).toHaveBeenCalledWith(1, 7, 'longsword', 1);
+    expect(pcService.patchLocalPC).toHaveBeenCalledWith(7, jasmine.objectContaining({
+      coins: jasmine.objectContaining({ gp: 5 }),
+    }));
+    expect(notifications.notify).toHaveBeenCalled();
+    expect(component.busyItem).toBeNull();
+  });
+
+  it('buy surfaces a friendly message on 409 insufficient funds', () => {
+    pcService.getPCById.and.returnValue({ id: 7, coins: { gp: 20 } } as PC);
+    shopService.purchase.and.returnValue(throwError(() => ({ status: 409 })));
+    component.state = state({ participants: [participant({ ownedByMe: true, pcId: 7 })] });
+
+    component.buy(longsword);
+
+    expect(notifications.notify).toHaveBeenCalledWith('Not enough coin for that purchase.');
+    expect(pcService.patchLocalPC).not.toHaveBeenCalled();
+    expect(component.busyItem).toBeNull();
+  });
+
+  it('fetches the catalog once when a shop becomes visible', () => {
+    shopService.getShop.and.returnValue(of({ shopId: 10, items: [] } as any));
+    component.state = state({ shopOpen: true, shopForMe: true, shopCategory: 'WEAPON' });
+
+    component.ngOnChanges();
+    component.ngOnChanges(); // a second poll with the same shop must not refetch
+
+    expect(shopService.getShop).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the shop when it closes', () => {
+    component.shop = { shopId: 10 } as any;
+    component.state = state({ shopOpen: false, shopForMe: false });
+    component.ngOnChanges();
+    expect(component.shop).toBeNull();
+  });
+});

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
@@ -1,0 +1,172 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { SessionState, ParticipantView } from '../../../models/session';
+import { ShopItem, ShopView, formatCp } from '../../../models/shop';
+import { PC } from '../../../models/pc';
+import { ShopService } from '../../../services/shop.service';
+import { PCService } from '../../../services/pc.service';
+import { NotificationService } from '../../../services/notification.service';
+
+/**
+ * Session Mode shop. The DM activates one weapon shop (Phase 1), types a
+ * settlement label, and toggles which roster characters are at it; targeted
+ * players see the catalog and buy. Visibility is driven by the session poll
+ * (`shopForMe` on the snapshot) — non-targeted players never render this.
+ *
+ * State stays server-authoritative: a purchase hits the backend (coins deducted
+ * + inventory appended on the pc row) and the returned coins/inventory are
+ * mirrored into the local PC store. DM open/target/close return the updated shop
+ * view directly so the DM's controls respond without waiting for the next poll.
+ */
+@Component({
+  selector: 'app-shop-panel',
+  templateUrl: './shop-panel.component.html',
+  styleUrls: ['./shop-panel.component.scss'],
+})
+export class ShopPanelComponent implements OnChanges {
+  @Input() state!: SessionState;
+
+  shop: ShopView | null = null;
+  loading = false;
+  busyItem: string | null = null; // itemKey mid-purchase
+
+  // DM open-shop form
+  settlement = '';
+  selected: { [pcId: number]: boolean } = {};
+
+  /** Guards re-fetching the catalog on every 2s poll; only refetch on a real change. */
+  private fetchedKey: string | null = null;
+
+  readonly formatCp = formatCp;
+
+  constructor(
+    private shopService: ShopService,
+    private pcService: PCService,
+    private notifications: NotificationService,
+  ) {}
+
+  ngOnChanges(): void {
+    const s = this.state;
+    if (!s) return;
+    if (s.shopForMe && s.shopOpen) {
+      const key = `${s.sessionId}|${s.shopCategory}`;
+      if (key !== this.fetchedKey) {
+        this.fetchedKey = key;
+        this.fetchShop();
+      }
+    } else if (!s.shopOpen) {
+      this.shop = null;
+      this.fetchedKey = null;
+    }
+  }
+
+  /** PC combatants the DM may place at a shop (NPCs excluded). */
+  get roster(): ParticipantView[] {
+    return (this.state?.participants ?? []).filter(p => p.pcId != null && !p.npc);
+  }
+
+  get myParticipant(): ParticipantView | null {
+    return (this.state?.participants ?? []).find(p => p.ownedByMe && p.pcId != null) ?? null;
+  }
+
+  get myPc(): PC | undefined {
+    const pcId = this.myParticipant?.pcId;
+    return pcId != null ? this.pcService.getPCById(pcId) : undefined;
+  }
+
+  /** The buyer's total wealth in copper (same rates as the coin purse). */
+  get myCoinsCp(): number {
+    const c = this.myPc?.coins;
+    if (!c) return 0;
+    return (c.cp ?? 0) + (c.sp ?? 0) * 10 + (c.ep ?? 0) * 50 + (c.gp ?? 0) * 100 + (c.pp ?? 0) * 1000;
+  }
+
+  canAfford(item: ShopItem): boolean {
+    return this.myCoinsCp >= item.costCp;
+  }
+
+  detail(item: ShopItem, key: string): string {
+    const v = item.details?.[key];
+    return Array.isArray(v) ? v.join(', ') : (v ?? '');
+  }
+
+  // --- DM actions ----------------------------------------------------------
+
+  openShop(): void {
+    const pcIds = this.roster.filter(p => this.selected[p.pcId!]).map(p => p.pcId!);
+    this.shopService.openShop(this.state.sessionId, 'WEAPON', this.settlement.trim(), pcIds).subscribe({
+      next: view => {
+        this.shop = view;
+        this.fetchedKey = `${this.state.sessionId}|WEAPON`;
+      },
+      error: err => this.notifications.notify(this.errMsg(err, 'Could not open the shop.')),
+    });
+  }
+
+  closeShop(): void {
+    this.shopService.closeShop(this.state.sessionId).subscribe({
+      next: () => {
+        this.shop = null;
+        this.fetchedKey = null;
+      },
+      error: err => this.notifications.notify(this.errMsg(err, 'Could not close the shop.')),
+    });
+  }
+
+  isAttendee(pcId: number): boolean {
+    return !!this.shop?.attendeePcIds?.includes(pcId);
+  }
+
+  toggleAttendee(pcId: number): void {
+    const next = new Set(this.shop?.attendeePcIds ?? []);
+    next.has(pcId) ? next.delete(pcId) : next.add(pcId);
+    this.shopService.setAttendees(this.state.sessionId, Array.from(next)).subscribe({
+      next: view => (this.shop = view),
+      error: err => this.notifications.notify(this.errMsg(err, 'Could not update who is at the shop.')),
+    });
+  }
+
+  // --- player action -------------------------------------------------------
+
+  buy(item: ShopItem): void {
+    const pcId = this.myParticipant?.pcId;
+    if (pcId == null || this.busyItem) return;
+    this.busyItem = item.itemKey;
+    this.shopService.purchase(this.state.sessionId, pcId, item.itemKey, 1).subscribe({
+      next: res => {
+        this.pcService.patchLocalPC(pcId, { coins: res.coins, inventory: res.inventory });
+        this.notifications.notify(`Bought ${item.name} for ${this.formatCp(item.costCp)}.`);
+        this.busyItem = null;
+      },
+      error: err => {
+        this.busyItem = null;
+        this.notifications.notify(this.errMsg(err, 'Purchase failed.'));
+      },
+    });
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private fetchShop(): void {
+    this.loading = true;
+    this.shopService.getShop(this.state.sessionId).subscribe({
+      next: view => {
+        this.shop = view;
+        this.loading = false;
+      },
+      error: () => {
+        this.shop = null;
+        this.loading = false;
+      },
+    });
+  }
+
+  private errMsg(err: any, fallback: string): string {
+    if (err?.status === 409) return 'Not enough coin for that purchase.';
+    if (err?.status === 403) return 'That character isn’t at this shop.';
+    return err?.error?.message || fallback;
+  }
+
+  trackByKey(_: number, item: ShopItem): string {
+    return item.itemKey;
+  }
+}

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -100,6 +100,26 @@ export class PCService {
   }
 
   /**
+   * Merge a partial update into a PC already in the local store and push to
+   * subscribers — no backend call. Used when the server has already persisted
+   * the change (e.g. a shop purchase returns the new coins/inventory), so a full
+   * PUT would be a redundant double-write.
+   */
+  patchLocalPC(pcId: number, patch: Partial<PC>): void {
+    let patched: PC | null = null;
+    this.pcs = this.pcs.map(p => {
+      if (p.id !== pcId) return p;
+      patched = { ...p, ...patch };
+      return patched;
+    });
+    this.pcsSubject.next(this.pcs);
+    const active = this.activePCSubject.getValue();
+    if (patched && active && active.id === pcId) {
+      this.activePCSubject.next(patched);
+    }
+  }
+
+  /**
    * Optimistically update a PC in the local store and push to all subscribers.
    * In non-demo mode, also persists to the backend.
    */


### PR DESCRIPTION
Adds the shopping UI to Session Mode, wired to the slice-A backend:
- ShopPanelComponent hosted under the initiative panel. DM activates one weapon shop (settlement label + pick characters from the roster), toggles attendees, and closes it; targeted players see the catalog and buy.
- Visibility is driven by the session poll (shopForMe) — non-targeted players render nothing. Catalog is fetched once per shop open (guarded against the 2s poll), DM open/target/close use the returned view for immediate feedback.
- Purchases call the backend and mirror the returned coins/inventory into the local PC store via a new PCService.patchLocalPC (no redundant PUT).
- Insufficient-funds (409) and not-at-shop (403) surface friendly messages; Buy is disabled when unaffordable.
- shop-panel.component.spec covers coins/affordability, roster filtering, open, buy success + 409, and fetch-once/close behaviour (258 tests green; build OK).

Demo mode shows the DM open form but rejects writes (no in-memory shop yet).