### PR TITLE
feat: material-component shop + fix merge-mangled shop UI (slice C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+# Claude Code (worktrees, local agent state)
+.claude/

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.html
@@ -6,7 +6,14 @@
     <!-- No shop open yet: the open form -->
     <div class="shop-card" *ngIf="!shop">
       <div class="eyebrow">Shop</div>
-      <h2 class="shop-title">Open a weapon shop</h2>
+      <h2 class="shop-title">Open a shop</h2>
+
+      <div class="field-label">What does it sell?</div>
+      <div class="seg" role="radiogroup">
+        <button type="button" class="seg-btn" *ngFor="let c of categories"
+                [class.active]="category === c.value"
+                (click)="category = c.value">{{ c.label }}</button>
+      </div>
 
       <label class="field">
         <span class="field-label">Settlement</span>
@@ -25,14 +32,13 @@
         <div class="muted">No characters are seated in this session yet.</div>
       </ng-template>
 
-      <button class="btn primary" (click)="openShop()">Open Weapons Shop</button>
+      <button class="btn primary" (click)="openShop()">Open Shop</button>
     </div>
 
     <!-- Shop open: manage attendees + browse the stock -->
     <div class="shop-card" *ngIf="shop">
       <div class="shop-head">
         <div>
-          <div class="eyebrow">Weapon Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
           <div class="eyebrow">{{ categoryLabel(shop.category) }} Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
           <h2 class="shop-title">Stock</h2>
         </div>
@@ -51,8 +57,7 @@
         <li class="catalog-row" *ngFor="let item of shop.items; trackBy: trackByKey">
           <div class="item-main">
             <span class="item-name">{{ item.name }}</span>
-            <span class="item-meta">{{ detail(item, 'damage') }}<span
-              *ngIf="detail(item, 'properties')"> · {{ detail(item, 'properties') }}</span></span>
+            <span class="item-meta">{{ itemMeta(item) }}</span>
           </div>
           <span class="item-price">{{ formatCp(item.costCp) }}</span>
         </li>
@@ -65,7 +70,7 @@
     <div class="shop-card" *ngIf="shop">
       <div class="shop-head">
         <div>
-          <div class="eyebrow">Weapon Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
+          <div class="eyebrow">{{ categoryLabel(shop.category) }} Shop{{ shop.settlement ? ' · ' + shop.settlement : '' }}</div>
           <h2 class="shop-title">Browse &amp; buy</h2>
         </div>
         <span class="purse" *ngIf="myPc">{{ formatCp(myCoinsCp) }}</span>
@@ -75,8 +80,7 @@
         <li class="catalog-row" *ngFor="let item of shop.items; trackBy: trackByKey">
           <div class="item-main">
             <span class="item-name">{{ item.name }}</span>
-            <span class="item-meta">{{ detail(item, 'damage') }}<span
-              *ngIf="detail(item, 'properties')"> · {{ detail(item, 'properties') }}</span></span>
+            <span class="item-meta">{{ itemMeta(item) }}</span>
           </div>
           <span class="item-price">{{ formatCp(item.costCp) }}</span>
           <button class="btn buy"

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.scss
@@ -26,6 +26,32 @@
   margin-bottom: 14px;
 }
 
+.seg {
+  display: inline-flex;
+  margin-bottom: 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  font: inherit;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  background: transparent;
+  border: 0;
+  padding: 7px 16px;
+  cursor: pointer;
+
+  & + .seg-btn {
+    border-left: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  }
+
+  &.active {
+    color: var(--text);
+    background: var(--celestial, rgba(120, 170, 255, 0.18));
+  }
+}
+
 .field-label {
   display: block;
   font-size: 0.8rem;

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
@@ -82,6 +82,49 @@ describe('ShopPanelComponent', () => {
     expect(component.shop).toBe(view);
   });
 
+  it('openShop sends the chosen category (armor / components)', () => {
+    const view: ShopView = { shopId: 11, sessionId: 1, category: 'ARMOR', settlement: '', attendeePcIds: [], items: [] };
+    shopService.openShop.and.returnValue(of(view));
+    component.state = state({ dm: true, participants: [participant({ pcId: 7 })] });
+    component.selected = { 7: true };
+
+    component.category = 'ARMOR';
+    component.openShop();
+    expect(shopService.openShop).toHaveBeenCalledWith(1, 'ARMOR', '', [7]);
+
+    component.category = 'MATERIAL_COMPONENT';
+    component.openShop();
+    expect(shopService.openShop).toHaveBeenCalledWith(1, 'MATERIAL_COMPONENT', '', [7]);
+  });
+
+  it('itemMeta adapts to category', () => {
+    expect(component.itemMeta(longsword)).toBe('1d8 slashing · versatile (1d10)');
+
+    const plate: ShopItem = {
+      itemKey: 'plate', name: 'Plate Armor', category: 'ARMOR', costCp: 150000, weight: 65,
+      details: { armorClass: '18', armorCategory: 'heavy' }, stock: null,
+    };
+    expect(component.itemMeta(plate)).toBe('18 · heavy');
+
+    const revivify: ShopItem = {
+      itemKey: 'mc-revivify', name: 'Diamonds (Revivify)', category: 'MATERIAL_COMPONENT',
+      costCp: 30000, weight: null, details: { spell: 'Revivify', consumedOnCast: true }, stock: null,
+    };
+    expect(component.itemMeta(revivify)).toBe('Revivify · consumed on cast');
+
+    const identify: ShopItem = {
+      itemKey: 'mc-identify', name: 'Pearl (Identify)', category: 'MATERIAL_COMPONENT',
+      costCp: 10000, weight: null, details: { spell: 'Identify', consumedOnCast: false }, stock: null,
+    };
+    expect(component.itemMeta(identify)).toBe('Identify · reusable');
+  });
+
+  it('categoryLabel is singular per category', () => {
+    expect(component.categoryLabel('WEAPON')).toBe('Weapon');
+    expect(component.categoryLabel('ARMOR')).toBe('Armor');
+    expect(component.categoryLabel('MATERIAL_COMPONENT')).toBe('Component');
+  });
+
   it('buy purchases, patches the local PC, and notifies', () => {
     pcService.getPCById.and.returnValue({ id: 7, coins: { gp: 20 } } as PC);
     shopService.purchase.and.returnValue(of({

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { SessionState, ParticipantView } from '../../../models/session';
-import { ShopItem, ShopView, formatCp } from '../../../models/shop';
+import { ShopCategory, ShopItem, ShopView, formatCp } from '../../../models/shop';
 import { PC } from '../../../models/pc';
 import { ShopService } from '../../../services/shop.service';
 import { PCService } from '../../../services/pc.service';
@@ -31,13 +31,14 @@ export class ShopPanelComponent implements OnChanges {
 
   // DM open-shop form
   settlement = '';
-  category: 'WEAPON' | 'ARMOR' = 'WEAPON';
+  category: ShopCategory = 'WEAPON';
   selected: { [pcId: number]: boolean } = {};
 
-  /** Catalog slices a DM can open (Phase 1). */
-  readonly categories: ReadonlyArray<{ value: 'WEAPON' | 'ARMOR'; label: string }> = [
+  /** Catalog slices a DM can open (Phase 1: all three). */
+  readonly categories: ReadonlyArray<{ value: ShopCategory; label: string }> = [
     { value: 'WEAPON', label: 'Weapons' },
     { value: 'ARMOR', label: 'Armor' },
+    { value: 'MATERIAL_COMPONENT', label: 'Components' },
   ];
 
   /** Guards re-fetching the catalog on every 2s poll; only refetch on a real change. */
@@ -96,14 +97,38 @@ export class ShopPanelComponent implements OnChanges {
     return Array.isArray(v) ? v.join(', ') : (v ?? '');
   }
 
+  /** The descriptive line under an item, by category. */
+  itemMeta(item: ShopItem): string {
+    const cat = (item.category || '').toUpperCase();
+    let fields: string[];
+    if (cat === 'ARMOR') {
+      fields = [this.detail(item, 'armorClass'), this.detail(item, 'armorCategory')];
+    } else if (cat === 'MATERIAL_COMPONENT') {
+      const consumed = item.details?.['consumedOnCast'] ? 'consumed on cast' : 'reusable';
+      fields = [this.detail(item, 'spell'), consumed];
+    } else {
+      fields = [this.detail(item, 'damage'), this.detail(item, 'properties')];
+    }
+    return fields.filter(f => f).join(' · ');
+  }
+
+  /** Singular label for a category, used in shop headers. */
+  categoryLabel(category: string | null | undefined): string {
+    switch ((category || '').toUpperCase()) {
+      case 'ARMOR': return 'Armor';
+      case 'MATERIAL_COMPONENT': return 'Component';
+      default: return 'Weapon';
+    }
+  }
+
   // --- DM actions ----------------------------------------------------------
 
   openShop(): void {
     const pcIds = this.roster.filter(p => this.selected[p.pcId!]).map(p => p.pcId!);
-    this.shopService.openShop(this.state.sessionId, 'WEAPON', this.settlement.trim(), pcIds).subscribe({
+    this.shopService.openShop(this.state.sessionId, this.category, this.settlement.trim(), pcIds).subscribe({
       next: view => {
         this.shop = view;
-        this.fetchedKey = `${this.state.sessionId}|WEAPON`;
+        this.fetchedKey = `${this.state.sessionId}|${this.category}`;
       },
       error: err => this.notifications.notify(this.errMsg(err, 'Could not open the shop.')),
     });


### PR DESCRIPTION
Slice C (material components) plus cleanup of merge fallout on develop:
- FIX: develop's shop-panel HTML called categoryLabel()/itemMeta() that the merged .ts didn't have (broken AOT build), had a duplicate eyebrow, and still said "Open Weapons Shop". Rebuilt the panel: generic "Open Shop" with a Weapons/Armor/Components selector, single category-aware header, itemMeta().
- FIX: re-add the dropped .seg selector styles; gitignore .claude/.
- Slice C: Components category in the selector; itemMeta shows the consuming spell + consumed-on-cast/reusable for material components.
- spec: restore category-open + itemMeta + categoryLabel coverage and add the component cases (261 FE tests green; build OK).