### PR TITLE
feat: show XP + ready-to-level badge on the character sheet (slice C)

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -44,6 +44,16 @@
           label="level"
           (committed)="onLevelCommit($event)"
         >{{ pc.level }}</app-editable-number>
+        <span class="dot">✦</span>
+        <span
+          class="sheet-xp"
+          [title]="xpForNextLevel != null
+            ? (pc.xp || 0) + ' / ' + xpForNextLevel + ' XP to next level'
+            : 'Maximum level reached'"
+        >{{ pc.xp || 0 }} XP</span>
+        <span *ngIf="readyToLevel" class="level-ready-badge" title="Enough XP to advance — use Level Up">
+          Ready to level up
+        </span>
       </div>
     </div>
 
@@ -83,7 +93,7 @@
         </svg>
         Long Rest
       </button>
-      <button class="btn" title="Advance a level" (click)="levelUpRequested.emit()">
+      <button class="btn" [class.ready]="readyToLevel" title="Advance a level" (click)="levelUpRequested.emit()">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
              style="margin-right: 6px; vertical-align: -2px;">
           <path d="M8 13V3M8 3L4 7M8 3l4 4M3 14h10"/>

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
@@ -62,3 +62,31 @@
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
+
+// XP total in the hero subtitle — quieter than the level, sits beside it.
+.sheet-xp {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+}
+
+// "Ready to level up" badge — appears once XP crosses the next 2024 PHB
+// threshold. Purely a hint; leveling is still the explicit Level Up action.
+.level-ready-badge {
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-family: 'Newsreader', serif;
+  font-size: 11px;
+  font-style: normal;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  color: var(--gold, #d9b25f);
+  border: 1px solid var(--gold, #d9b25f);
+  border-radius: 999px;
+  background: rgba(217, 178, 95, 0.10);
+}
+
+// Emphasize the Level Up button when the character is ready to advance.
+.btn.ready {
+  color: var(--gold, #d9b25f);
+  border-color: var(--gold, #d9b25f);
+}

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { PC } from '../../models/pc';
 import { PCService } from '../../services/pc.service';
 import { tintFor } from '../../utils/character-math';
+import { isReadyToLevel, xpForNextLevel } from '../../models/xp-thresholds';
 
 @Component({
   selector: 'app-character-sheet',
@@ -25,6 +26,21 @@ export class CharacterSheetComponent implements OnChanges {
   /** Whether this PC belongs to a campaign (gates the Connect button). */
   get inCampaign(): boolean {
     return this.pc?.campaignId != null;
+  }
+
+  // ── XP (display only) ────────────────────────────────────────────────────
+  // XP accumulates via DM awards in Session Mode; leveling stays the explicit
+  // flow below. These getters drive the header's XP total and a "ready to level
+  // up" badge — they never advance a level on their own.
+
+  /** Total XP required to reach the next level, or null at max level. */
+  get xpForNextLevel(): number | null {
+    return xpForNextLevel(this.pc?.level ?? 1);
+  }
+
+  /** True once total XP has crossed the next 2024 PHB threshold. */
+  get readyToLevel(): boolean {
+    return isReadyToLevel(this.pc?.level ?? 1, this.pc?.xp ?? 0);
   }
 
   /** Briefly shows the "not in a campaign" hint after a click (hover shows it via CSS). */

--- a/src/app/charactermanager/models/xp-thresholds.ts
+++ b/src/app/charactermanager/models/xp-thresholds.ts
@@ -1,0 +1,46 @@
+/**
+ * 2024 PHB cumulative XP thresholds, indexed by character level (1–20). A
+ * character at level L becomes "ready to level up" once their total XP reaches
+ * the threshold for L+1. Used only for the display-only badge on the character
+ * sheet — leveling itself stays the explicit, server-authoritative flow, so this
+ * never advances a level on its own. (The 2024 table matches the 2014 PHB.)
+ */
+export const XP_THRESHOLDS: readonly number[] = [
+  0,       // L1
+  300,     // L2
+  900,     // L3
+  2_700,   // L4
+  6_500,   // L5
+  14_000,  // L6
+  23_000,  // L7
+  34_000,  // L8
+  48_000,  // L9
+  64_000,  // L10
+  85_000,  // L11
+  100_000, // L12
+  120_000, // L13
+  140_000, // L14
+  165_000, // L15
+  195_000, // L16
+  225_000, // L17
+  265_000, // L18
+  305_000, // L19
+  355_000, // L20
+];
+
+export const MAX_LEVEL = 20;
+
+/**
+ * Total XP required to reach the next level, or null at max level. The threshold
+ * for level L+1 lives at index L (the array is 0-based, levels are 1-based).
+ */
+export function xpForNextLevel(level: number): number | null {
+  if (level >= MAX_LEVEL) return null;
+  return XP_THRESHOLDS[level] ?? null;
+}
+
+/** Whether a character's total XP has reached the next level's threshold. */
+export function isReadyToLevel(level: number, xp: number): boolean {
+  const next = xpForNextLevel(level);
+  return next != null && xp >= next;
+}


### PR DESCRIPTION
Surfaces the XP stat added in the dm-character XP feature on the sheet header, beside the level. Adds a display-only "Ready to level up" badge that appears once total XP crosses the next 2024 PHB threshold — leveling itself stays the explicit, server-authoritative Level Up flow (the badge only emphasizes that existing button, it never auto-levels).

- models/xp-thresholds.ts: 2024 PHB cumulative XP table + xpForNextLevel / isReadyToLevel helpers (client-side; matches the 2014 table)
- character-sheet header: XP total (with "x / next XP to next level" tooltip) and the badge; Level Up button gets a .ready accent at the threshold