### PR TITLE
feat: add an XP progress bar to the character sheet

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -50,10 +50,22 @@
           [title]="xpForNextLevel != null
             ? (pc.xp || 0) + ' / ' + xpForNextLevel + ' XP to next level'
             : 'Maximum level reached'"
-        >{{ pc.xp || 0 }} XP</span>
+        >{{ pc.xp || 0 }}<ng-container *ngIf="xpForNextLevel != null"> / {{ xpForNextLevel }}</ng-container> XP</span>
         <span *ngIf="readyToLevel" class="level-ready-badge" title="Enough XP to advance — use Level Up">
           Ready to level up
         </span>
+      </div>
+
+      <!-- XP progress through the current level -->
+      <div
+        class="xp-track"
+        [class.max]="xpForNextLevel == null"
+        [class.ready]="readyToLevel"
+        [title]="xpForNextLevel != null
+          ? (pc.xp || 0) + ' / ' + xpForNextLevel + ' XP to next level'
+          : 'Maximum level reached'"
+      >
+        <span class="xp-fill" [style.width.%]="xpProgressPct"></span>
       </div>
     </div>
 

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
@@ -90,3 +90,28 @@
   color: var(--gold, #d9b25f);
   border-color: var(--gold, #d9b25f);
 }
+
+// XP progress bar — fills through the current level toward the next.
+.xp-track {
+  position: relative;
+  height: 6px;
+  margin-top: 10px;
+  max-width: 280px;
+  background: var(--bg-elev, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: 999px;
+  overflow: hidden;
+}
+.xp-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--gold, #d9b25f);
+  transition: width 0.3s ease;
+}
+// Once ready (or at max level), let the full bar glow a touch brighter.
+.xp-track.ready .xp-fill,
+.xp-track.max .xp-fill {
+  background: var(--gold, #d9b25f);
+  box-shadow: 0 0 8px rgba(217, 178, 95, 0.5);
+}

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { PC } from '../../models/pc';
 import { PCService } from '../../services/pc.service';
 import { tintFor } from '../../utils/character-math';
-import { isReadyToLevel, xpForNextLevel } from '../../models/xp-thresholds';
+import { isReadyToLevel, xpForNextLevel, xpProgressPct } from '../../models/xp-thresholds';
 
 @Component({
   selector: 'app-character-sheet',
@@ -44,6 +44,11 @@ export class CharacterSheetComponent implements OnChanges {
   /** True once total XP has crossed the next 2024 PHB threshold. */
   get readyToLevel(): boolean {
     return isReadyToLevel(this.pc?.level ?? 1, this.pc?.xp ?? 0);
+  }
+
+  /** Fill % (0–100) of the XP bar — progress through the current level. */
+  get xpProgressPct(): number {
+    return xpProgressPct(this.pc?.level ?? 1, this.pc?.xp ?? 0);
   }
 
   /** Briefly shows the "not in a campaign" hint after a click (hover shows it via CSS). */

--- a/src/app/charactermanager/models/xp-thresholds.ts
+++ b/src/app/charactermanager/models/xp-thresholds.ts
@@ -44,3 +44,17 @@ export function isReadyToLevel(level: number, xp: number): boolean {
   const next = xpForNextLevel(level);
   return next != null && xp >= next;
 }
+
+/**
+ * Progress (0–100) through the current level toward the next — the share of the
+ * current level's XP span already earned. Returns 100 at max level (or for any
+ * degenerate span). Used to fill the sheet's XP bar.
+ */
+export function xpProgressPct(level: number, xp: number): number {
+  if (level >= MAX_LEVEL) return 100;
+  const floor = XP_THRESHOLDS[level - 1] ?? 0; // current level's threshold
+  const ceil = XP_THRESHOLDS[level] ?? floor;  // next level's threshold
+  const span = ceil - floor;
+  if (span <= 0) return 100;
+  return Math.max(0, Math.min(100, ((xp - floor) / span) * 100));
+}


### PR DESCRIPTION
Adds a slim within-level XP bar under the sheet header, filling from the current level's threshold toward the next (mirrors the HP vital-bar style). The header XP text now reads "current / next XP", and the bar glows at the threshold / at max level. Display-only — leveling stays the explicit flow.

- xp-thresholds.ts: xpProgressPct(level, xp) helper (0–100, clamped)
- character-sheet: xpProgressPct getter + .xp-track/.xp-fill markup & styles