### PR TITLE
fix: remove merge-resurrected Campaign Chronicle from the dashboard

### DIFF
--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -72,10 +72,6 @@
     <app-campaign-notes [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-campaign-notes>
 
     <app-curated-shops [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-curated-shops>
-    <div class="dm-cols" style="margin-top: 20px;">
-      <app-campaign-chronicle [campaign]="vm.campaign"></app-campaign-chronicle>
-      <app-party-treasury [members]="vm.members"></app-party-treasury>
-    </div>
 
   </div>
 


### PR DESCRIPTION
A main<->develop merge re-added the old Campaign Chronicle section to the campaign dashboard (an "accept both" conflict resolution): the template referenced <app-campaign-chronicle> and a duplicate <app-party-treasury> inside a .dm-cols block. The chronicle component was deleted in #139, so the reference broke the AOT build (NG8001: not a known element) on both main and develop. Removed the stray block; the full-width party treasury above it is the intended layout.

Verified: production AOT build passes.