### PR TITLE
feat: add Sell button to inventory during an open shop

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -151,7 +151,10 @@
       <app-inventory-panel
         [pc]="pc"
         [editable]="showActions || inventoryEditable"
-        (pcChange)="onPcChange($event)">
+        [shopOpenForMe]="shopOpenForMe"
+        [shopCategory]="shopCategory"
+        (pcChange)="onPcChange($event)"
+        (sellRequested)="sellRequested.emit($event)">
       </app-inventory-panel>
       <app-spellbook-panel
         [pc]="pc"

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -24,11 +24,18 @@ export class CharacterSheetComponent implements OnChanges {
    *  Session Mode, where the header actions stay hidden but players still need to
    *  manage their inventory mid-session. */
   @Input() inventoryEditable = false;
+  /** True while a shop is open and this PC is targeted — passed through to the
+   *  inventory panel to reveal its Sell button. */
+  @Input() shopOpenForMe = false;
+  /** The open shop's category (backend format), or null for curated/no shop. */
+  @Input() shopCategory: string | null = null;
   @Output() deleteRequested = new EventEmitter<void>();
   @Output() rollRequested = new EventEmitter<void>();
   @Output() levelUpRequested = new EventEmitter<void>();
   /** Player asks to connect to their campaign's live session. */
   @Output() connectRequested = new EventEmitter<void>();
+  /** Player sells the inventory item at this index; bubbled from the inventory panel. */
+  @Output() sellRequested = new EventEmitter<number>();
 
   /** Whether this PC belongs to a campaign (gates the Connect button). */
   get inCampaign(): boolean {

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
@@ -30,6 +30,8 @@
       </div>
 
       <div *ngIf="editable" class="inv-controls">
+        <button type="button" *ngIf="canSell(item)" class="inv-btn sell" (click)="sell(i)"
+                [attr.aria-label]="'Sell ' + item.name" title="Sell to the shop">Sell</button>
         <button type="button" class="inv-btn" [class.on]="item.equipped" (click)="toggleEquipped(i)"
                 [attr.aria-label]="(item.equipped ? 'Unequip ' : 'Equip ') + item.name">
           {{ item.equipped ? 'Unequip' : 'Equip' }}

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.scss
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.scss
@@ -91,6 +91,16 @@
     border-color: var(--accent, gold);
   }
 
+  &.sell {
+    color: var(--accent, gold);
+    border-color: var(--accent, gold);
+
+    &:hover:not(:disabled) {
+      color: var(--accent, gold);
+      background: rgba(255, 215, 0, 0.1);
+    }
+  }
+
   &.danger:hover:not(:disabled) {
     color: var(--crimson, #d9534f);
     border-color: var(--crimson, #d9534f);

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.spec.ts
@@ -49,4 +49,57 @@ describe('InventoryPanelComponent', () => {
     ]);
     expect(component.totalWeight).toBe(9);
   });
+
+  describe('canSell', () => {
+    const catalogItem: PcItem = { name: 'Longsword', category: 'weapon', qty: 1, catalogKey: 'longsword' };
+    const adHocItem: PcItem = { name: 'Heirloom Ring', category: 'gear', qty: 1, unitCostCp: 500 };
+    const priceless: PcItem = { name: 'Note', category: 'gear', qty: 1 };
+
+    it('is false when no shop is open', () => {
+      component.shopOpenForMe = false;
+      expect(component.canSell(catalogItem)).toBe(false);
+    });
+
+    it('is true for a catalog item when the shop is open with no category filter (curated)', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = null;
+      expect(component.canSell(catalogItem)).toBe(true);
+    });
+
+    it('is false when the standard shop category does not match the item', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = 'ARMOR';
+      expect(component.canSell(catalogItem)).toBe(false);
+    });
+
+    it('is true when the standard shop category matches the item', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = 'WEAPON';
+      expect(component.canSell(catalogItem)).toBe(true);
+    });
+
+    it('falls back to unitCostCp for an item with no catalogKey', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = null;
+      expect(component.canSell(adHocItem)).toBe(true);
+    });
+
+    it('is false for an item with no catalogKey and no unitCostCp', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = null;
+      expect(component.canSell(priceless)).toBe(false);
+    });
+
+    it('is false for a dropped item', () => {
+      component.shopOpenForMe = true;
+      component.shopCategory = null;
+      expect(component.canSell({ ...catalogItem, status: 'dropped' })).toBe(false);
+    });
+  });
+
+  it('sell() emits the requested index via sellRequested', () => {
+    const spy = spyOn(component.sellRequested, 'emit');
+    component.sell(2);
+    expect(spy).toHaveBeenCalledWith(2);
+  });
 });

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
@@ -22,7 +22,15 @@ export class InventoryPanelComponent {
   @Input() pc!: PC;
   /** When true, shows the manage controls (equip / reduce qty / drop) and emits pcChange. */
   @Input() editable = false;
+  /** True while a shop is open and this PC is targeted — reveals the Sell button. */
+  @Input() shopOpenForMe = false;
+  /** The open shop's category (backend format, e.g. 'WEAPON'), or null for a
+   *  curated shop (buys any category) or when no shop is open. */
+  @Input() shopCategory: string | null = null;
   @Output() pcChange = new EventEmitter<PC>();
+  /** Player sells the item at this inventory index; the host owns the actual
+   *  sell transaction (it needs the session/shop context this panel doesn't have). */
+  @Output() sellRequested = new EventEmitter<number>();
 
   readonly formatCp = formatCp;
 
@@ -70,6 +78,32 @@ export class InventoryPanelComponent {
     if (!line) return;
     line.equipped = !line.equipped;
     this.emit(inventory);
+  }
+
+  /**
+   * Whether this line can be sold to the open shop right now — best-effort
+   * client-side gating (mirrors the server's rules) so a doomed sell request
+   * never gets sent. The server is still authoritative.
+   */
+  canSell(item: PcItem): boolean {
+    if (!this.shopOpenForMe) return false;
+    if (item.status === 'dropped') return false;
+    if (this.shopCategory != null && this.categoryLabelFor(this.shopCategory) !== item.category) return false;
+    return !!item.catalogKey || (item.unitCostCp != null && item.unitCostCp > 0);
+  }
+
+  sell(index: number): void {
+    this.sellRequested.emit(index);
+  }
+
+  /** Mirrors the backend's ShopService#categoryLabel mapping. */
+  private categoryLabelFor(backendCategory: string): string {
+    switch (backendCategory) {
+      case 'WEAPON': return 'weapon';
+      case 'ARMOR': return 'armor';
+      case 'MATERIAL_COMPONENT': return 'material-component';
+      default: return backendCategory.toLowerCase();
+    }
   }
 
   private emit(inventory: PcItem[]): void {

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -73,7 +73,9 @@
     <!-- Player: their own character sheet (read-only) for reference at the table -->
     <ng-container *ngIf="!state.dm && myPc(state) as pc">
       <div class="eyebrow" style="margin: 24px 0 8px;">Your Character</div>
-      <app-character-sheet [pc]="pc" [showActions]="false" [inventoryEditable]="true"></app-character-sheet>
+      <app-character-sheet [pc]="pc" [showActions]="false" [inventoryEditable]="true"
+                           [shopOpenForMe]="state.shopOpen && state.shopForMe" [shopCategory]="state.shopCategory"
+                           (sellRequested)="sell($event, state)"></app-character-sheet>
     </ng-container>
   </div>
 </ng-container>

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -7,6 +7,8 @@ import { UiStateService } from '../../services/ui-state.service';
 import { PCService } from '../../services/pc.service';
 import { NotificationService } from '../../services/notification.service';
 import { CampaignService } from '../../services/campaign.service';
+import { ShopService } from '../../services/shop.service';
+import { formatCp } from '../../models/shop';
 
 /**
  * Session Mode screen — a full-width overlay (chosen in the sidenav over the
@@ -40,6 +42,7 @@ export class SessionModeComponent implements OnInit, OnDestroy {
     private pcService: PCService,
     private notifications: NotificationService,
     private campaignService: CampaignService,
+    private shopService: ShopService,
   ) {}
 
   ngOnInit(): void {
@@ -111,6 +114,23 @@ export class SessionModeComponent implements OnInit, OnDestroy {
       conditions: mine.conditions ?? pc.conditions,
       xp: state.myXp ?? pc.xp,
     };
+  }
+
+  /**
+   * The player sells the inventory item at `index` (bubbled up from the
+   * character sheet's inventory panel) back to the open shop.
+   */
+  sell(index: number, state: SessionState): void {
+    const mine = state.participants.find(p => p.ownedByMe && p.pcId != null);
+    if (mine?.pcId == null) return;
+    const pcId = mine.pcId;
+    this.shopService.sell(state.sessionId, pcId, index).subscribe({
+      next: result => {
+        this.pcService.patchLocalPC(pcId, { coins: result.coins, inventory: result.inventory });
+        this.notifications.notify(`Sold for ${formatCp(result.totalGainCp)}.`);
+      },
+      error: () => this.notifications.notify('Could not sell that item. Try again.'),
+    });
   }
 
   /** The DM ends the session for everyone, then exits the screen. */

--- a/src/app/charactermanager/models/shop.ts
+++ b/src/app/charactermanager/models/shop.ts
@@ -35,6 +35,12 @@ export interface PurchaseResult {
   totalCostCp: number;
 }
 
+export interface SellResult {
+  coins: { cp: number; sp: number; ep: number; gp: number; pp: number };
+  inventory: PcItem[];
+  totalGainCp: number;
+}
+
 /** Break a copper price into whole gp/sp/cp (no electrum), matching the purse rates. */
 export function costToCoins(costCp: number): { gp: number; sp: number; cp: number } {
   let rem = Math.max(0, Math.floor(costCp));

--- a/src/app/charactermanager/services/shop.service.ts
+++ b/src/app/charactermanager/services/shop.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { PurchaseResult, ShopView } from '../models/shop';
+import { PurchaseResult, SellResult, ShopView } from '../models/shop';
 
 /**
  * Shop client for Session Mode. Real mode talks to character-manager-service;
@@ -62,6 +62,12 @@ export class ShopService {
     if (environment.demoMode) return this.demoUnsupported();
     return this.http.post<PurchaseResult>(`${this.base}/${sessionId}/shop/purchase`,
       { pcId, itemKey, qty });
+  }
+
+  /** Sell the entire stack at inventory position `index` back to the shop. */
+  sell(sessionId: number | string, pcId: number, index: number): Observable<SellResult> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.post<SellResult>(`${this.base}/${sessionId}/shop/sell`, { pcId, index });
   }
 
   private demoUnsupported<T>(): Observable<T> {


### PR DESCRIPTION
Adds a gold Sell button to the left of Equip on each inventory row, shown only while a shop is open and targeting this character. Selling calls the new shop sell endpoint and patches the local PC store with the returned coins/inventory, mirroring the existing buy flow. Client- side gating (shop category match, dropped-item exclusion, resolvable price) mirrors the server's rules so a doomed request never gets sent, but the server remains authoritative.