### PR TITLE
feat: curate encounters on the campaign screen and load them in-session

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -41,6 +41,7 @@ import { PartyBoardComponent } from './components/campaign-dashboard/party-board
 import { PartyTreasuryComponent } from './components/campaign-dashboard/party-treasury/party-treasury.component';
 import { CampaignNotesComponent } from './components/campaign-dashboard/campaign-notes/campaign-notes.component';
 import { CuratedShopsComponent } from './components/campaign-dashboard/curated-shops/curated-shops.component';
+import { CuratedEncountersComponent } from './components/campaign-dashboard/curated-encounters/curated-encounters.component';
 import { CreateCampaignModalComponent } from './components/create-campaign-modal/create-campaign-modal.component';
 import { JoinCampaignModalComponent } from './components/join-campaign-modal/join-campaign-modal.component';
 
@@ -48,6 +49,7 @@ import { JoinCampaignModalComponent } from './components/join-campaign-modal/joi
 import { SessionModeComponent } from './components/session-mode/session-mode.component';
 import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
 import { ShopPanelComponent } from './components/session-mode/shop-panel/shop-panel.component';
+import { EncounterLoaderComponent } from './components/session-mode/encounter-loader/encounter-loader.component';
 import { SessionLiveBannerComponent } from './components/session-live-banner/session-live-banner.component';
 import { ToastComponent } from './components/toast/toast.component';
 
@@ -109,11 +111,13 @@ const routes: Routes = [
     PartyTreasuryComponent,
     CampaignNotesComponent,
     CuratedShopsComponent,
+    CuratedEncountersComponent,
     CreateCampaignModalComponent,
     JoinCampaignModalComponent,
     SessionModeComponent,
     InitiativePanelComponent,
     ShopPanelComponent,
+    EncounterLoaderComponent,
     SessionLiveBannerComponent,
     ToastComponent,
   ],

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -73,6 +73,8 @@
 
     <app-curated-shops [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-curated-shops>
 
+    <app-curated-encounters [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-curated-encounters>
+
   </div>
 
   <!-- Manage Party — bind/unbind your characters to this campaign -->

--- a/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.html
@@ -1,0 +1,74 @@
+<section class="curated-card">
+  <div class="eyebrow">DM · Encounters</div>
+
+  <!-- ===== Encounter list ===== -->
+  <ng-container *ngIf="!selected">
+    <h2 class="curated-title">Curated Encounters</h2>
+
+    <div class="new-shop">
+      <input class="text-input" type="text" [(ngModel)]="newName"
+             placeholder="New encounter name (e.g. Goblin Ambush)"
+             (keyup.enter)="createEncounter()" />
+      <button class="btn primary" [disabled]="!newName.trim() || busy" (click)="createEncounter()">Create</button>
+    </div>
+
+    <ul class="shop-list" *ngIf="encounters.length; else noEncounters">
+      <li class="shop-row" *ngFor="let e of encounters; trackBy: trackById" (click)="open(e)">
+        <div>
+          <div class="shop-name">{{ e.name }}</div>
+          <div class="shop-sub">{{ e.creatureCount }} creature{{ e.creatureCount === 1 ? '' : 's' }}</div>
+        </div>
+        <span class="chevron">›</span>
+      </li>
+    </ul>
+    <ng-template #noEncounters>
+      <div class="muted">No curated encounters yet. Create one, then add creatures to it.</div>
+    </ng-template>
+  </ng-container>
+
+  <!-- ===== Encounter editor ===== -->
+  <ng-container *ngIf="selected as encounter">
+    <div class="editor-head">
+      <button class="btn link" (click)="back()">‹ All encounters</button>
+      <button class="btn danger" (click)="deleteEncounter()">Delete encounter</button>
+    </div>
+
+    <h2 class="curated-title">{{ encounter.name }}</h2>
+
+    <div class="field-label">Notes</div>
+    <textarea class="text-input notes" rows="2" [(ngModel)]="notesDraft"
+              placeholder="Tactics, terrain, read-aloud text…"></textarea>
+    <div class="notes-actions">
+      <button class="btn" [disabled]="notesDraft === (encounter.notes ?? '')" (click)="saveNotes()">Save notes</button>
+    </div>
+
+    <div class="field-label">Add a creature</div>
+    <div class="creature-form">
+      <input class="text-input" type="text" [(ngModel)]="cName" placeholder="Name (e.g. Goblin)"
+             (keyup.enter)="addCreature()" />
+      <input class="num-input" type="number" [(ngModel)]="cDex" placeholder="DEX mod" title="DEX modifier" />
+      <input class="num-input" type="number" min="1" [(ngModel)]="cHp" placeholder="HP" title="Max HP (optional)" />
+      <input class="num-input" type="number" min="1" [(ngModel)]="cQty" placeholder="Qty" title="Quantity" />
+      <button class="btn primary" [disabled]="!cName.trim() || cDex == null || busy" (click)="addCreature()">Add</button>
+    </div>
+
+    <ul class="catalog" *ngIf="encounter.creatures.length; else emptyEncounter">
+      <li class="catalog-row" *ngFor="let c of encounter.creatures; trackBy: trackById">
+        <div class="item-main">
+          <span class="item-name">{{ c.quantity > 1 ? c.quantity + '× ' : '' }}{{ c.name }}</span>
+          <span class="item-meta">
+            DEX {{ c.dexModifier >= 0 ? '+' : '' }}{{ c.dexModifier }}<ng-container *ngIf="c.hpMax != null"> · {{ c.hpMax }} HP</ng-container>
+          </span>
+        </div>
+        <button class="btn-x" title="Remove" (click)="removeCreature(c)">✕</button>
+      </li>
+    </ul>
+    <ng-template #emptyEncounter>
+      <div class="muted">No creatures yet. Add one above.</div>
+    </ng-template>
+
+    <div class="total-line" *ngIf="encounter.creatures.length">
+      Loads {{ totalCombatants(encounter) }} combatant{{ totalCombatants(encounter) === 1 ? '' : 's' }} into a session.
+    </div>
+  </ng-container>
+</section>

--- a/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.scss
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.scss
@@ -1,0 +1,152 @@
+.curated-card {
+  display: block;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+  border-radius: 12px;
+  padding: 18px 20px;
+}
+
+.curated-title {
+  margin: 2px 0 14px;
+  font-size: 1.15rem;
+}
+
+.new-shop {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.text-input {
+  flex: 1;
+  padding: 8px 10px;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+}
+
+.text-input.notes {
+  width: 100%;
+  resize: vertical;
+}
+
+.notes-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin: 8px 0 4px;
+}
+
+.shop-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.shop-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 12px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: 10px;
+  margin-bottom: 8px;
+  cursor: pointer;
+
+  &:hover { border-color: var(--celestial, rgba(120, 170, 255, 0.5)); }
+}
+
+.shop-name { font-weight: 600; }
+.shop-sub {
+  font-size: 0.8rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+}
+.chevron { color: var(--muted, rgba(255, 255, 255, 0.5)); font-size: 1.4rem; }
+
+.editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.btn.link {
+  background: transparent;
+  border: 0;
+  color: var(--celestial, #8aabff);
+  padding: 0;
+  cursor: pointer;
+}
+
+.field-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  margin: 12px 0 6px;
+}
+
+.creature-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.num-input {
+  width: 80px;
+  padding: 8px 10px;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+}
+
+.catalog {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.catalog-row {
+  display: grid;
+  grid-template-columns: 1fr 28px;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border, rgba(255, 255, 255, 0.10));
+}
+
+.item-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.item-name { font-weight: 600; }
+.item-meta {
+  font-size: 0.78rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+}
+
+.btn-x {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  background: transparent;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  cursor: pointer;
+
+  &:hover { border-color: var(--crimson, #d9534f); color: var(--crimson, #d9534f); }
+}
+
+.muted {
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  font-size: 0.85rem;
+  padding: 6px 0;
+}
+
+.total-line {
+  margin-top: 12px;
+  font-size: 0.8rem;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+}

--- a/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.spec.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.spec.ts
@@ -1,0 +1,117 @@
+import { of } from 'rxjs';
+import { CuratedEncountersComponent } from './curated-encounters.component';
+import { Campaign } from '../../../models/campaign';
+import { Encounter, EncounterSummary } from '../../../models/encounter';
+
+/** Tests the component class directly (no TestBed/DOM), per the app convention. */
+describe('CuratedEncountersComponent', () => {
+  let component: CuratedEncountersComponent;
+  let service: any;
+
+  const campaign = { id: '1', name: 'The Veiled Compass' } as unknown as Campaign;
+
+  const encounter: Encounter = {
+    id: 5, campaignId: 1, name: 'Goblin Ambush', notes: 'They wait in the trees.',
+    creatures: [{ id: 9, name: 'Goblin', dexModifier: 2, hpMax: 7, quantity: 4 }],
+  };
+
+  beforeEach(() => {
+    service = jasmine.createSpyObj('CuratedEncounterService',
+      ['list', 'create', 'get', 'update', 'delete', 'addCreature', 'updateCreature', 'removeCreature']);
+    service.list.and.returnValue(of([] as EncounterSummary[]));
+    component = new CuratedEncountersComponent(service);
+    component.campaign = campaign;
+  });
+
+  it('loads encounters when the campaign changes', () => {
+    const summaries: EncounterSummary[] = [
+      { id: 5, campaignId: 1, name: 'Goblin Ambush', notes: null, creatureCount: 1 }];
+    service.list.and.returnValue(of(summaries));
+    component.ngOnChanges({ campaign: {} as any });
+    expect(service.list).toHaveBeenCalledWith('1');
+    expect(component.encounters).toEqual(summaries);
+    expect(component.selected).toBeNull();
+  });
+
+  it('createEncounter posts the name and selects the new encounter', () => {
+    service.create.and.returnValue(of(encounter));
+    component.newName = '  Goblin Ambush  ';
+    component.createEncounter();
+    expect(service.create).toHaveBeenCalledWith('1', 'Goblin Ambush', '');
+    expect(component.selected).toBe(encounter);
+    expect(component.notesDraft).toBe('They wait in the trees.');
+    expect(component.newName).toBe('');
+  });
+
+  it('createEncounter ignores a blank name', () => {
+    component.newName = '   ';
+    component.createEncounter();
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
+  it('open loads the full encounter and seeds the notes draft', () => {
+    service.get.and.returnValue(of(encounter));
+    component.open({ id: 5 } as EncounterSummary);
+    expect(service.get).toHaveBeenCalledWith(5);
+    expect(component.selected).toBe(encounter);
+    expect(component.notesDraft).toBe('They wait in the trees.');
+  });
+
+  it('addCreature posts the form, defaults quantity, and resets the form', () => {
+    component.selected = encounter;
+    component.cName = '  Goblin Boss ';
+    component.cDex = 1;
+    component.cHp = 21;
+    component.cQty = 1;
+    const after = { ...encounter, creatures: [...encounter.creatures,
+      { id: 10, name: 'Goblin Boss', dexModifier: 1, hpMax: 21, quantity: 1 }] };
+    service.addCreature.and.returnValue(of(after));
+    component.addCreature();
+    expect(service.addCreature).toHaveBeenCalledWith(5, 'Goblin Boss', 1, 21, 1);
+    expect(component.selected!.creatures.length).toBe(2);
+    expect(component.cName).toBe('');
+    expect(component.cDex).toBeNull();
+  });
+
+  it('addCreature requires a name and DEX modifier', () => {
+    component.selected = encounter;
+    component.cName = 'Goblin';
+    component.cDex = null;
+    component.addCreature();
+    expect(service.addCreature).not.toHaveBeenCalled();
+  });
+
+  it('saveNotes sends the draft with the unchanged name', () => {
+    component.selected = encounter;
+    component.notesDraft = 'New tactics';
+    service.update.and.returnValue(of({ ...encounter, notes: 'New tactics' }));
+    component.saveNotes();
+    expect(service.update).toHaveBeenCalledWith(5, 'Goblin Ambush', 'New tactics');
+    expect(component.selected!.notes).toBe('New tactics');
+  });
+
+  it('removeCreature updates the selected encounter', () => {
+    component.selected = encounter;
+    const after = { ...encounter, creatures: [] };
+    service.removeCreature.and.returnValue(of(after));
+    component.removeCreature(encounter.creatures[0]);
+    expect(service.removeCreature).toHaveBeenCalledWith(5, 9);
+    expect(component.selected!.creatures.length).toBe(0);
+  });
+
+  it('totalCombatants sums the quantities', () => {
+    const e = { ...encounter, creatures: [
+      { id: 1, name: 'Goblin', dexModifier: 2, hpMax: 7, quantity: 4 },
+      { id: 2, name: 'Boss', dexModifier: 1, hpMax: 21, quantity: 1 }] };
+    expect(component.totalCombatants(e)).toBe(5);
+  });
+
+  it('deleteEncounter clears selection and reloads', () => {
+    component.selected = encounter;
+    service.delete.and.returnValue(of(void 0));
+    component.deleteEncounter();
+    expect(service.delete).toHaveBeenCalledWith(5);
+    expect(component.selected).toBeNull();
+    expect(service.list).toHaveBeenCalled(); // back() reloads
+  });
+});

--- a/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-encounters/curated-encounters.component.ts
@@ -1,0 +1,134 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Campaign } from '../../../models/campaign';
+import { Encounter, EncounterCreature, EncounterSummary } from '../../../models/encounter';
+import { CuratedEncounterService } from '../../../services/curated-encounter.service';
+
+/**
+ * DM-curated encounters panel on the campaign dashboard. The DM creates reusable
+ * encounters and fills them with free-hand enemy creatures (name, DEX modifier,
+ * optional HP, quantity); the encounter is later loaded into Session Mode, where
+ * each creature becomes an enemy combatant. Mirrors the curated-shops panel:
+ * reloads when the selected campaign changes.
+ */
+@Component({
+  selector: 'app-curated-encounters',
+  templateUrl: './curated-encounters.component.html',
+  styleUrls: ['./curated-encounters.component.scss'],
+})
+export class CuratedEncountersComponent implements OnChanges {
+  @Input() campaign!: Campaign;
+
+  encounters: EncounterSummary[] = [];
+  selected: Encounter | null = null;
+  newName = '';
+  notesDraft = '';
+  busy = false;
+
+  // The "add creature" form.
+  cName = '';
+  cDex: number | null = null;
+  cHp: number | null = null;
+  cQty = 1;
+
+  constructor(private curatedEncounters: CuratedEncounterService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['campaign']) {
+      this.selected = null;
+      this.loadEncounters();
+    }
+  }
+
+  private loadEncounters(): void {
+    if (!this.campaign) { this.encounters = []; return; }
+    this.curatedEncounters.list(this.campaign.id).subscribe({
+      next: encounters => (this.encounters = encounters),
+      error: err => console.error('Failed to load curated encounters', err),
+    });
+  }
+
+  createEncounter(): void {
+    const name = this.newName.trim();
+    if (!name || this.busy) return;
+    this.busy = true;
+    this.curatedEncounters.create(this.campaign.id, name, '').subscribe({
+      next: encounter => {
+        this.newName = '';
+        this.busy = false;
+        this.select(encounter);
+        this.loadEncounters();
+      },
+      error: err => { this.busy = false; console.error('Failed to create encounter', err); },
+    });
+  }
+
+  open(summary: EncounterSummary): void {
+    this.curatedEncounters.get(summary.id).subscribe({
+      next: encounter => this.select(encounter),
+      error: err => console.error('Failed to open encounter', err),
+    });
+  }
+
+  back(): void {
+    this.selected = null;
+    this.loadEncounters(); // refresh creature counts
+  }
+
+  /** Persist the notes textarea (name unchanged). */
+  saveNotes(): void {
+    if (!this.selected) return;
+    this.curatedEncounters.update(this.selected.id, this.selected.name, this.notesDraft).subscribe({
+      next: encounter => this.select(encounter),
+      error: err => console.error('Failed to save notes', err),
+    });
+  }
+
+  addCreature(): void {
+    if (!this.selected || this.busy) return;
+    const name = this.cName.trim();
+    if (!name || this.cDex == null) return;
+    const qty = this.cQty && this.cQty >= 1 ? Math.floor(this.cQty) : 1;
+    this.busy = true;
+    this.curatedEncounters.addCreature(this.selected.id, name, this.cDex, this.cHp, qty).subscribe({
+      next: encounter => {
+        this.select(encounter);
+        this.cName = '';
+        this.cDex = null;
+        this.cHp = null;
+        this.cQty = 1;
+        this.busy = false;
+      },
+      error: err => { this.busy = false; console.error('Failed to add creature', err); },
+    });
+  }
+
+  removeCreature(creature: EncounterCreature): void {
+    if (!this.selected) return;
+    this.curatedEncounters.removeCreature(this.selected.id, creature.id).subscribe({
+      next: encounter => this.select(encounter),
+      error: err => console.error('Failed to remove creature', err),
+    });
+  }
+
+  deleteEncounter(): void {
+    if (!this.selected) return;
+    this.curatedEncounters.delete(this.selected.id).subscribe({
+      next: () => this.back(),
+      error: err => console.error('Failed to delete encounter', err),
+    });
+  }
+
+  /** Total combatants this encounter will spawn (sum of quantities). */
+  totalCombatants(encounter: Encounter): number {
+    return encounter.creatures.reduce((sum, c) => sum + Math.max(1, c.quantity), 0);
+  }
+
+  trackById(_index: number, x: { id: number }): number {
+    return x.id;
+  }
+
+  private select(encounter: Encounter): void {
+    this.selected = encounter;
+    this.notesDraft = encounter.notes ?? '';
+  }
+}

--- a/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.html
+++ b/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.html
@@ -1,0 +1,20 @@
+<section class="encounter-loader" *ngIf="state.dm">
+  <div class="eyebrow">DM · Encounters</div>
+  <h3 class="loader-title">Load an encounter</h3>
+
+  <div class="loader-row" *ngIf="encounters.length; else noEncounters">
+    <select class="select" [(ngModel)]="selectedId">
+      <option [ngValue]="null" disabled>Choose an encounter…</option>
+      <option *ngFor="let e of encounters; trackBy: trackById" [ngValue]="e.id">
+        {{ e.name }} ({{ e.creatureCount }})
+      </option>
+    </select>
+    <button class="btn primary" [disabled]="selectedId == null || busy" (click)="load()">Load</button>
+  </div>
+
+  <div class="notes" *ngIf="selectedNotes">{{ selectedNotes }}</div>
+
+  <ng-template #noEncounters>
+    <div class="muted">No curated encounters for this campaign. Build one on the campaign screen.</div>
+  </ng-template>
+</section>

--- a/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.scss
+++ b/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.scss
@@ -1,0 +1,40 @@
+.encounter-loader {
+  display: block;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  background: var(--bg-elev, rgba(255, 255, 255, 0.04));
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+
+.loader-title {
+  margin: 2px 0 12px;
+  font-size: 1.02rem;
+}
+
+.loader-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.select {
+  flex: 1;
+  padding: 8px 10px;
+  font: inherit;
+  color: var(--text);
+  background: var(--bg, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.16));
+  border-radius: 8px;
+}
+
+.notes {
+  margin-top: 10px;
+  font-size: 0.82rem;
+  color: var(--muted, rgba(255, 255, 255, 0.7));
+  font-style: italic;
+}
+
+.muted {
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  font-size: 0.85rem;
+}

--- a/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.spec.ts
@@ -1,0 +1,75 @@
+import { of, throwError } from 'rxjs';
+import { EncounterLoaderComponent } from './encounter-loader.component';
+import { SessionState } from '../../../models/session';
+import { EncounterSummary } from '../../../models/encounter';
+
+/** Tests the component class directly (no TestBed/DOM), per the app convention. */
+describe('EncounterLoaderComponent', () => {
+  let component: EncounterLoaderComponent;
+  let curated: any;
+  let session: any;
+  let notifications: any;
+
+  const summaries: EncounterSummary[] = [
+    { id: 5, campaignId: 1, name: 'Goblin Ambush', notes: 'In the trees.', creatureCount: 3 }];
+
+  const dmState = (over: Partial<SessionState> = {}): SessionState =>
+    ({ sessionId: 7, campaignId: 1, dm: true, participants: [], ...over } as unknown as SessionState);
+
+  beforeEach(() => {
+    curated = jasmine.createSpyObj('CuratedEncounterService', ['list']);
+    curated.list.and.returnValue(of(summaries));
+    session = jasmine.createSpyObj('SessionService', ['loadEncounter']);
+    notifications = jasmine.createSpyObj('NotificationService', ['notify']);
+    component = new EncounterLoaderComponent(curated, session, notifications);
+  });
+
+  it('loads the campaign encounters once for the DM', () => {
+    component.state = dmState();
+    component.ngOnChanges();
+    component.ngOnChanges(); // second poll tick — must not refetch
+    expect(curated.list).toHaveBeenCalledTimes(1);
+    expect(component.encounters).toEqual(summaries);
+  });
+
+  it('does not fetch for a non-DM viewer', () => {
+    component.state = dmState({ dm: false });
+    component.ngOnChanges();
+    expect(curated.list).not.toHaveBeenCalled();
+  });
+
+  it('exposes the selected encounter notes', () => {
+    component.state = dmState();
+    component.ngOnChanges();
+    component.selectedId = 5;
+    expect(component.selectedNotes).toBe('In the trees.');
+  });
+
+  it('load posts to the session and toasts on success', () => {
+    component.state = dmState();
+    component.ngOnChanges();
+    component.selectedId = 5;
+    session.loadEncounter.and.returnValue(of({} as SessionState));
+    component.load();
+    expect(session.loadEncounter).toHaveBeenCalledWith(7, 5);
+    expect(notifications.notify).toHaveBeenCalledWith('Loaded Goblin Ambush into the session.');
+    expect(component.selectedId).toBeNull();
+    expect(component.busy).toBeFalse();
+  });
+
+  it('load does nothing without a selection', () => {
+    component.state = dmState();
+    component.load();
+    expect(session.loadEncounter).not.toHaveBeenCalled();
+  });
+
+  it('load surfaces an error toast and clears busy', () => {
+    component.state = dmState();
+    component.ngOnChanges();
+    component.selectedId = 5;
+    session.loadEncounter.and.returnValue(throwError(() => ({ error: { message: 'boom' } })));
+    component.load();
+    expect(notifications.notify).toHaveBeenCalledWith('boom');
+    expect(component.busy).toBeFalse();
+  });
+});

--- a/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.ts
+++ b/src/app/charactermanager/components/session-mode/encounter-loader/encounter-loader.component.ts
@@ -1,0 +1,72 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { SessionState } from '../../../models/session';
+import { EncounterSummary } from '../../../models/encounter';
+import { CuratedEncounterService } from '../../../services/curated-encounter.service';
+import { SessionService } from '../../../services/session.service';
+import { NotificationService } from '../../../services/notification.service';
+
+/**
+ * DM-only in-session control: pick one of the campaign's curated encounters and
+ * load its creatures into the initiative tracker as enemy combatants. Mirrors the
+ * curated-shop side of the shop panel — the campaign's encounters are fetched once
+ * per campaign, and loading appends enemies (the DM then rolls their initiative).
+ */
+@Component({
+  selector: 'app-encounter-loader',
+  templateUrl: './encounter-loader.component.html',
+  styleUrls: ['./encounter-loader.component.scss'],
+})
+export class EncounterLoaderComponent implements OnChanges {
+  @Input() state!: SessionState;
+
+  encounters: EncounterSummary[] = [];
+  selectedId: number | null = null;
+  busy = false;
+
+  private loadedFor: string | null = null;
+
+  constructor(
+    private curatedEncounters: CuratedEncounterService,
+    private sessionService: SessionService,
+    private notifications: NotificationService,
+  ) {}
+
+  ngOnChanges(): void {
+    const s = this.state;
+    if (!s || !s.dm) return;
+    // The poll re-emits state every 2s; only refetch when the campaign changes.
+    if (`${s.campaignId}` !== this.loadedFor) {
+      this.loadedFor = `${s.campaignId}`;
+      this.curatedEncounters.list(s.campaignId).subscribe({
+        next: encounters => (this.encounters = encounters),
+        error: () => (this.encounters = []),
+      });
+    }
+  }
+
+  get selectedNotes(): string | null {
+    const e = this.encounters.find(x => x.id === this.selectedId);
+    return e?.notes ?? null;
+  }
+
+  load(): void {
+    if (this.selectedId == null || this.busy) return;
+    const encounter = this.encounters.find(x => x.id === this.selectedId);
+    this.busy = true;
+    this.sessionService.loadEncounter(this.state.sessionId, this.selectedId).subscribe({
+      next: () => {
+        this.busy = false;
+        this.notifications.notify(`Loaded ${encounter?.name ?? 'encounter'} into the session.`);
+        this.selectedId = null;
+      },
+      error: err => {
+        this.busy = false;
+        this.notifications.notify(err?.error?.message || 'Could not load the encounter.');
+      },
+    });
+  }
+
+  trackById(_index: number, e: EncounterSummary): number {
+    return e.id;
+  }
+}

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -108,6 +108,8 @@
       [turnSound]="state.turnSound"
     ></app-initiative-panel>
 
+    <app-encounter-loader [state]="state" *ngIf="state.dm" style="display: block; margin-top: 16px;"></app-encounter-loader>
+
     <app-shop-panel [state]="state"></app-shop-panel>
     <!-- DM-only: capture a note to the campaign log without leaving the table -->
     <div *ngIf="state.dm" class="panel session-note">

--- a/src/app/charactermanager/models/encounter.ts
+++ b/src/app/charactermanager/models/encounter.ts
@@ -1,0 +1,30 @@
+/**
+ * DM-curated encounter types — client mirror of the backend EncounterView /
+ * EncounterCreatureView / EncounterSummaryView DTOs. An encounter is a reusable,
+ * named list of enemy creatures a DM builds on the campaign screen and loads into
+ * a live session, where each creature becomes an enemy combatant.
+ */
+
+export interface EncounterSummary {
+  id: number;
+  campaignId: number;
+  name: string;
+  notes: string | null;
+  creatureCount: number;
+}
+
+export interface EncounterCreature {
+  id: number;
+  name: string;
+  dexModifier: number;      // DM-calculated initiative tie-breaker
+  hpMax: number | null;     // null = untracked HP
+  quantity: number;         // expands into that many numbered combatants on load
+}
+
+export interface Encounter {
+  id: number;
+  campaignId: number;
+  name: string;
+  notes: string | null;
+  creatures: EncounterCreature[];
+}

--- a/src/app/charactermanager/services/curated-encounter.service.spec.ts
+++ b/src/app/charactermanager/services/curated-encounter.service.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { environment } from '../../../environments/environment';
+import { CuratedEncounterService } from './curated-encounter.service';
+
+describe('CuratedEncounterService', () => {
+  let service: CuratedEncounterService;
+  let httpMock: HttpTestingController;
+  const base = `${environment.characterApiUrl}/api/v1`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [CuratedEncounterService],
+    });
+    service = TestBed.inject(CuratedEncounterService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('list GETs the campaign encounters', () => {
+    service.list(1).subscribe();
+    const req = httpMock.expectOne(`${base}/campaign/1/encounters`);
+    expect(req.request.method).toBe('GET');
+    req.flush([]);
+  });
+
+  it('create POSTs the name and notes', () => {
+    service.create(1, 'Goblin Ambush', 'In the trees.').subscribe();
+    const req = httpMock.expectOne(`${base}/campaign/1/encounters`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'Goblin Ambush', notes: 'In the trees.' });
+    req.flush({});
+  });
+
+  it('addCreature POSTs the creature fields', () => {
+    service.addCreature(5, 'Goblin', 2, 7, 4).subscribe();
+    const req = httpMock.expectOne(`${base}/encounters/5/creatures`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ name: 'Goblin', dexModifier: 2, hpMax: 7, quantity: 4 });
+    req.flush({});
+  });
+
+  it('removeCreature DELETEs the line', () => {
+    service.removeCreature(5, 9).subscribe();
+    const req = httpMock.expectOne(`${base}/encounters/5/creatures/9`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+  });
+
+  it('delete DELETEs the encounter', () => {
+    service.delete(5).subscribe();
+    const req = httpMock.expectOne(`${base}/encounters/5`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+});

--- a/src/app/charactermanager/services/curated-encounter.service.ts
+++ b/src/app/charactermanager/services/curated-encounter.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Encounter, EncounterSummary } from '../models/encounter';
+
+/**
+ * DM-curated encounter management client. Talks to the campaign-scoped
+ * curated-encounter API; the DM builds reusable encounters out of session, then
+ * loads them into Session Mode. Demo mode has no backend, so reads return empty
+ * and writes are rejected.
+ */
+@Injectable({ providedIn: 'root' })
+export class CuratedEncounterService {
+
+  private readonly base = `${environment.characterApiUrl}/api/v1`;
+
+  constructor(private http: HttpClient) {}
+
+  list(campaignId: number | string): Observable<EncounterSummary[]> {
+    // Demo has no backend; offer one canned encounter so the in-session loader is
+    // still exercisable (SessionService.demoLoadEncounter spawns its creatures).
+    if (environment.demoMode) {
+      return of([{ id: -1, campaignId: Number(campaignId) || 0, name: 'Goblin Ambush (demo)',
+        notes: 'Three goblins spring from the underbrush.', creatureCount: 3 }]);
+    }
+    return this.http.get<EncounterSummary[]>(`${this.base}/campaign/${campaignId}/encounters`);
+  }
+
+  create(campaignId: number | string, name: string, notes: string): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.post<Encounter>(`${this.base}/campaign/${campaignId}/encounters`, { name, notes });
+  }
+
+  get(encounterId: number): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.get<Encounter>(`${this.base}/encounters/${encounterId}`);
+  }
+
+  update(encounterId: number, name: string, notes: string): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.put<Encounter>(`${this.base}/encounters/${encounterId}`, { name, notes });
+  }
+
+  delete(encounterId: number): Observable<void> {
+    if (environment.demoMode) return of(void 0);
+    return this.http.delete<void>(`${this.base}/encounters/${encounterId}`);
+  }
+
+  addCreature(encounterId: number, name: string, dexModifier: number,
+              hpMax: number | null, quantity: number): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.post<Encounter>(`${this.base}/encounters/${encounterId}/creatures`,
+      { name, dexModifier, hpMax, quantity });
+  }
+
+  updateCreature(encounterId: number, creatureId: number, name: string, dexModifier: number,
+                 hpMax: number | null, quantity: number): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.put<Encounter>(`${this.base}/encounters/${encounterId}/creatures/${creatureId}`,
+      { name, dexModifier, hpMax, quantity });
+  }
+
+  removeCreature(encounterId: number, creatureId: number): Observable<Encounter> {
+    if (environment.demoMode) return this.demoUnsupported();
+    return this.http.delete<Encounter>(`${this.base}/encounters/${encounterId}/creatures/${creatureId}`);
+  }
+
+  private demoUnsupported<T>(): Observable<T> {
+    return throwError(() => new Error('Curated encounters are not available in demo mode'));
+  }
+}

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -302,6 +302,21 @@ export class SessionService {
     );
   }
 
+  /**
+   * DM loads a curated encounter: every creature becomes an enemy combatant,
+   * appended to the current order with no initiative (the DM rolls). Quantity is
+   * expanded server-side into numbered rows.
+   */
+  loadEncounter(sessionId: number | string, encounterId: number): Observable<SessionState> {
+    if (environment.demoMode) return of(this.demoLoadEncounter());
+    return this.http.post<unknown>(`${this.sessionBase}/${sessionId}/encounter/load`, {
+      encounterId,
+    }).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(state => this.pushState(state)),
+    );
+  }
+
   /** DM toggles whether players can see enemy combatants at all. */
   setVisibility(sessionId: number | string, enemiesHidden: boolean): Observable<SessionState> {
     if (environment.demoMode) return of(this.demoPatch({ enemiesHidden }));
@@ -494,6 +509,23 @@ export class SessionService {
       deathSaveSuccesses: 0, deathSaveFailures: 0,
     };
     const participants = this.demoSort([...state.participants, enemy]);
+    const next = this.demoWithPointers({ ...state, participants, version: state.version + 1 });
+    this.pushState(next);
+    return next;
+  }
+
+  /** Demo: spawn the canned "Goblin Ambush" encounter as three enemy rows. */
+  private demoLoadEncounter(): SessionState {
+    const state = this.stateSubject.getValue() ?? this.emptyState('demo-session');
+    const base = Date.now();
+    const goblins: ParticipantView[] = [1, 2, 3].map((n, i) => ({
+      participantId: base + i, pcId: null, npc: true, ownedByMe: false, currentTurn: false,
+      name: `Goblin ${n}`, clazz: null, level: null, portraitTint: null, portraitInitials: null,
+      initiative: null, initRolled: false, dexModifier: 2, orderIndex: state.participants.length + i,
+      hpMax: 7, hpCurrent: 7, hpTemp: null, ac: null, conditions: [],
+      deathSaveSuccesses: 0, deathSaveFailures: 0,
+    }));
+    const participants = this.demoSort([...state.participants, ...goblins]);
     const next = this.demoWithPointers({ ...state, participants, version: state.version + 1 });
     this.pushState(next);
     return next;


### PR DESCRIPTION
Mirrors curated shops for combat. On the campaign dashboard the DM builds reusable encounters as a free-hand list of enemy creatures (name, DEX modifier, optional HP, quantity) plus free-text notes. In Session Mode a DM-only "Load an encounter" control drops the chosen encounter's creatures into the initiative tracker as enemy combatants (quantity expands to numbered rows; no initiative — the DM rolls).

- encounter model + CuratedEncounterService (CRUD)
- SessionService.loadEncounter -> POST /session/{id}/encounter/load, with a demo-mode stub so the flow is exercisable without a backend
- CuratedEncountersComponent (dashboard) + EncounterLoaderComponent (session)
- module wiring + template slots next to curated shops / initiative panel
- specs for the service and both components