### PR TITLE
feat: show party survival to the DM and the clock on the dashboard

### DIFF
--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -13,6 +13,10 @@
           <span class="eyebrow">Invite</span>
           <span class="invite-code numeric">{{ vm.campaign.inviteCode }}</span>
         </div>
+        <div class="invite-chip" *ngIf="vm.campaign.gameTime" title="The in-world clock — advance it from Session Mode">
+          <span class="eyebrow">Clock</span>
+          <span class="invite-code">{{ describeGameTime(vm.campaign.gameTime) }}</span>
+        </div>
       </div>
       <div class="sheet-actions">
         <button class="btn" (click)="openManageParty()">

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.ts
@@ -9,6 +9,7 @@ import { SessionService } from '../../services/session.service';
 import { UiStateService } from '../../services/ui-state.service';
 import { SessionState } from '../../models/session';
 import { passiveScore, tintFor } from '../../utils/character-math';
+import { describeGameTime } from '../../utils/survival';
 
 interface DashboardVm {
   campaign: Campaign;
@@ -32,6 +33,9 @@ interface DashboardVm {
   templateUrl: './campaign-dashboard.component.html',
 })
 export class CampaignDashboardComponent {
+  /** In-world clock label for the header chip (campaigns$ keeps it fresh). */
+  readonly describeGameTime = describeGameTime;
+
   // Bump to re-pull the member projection (after a bind/unbind).
   private membersRefresh$ = new BehaviorSubject<void>(undefined);
 

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
@@ -66,6 +66,13 @@
       <div class="board-conditions">
         <span *ngIf="!p.conditions?.length" class="board-cond calm">steady</span>
         <span *ngFor="let c of p.conditions" class="board-cond">{{ c }}</span>
+        <!-- DM only: the party's survival stages at a glance (variant campaigns).
+             Muted while fine; the chip goes crimson at stage 5-6. -->
+        <ng-container *ngIf="dm && survivalConditions">
+          <span *ngFor="let chip of survivalChips(p)" class="board-cond"
+                [class.calm]="!chip.dire"
+                [title]="chip.title">{{ chip.text }}</span>
+        </ng-container>
       </div>
 
       <div *ngIf="dm" class="dm-adjust" (click)="$event.stopPropagation()">

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
@@ -3,6 +3,7 @@ import { ParticipantView, SessionStatus } from '../../../models/session';
 import { SessionService, TURN_SOUNDS } from '../../../services/session.service';
 import { NotificationService } from '../../../services/notification.service';
 import { tintFor } from '../../../utils/character-math';
+import { SURVIVAL_KEYS, SURVIVAL_LABELS, clampStage } from '../../../utils/survival';
 
 /**
  * Initiative order — one row per combatant in server-computed turn order, with
@@ -34,6 +35,10 @@ export class InitiativePanelComponent {
   @Input() onDeckParticipantId: number | null = null;
   @Input() enemiesHidden = true;
   @Input() turnSound: string | null = null;
+  /** True when the campaign runs the survival-conditions variant — the DM's
+   *  rows then show compact hunger/thirst/fatigue chips so time can be
+   *  advanced with the party's state in view. */
+  @Input() survivalConditions = false;
 
   /** Per-row amount typed into the DM's damage/heal box, keyed by participant id. */
   amounts: { [participantId: number]: number | null } = {};
@@ -60,6 +65,24 @@ export class InitiativePanelComponent {
     private notifications: NotificationService,
   ) {
     this.muted = this.sessionService.isMuted();
+  }
+
+  /**
+   * Compact survival chips for a PC row (DM view, survival campaigns): "H3"
+   * with the stage label in the tooltip; stage 5–6 chips are flagged dire.
+   * NPCs render nothing; a never-tracked PC shows the neutral Ok default.
+   */
+  survivalChips(p: ParticipantView): Array<{ text: string; title: string; dire: boolean }> {
+    if (p.npc) return [];
+    return SURVIVAL_KEYS.map(key => {
+      // Never-tracked PCs sit at the neutral Ok default, same as the panel.
+      const stage = clampStage(p.survival?.[key] ?? 2);
+      return {
+        text: `${key.charAt(0).toUpperCase()}${stage}`,
+        title: `${key}: ${SURVIVAL_LABELS[key][stage]} (${stage}/6)`,
+        dire: stage >= 5,
+      };
+    });
   }
 
   /**

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -136,6 +136,7 @@
       [onDeckParticipantId]="state.onDeckParticipantId"
       [enemiesHidden]="state.enemiesHidden"
       [turnSound]="state.turnSound"
+      [survivalConditions]="survivalConditions"
     ></app-initiative-panel>
 
     <app-encounter-loader [state]="state" *ngIf="state.dm" style="display: block; margin-top: 16px;"></app-encounter-loader>

--- a/src/app/charactermanager/services/campaign.service.spec.ts
+++ b/src/app/charactermanager/services/campaign.service.spec.ts
@@ -40,6 +40,51 @@ describe('CampaignService', () => {
     });
   });
 
+  describe('game clock (de)serialization', () => {
+    it('createCampaign sends gameTime as a JSON string (null when unset) and parses it back', done => {
+      http.post.and.returnValue(of({
+        id: 9, name: 'Timed Table',
+        gameTime: '{"year":1492,"month":3,"day":12,"timeOfDay":"dawn"}',
+      }));
+
+      service.createCampaign({
+        name: 'Timed Table', setting: '', tint: 'celestial', variantRules: {},
+        gameTime: { year: 1492, month: 3, day: 12, timeOfDay: 'dawn' },
+      }).subscribe(campaign => {
+        const body = http.post.calls.mostRecent().args[1] as Record<string, unknown>;
+        expect(body['gameTime']).toBe('{"year":1492,"month":3,"day":12,"timeOfDay":"dawn"}');
+        expect(campaign.gameTime).toEqual({ year: 1492, month: 3, day: 12, timeOfDay: 'dawn' });
+        done();
+      });
+    });
+
+    it('createCampaign without a start date sends null (clock never set)', done => {
+      http.post.and.returnValue(of({ id: 9, name: 'Plain Table', gameTime: null }));
+
+      service.createCampaign({
+        name: 'Plain Table', setting: '', tint: 'celestial', variantRules: {},
+      }).subscribe(campaign => {
+        const body = http.post.calls.mostRecent().args[1] as Record<string, unknown>;
+        expect(body['gameTime']).toBeNull();
+        expect(campaign.gameTime).toBeNull();
+        done();
+      });
+    });
+
+    it('setLocalGameTime updates the stored campaign copy', done => {
+      http.post.and.returnValue(of({ id: 9, name: 'Timed Table', gameTime: null }));
+
+      service.createCampaign({
+        name: 'Timed Table', setting: '', tint: 'celestial', variantRules: {},
+      }).subscribe(() => {
+        service.setLocalGameTime(9, { year: 2, month: 1, day: 1, timeOfDay: 'dusk' });
+        expect(service.getLocalCampaign(9)?.gameTime)
+          .toEqual({ year: 2, month: 1, day: 1, timeOfDay: 'dusk' });
+        done();
+      });
+    });
+  });
+
   describe('previewByCode', () => {
     it('normalizes the code and tolerates a null variantRules column', done => {
       http.get.and.returnValue(of({ name: 'Plain Table', variantRules: null }));


### PR DESCRIPTION
DM initiative rows gain compact H/T/F chips (muted while fine, crimson at stage 5-6, stage label in the tooltip; never-tracked PCs read as the neutral Ok default) so time can be advanced with the party's state in view, and the campaign dashboard header shows the persisted in-world clock next to the invite code. Adds the missing gameTime round-trip coverage to the campaign service spec.