### PR TITLE
fix: count campaign heroes from the member projection, not the local …

### DIFF
--- a/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.spec.ts
+++ b/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.spec.ts
@@ -1,0 +1,75 @@
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { CampaignSidebarComponent } from './campaign-sidebar.component';
+import { CampaignService } from '../../services/campaign.service';
+import { PCService } from '../../services/pc.service';
+import { UiStateService } from '../../services/ui-state.service';
+import { Campaign } from '../../models/campaign';
+import { PC } from '../../models/pc';
+
+// Class-only tests (no TestBed), matching the house style.
+describe('CampaignSidebarComponent', () => {
+  let campaignService: jasmine.SpyObj<CampaignService>;
+  let pcService: Partial<PCService>;
+  let uiState: jasmine.SpyObj<UiStateService>;
+  let campaigns$: BehaviorSubject<Campaign[]>;
+  let pcs$: BehaviorSubject<PC[]>;
+
+  const campaign = (id: string, name: string): Campaign =>
+    ({ id, name, party: name, setting: '', session: 1, next: '', arc: '', tint: 'celestial',
+       chronicle: '', secrets: '', threads: [] } as Campaign);
+
+  const pc = (id: number, level: number): PC =>
+    ({ id, name: 'M' + id, clazz: 'Fighter', level, playerName: 'P' } as PC);
+
+  beforeEach(() => {
+    campaigns$ = new BehaviorSubject<Campaign[]>([]);
+    pcs$ = new BehaviorSubject<PC[]>([]);
+    campaignService = jasmine.createSpyObj<CampaignService>('CampaignService', ['getMembers'],
+      { campaigns$: campaigns$.asObservable() });
+    pcService = { pcs$: pcs$.asObservable() } as Partial<PCService>;
+    uiState = jasmine.createSpyObj<UiStateService>('UiStateService', ['setActiveCampaign'],
+      { activeCampaignId$: of(null) });
+  });
+
+  function build(): CampaignSidebarComponent {
+    return new CampaignSidebarComponent(
+      campaignService, pcService as PCService, uiState);
+  }
+
+  it('counts heroes from the member projection, not the local PC store', done => {
+    // The local store is EMPTY (real mode: only the DM's own PCs live there) —
+    // the projection still reports the two members other players bound.
+    campaignService.getMembers.and.returnValue(of([pc(1, 5), pc(2, 7)]));
+    campaigns$.next([campaign('c1', 'The Veiled Compass')]);
+
+    build().rows$.subscribe(rows => {
+      expect(rows.length).toBe(1);
+      expect(rows[0].heroes).toBe(2);
+      expect(rows[0].range).toBe('Lv 5–7');
+      expect(campaignService.getMembers).toHaveBeenCalledWith('c1');
+      done();
+    });
+  });
+
+  it('shows "no heroes" for an empty campaign and survives a failed lookup', done => {
+    campaignService.getMembers.and.callFake((id: string) =>
+      id === 'ok' ? of([] as PC[]) : throwError(() => new Error('403')));
+    campaigns$.next([campaign('ok', 'A'), campaign('denied', 'B')]);
+
+    build().rows$.subscribe(rows => {
+      expect(rows[0].heroes).toBe(0);
+      expect(rows[0].range).toBe('no heroes');
+      expect(rows[1].heroes).toBe(0); // errored lookup degrades to zero, no crash
+      done();
+    });
+  });
+
+  it('emits an empty row list when there are no campaigns', done => {
+    campaigns$.next([]);
+    build().rows$.subscribe(rows => {
+      expect(rows).toEqual([]);
+      expect(campaignService.getMembers).not.toHaveBeenCalled();
+      done();
+    });
+  });
+});

--- a/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.ts
+++ b/src/app/charactermanager/components/campaign-sidebar/campaign-sidebar.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
-import { combineLatest, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest, forkJoin, of } from 'rxjs';
+import { catchError, map, switchMap, take } from 'rxjs/operators';
 import { Campaign } from '../../models/campaign';
+import { PC } from '../../models/pc';
 import { CampaignService } from '../../services/campaign.service';
 import { PCService } from '../../services/pc.service';
 import { UiStateService } from '../../services/ui-state.service';
@@ -17,28 +18,43 @@ interface CampaignRow {
   selector: 'app-campaign-sidebar',
   templateUrl: './campaign-sidebar.component.html',
 })
-export class CampaignSidebarComponent {
+export class CampaignSidebarComponent implements OnInit, OnDestroy {
   activeCampaignId$ = this.uiState.activeCampaignId$;
 
+  // Refetch valve: fired on window refocus so a player joining while the DM
+  // was in another tab shows up without a manual reload. No background polling.
+  private refresh$ = new BehaviorSubject<void>(undefined);
+
+  /**
+   * One row per campaign with a real member count. Counts come from the
+   * DM-scoped member projection (getMembers) — the local PC store only holds
+   * the signed-in user's OWN characters, so filtering it undercounts every
+   * campaign whose members belong to other players (the "0 heroes" bug).
+   * pcs$ stays in the trigger set so demo-mode joins refresh instantly.
+   */
   rows$: Observable<CampaignRow[]> = combineLatest([
     this.campaignService.campaigns$,
     this.pcService.pcs$,
+    this.refresh$,
   ]).pipe(
-    map(([campaigns, pcs]) =>
-      campaigns.map(campaign => {
-        const members = this.campaignService.membersOf(campaign, pcs);
-        const levels = members.map(m => m.level);
-        const range = levels.length
-          ? (Math.min(...levels) === Math.max(...levels)
-              ? `Lv ${levels[0]}`
-              : `Lv ${Math.min(...levels)}–${Math.max(...levels)}`)
-          : 'no heroes';
-        return { campaign, heroes: members.length, range };
-      })
+    switchMap(([campaigns]) =>
+      campaigns.length === 0
+        ? of([] as CampaignRow[])
+        : forkJoin(
+            campaigns.map(c =>
+              this.campaignService.getMembers(c.id).pipe(
+                take(1),
+                catchError(() => of([] as PC[])),
+              )),
+          ).pipe(map(lists => campaigns.map((campaign, i) => this.toRow(campaign, lists[i]))))
     )
   );
 
   count$ = this.campaignService.campaigns$.pipe(map(c => c.length));
+
+  private readonly onVisible = () => {
+    if (document.visibilityState === 'visible') this.refresh$.next();
+  };
 
   constructor(
     private campaignService: CampaignService,
@@ -46,11 +62,29 @@ export class CampaignSidebarComponent {
     private uiState: UiStateService,
   ) {}
 
+  ngOnInit(): void {
+    document.addEventListener('visibilitychange', this.onVisible);
+  }
+
+  ngOnDestroy(): void {
+    document.removeEventListener('visibilitychange', this.onVisible);
+  }
+
   select(id: string): void {
     this.uiState.setActiveCampaign(id);
   }
 
   padCount(n: number): string {
     return n.toString().padStart(2, '0');
+  }
+
+  private toRow(campaign: Campaign, members: PC[]): CampaignRow {
+    const levels = members.map(m => m.level);
+    const range = levels.length
+      ? (Math.min(...levels) === Math.max(...levels)
+          ? `Lv ${levels[0]}`
+          : `Lv ${Math.min(...levels)}–${Math.max(...levels)}`)
+      : 'no heroes';
+    return { campaign, heroes: members.length, range };
   }
 }


### PR DESCRIPTION
…store

The sidebar filtered the local PC store, which in real mode only holds the signed-in users own characters, so campaigns whose members belong to other players showed zero heroes. Rows now load counts from the DM-scoped member projection (same source as the dashboard) and refetch when the tab regains focus.