### PR TITLE
fix: restrict spellcasting to session mode and lock player slots

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -170,8 +170,8 @@
         [pc]="pc"
         [editable]="editable"
         [strictComponents]="strictComponents"
+        [castable]="sessionLive"
         [addAllowed]="editable"
-        (slotToggled)="onSlotToggle($event.level, $event.index)"
         (castRequested)="onCastRequested($event)"
         (pcChange)="onPcChange($event)"
         (spellsGranted)="onSpellsGrant($event)">

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -4,7 +4,7 @@ import { PCService } from '../../services/pc.service';
 import { GrantService } from '../../services/grant.service';
 import { tintFor } from '../../utils/character-math';
 import { SurvivalAction, applyConsumeToPc } from '../../utils/survival';
-import { applyCastToPc, applyLongRestToSlots } from '../../utils/spellcasting';
+import { applyLongRestToSlots } from '../../utils/spellcasting';
 import { CastRequest } from './panels/spellbook-panel/spellbook-panel.component';
 import { isReadyToLevel, xpForNextLevel, xpProgressPct } from '../../models/xp-thresholds';
 
@@ -147,16 +147,12 @@ export class CharacterSheetComponent implements OnChanges {
   }
 
   /**
-   * A cast from the spellbook panel. In a live session the host owns it (the
-   * server spends the slot, consumes the component, and bumps the poll version);
-   * on the plain sheet the local reducer applies the same rules and persists.
+   * A cast from the spellbook panel — only reachable inside a live session (the
+   * Cast buttons are hidden otherwise). The host forwards it to Session Mode,
+   * which spends the slot, consumes the component, and bumps the poll version.
    */
   onCastRequested(ev: CastRequest): void {
-    if (this.sessionLive) {
-      this.castRequested.emit(ev);
-      return;
-    }
-    this.persist(applyCastToPc(this.pc, ev.spellName, ev.atLevel));
+    this.castRequested.emit(ev);
   }
 
   /** Long rest — restore every spent spell slot. HP/survival stay out of scope for now. */
@@ -211,17 +207,6 @@ export class CharacterSheetComponent implements OnChanges {
       ? conditions.filter(c => c !== condition)
       : [...conditions, condition];
     this.persist({ ...this.pc, conditions: next });
-  }
-
-  // ── Spell slots (wired fully in Phase 5) ────────────────────────────────────
-
-  onSlotToggle(level: number, index: number): void {
-    const slots = { ...(this.pc.spellSlots ?? {}) };
-    const slot = slots[level];
-    if (!slot) return;
-    const used = index < slot.used ? index : index + 1;
-    slots[level] = { ...slot, used: Math.min(slot.max, Math.max(0, used)) };
-    this.persist({ ...this.pc, spellSlots: slots });
   }
 
   // ── DM grants ────────────────────────────────────────────────────────────

--- a/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.html
@@ -40,13 +40,14 @@
         <span class="spell-level-name">{{ level.label }}</span>
         <div *ngIf="level.slots" class="spell-slots">
           <ng-container *ngIf="!editable">
-            <button
+            <!-- Display-only for players: slots are spent by casting (in session),
+                 never toggled by hand. The DM edits them via the numbers below. -->
+            <span
               *ngFor="let i of level.slotIndices"
               class="spell-slot"
               [class.used]="i < level.slots!.used"
-              (click)="slotToggled.emit({ level: level.lvl, index: i })"
-              [title]="i < level.slots!.used ? 'Restore slot' : 'Expend slot'"
-            ></button>
+              [title]="i < level.slots!.used ? 'Slot expended' : 'Slot available'"
+            ></span>
           </ng-container>
           <span *ngIf="editable" class="slot-edit">
             <app-editable-number
@@ -71,7 +72,7 @@
           <span class="spell-time">{{ s.time }}</span>
           <span class="spell-range" *ngIf="s.range">{{ s.range }}</span>
           <button
-            *ngIf="!editable && s.prepared"
+            *ngIf="!editable && s.prepared && castable"
             class="spell-cast-btn"
             [disabled]="!canCast(s)"
             [title]="castTitle(s)"

--- a/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/spellbook-panel/spellbook-panel.component.ts
@@ -31,12 +31,15 @@ export class SpellbookPanelComponent implements OnChanges {
   @Input() editable = false;
   /** Campaign runs strict material components: a missing costly component blocks the cast. */
   @Input() strictComponents = false;
+  /** True only inside a live session — casting is a session-mode action, so the
+   *  Cast buttons appear only when this is set. Slots are never player-editable
+   *  by hand; they change solely through casting (session) or the DM's editor. */
+  @Input() castable = false;
   /** DM cross-link: reveals the "Grant spells" control. Distinct from `editable`
    *  (slot editing) — a DM may be able to grant spells without also editing slots. */
   @Input() addAllowed = false;
-  @Output() slotToggled = new EventEmitter<{ level: number; index: number }>();
   @Output() pcChange = new EventEmitter<PC>();
-  /** A cast resolved to a slot level — the host decides local vs. live-session handling. */
+  /** A cast resolved to a slot level — the host forwards it to the live session. */
   @Output() castRequested = new EventEmitter<CastRequest>();
   /**
    * DM-granted spells, already mapped to the PcSpell snapshot shape. Emitted as a bare


### PR DESCRIPTION
Casting is now a Session Mode action only: the Cast buttons appear solely when the sheet is embedded live (new castable input = sessionLive), and the off-session local-cast path is removed. Player spell-slot pips are display-only — slots change only by casting in session or via the DM's slot editor; players can no longer click to spend or restore them.