### PR TITLE
fix: remove merge-duplicated grant methods, panels, and Long Rest button

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -98,13 +98,6 @@
         </svg>
         Roll
       </button>
-      <button class="btn" title="Take a long rest" (click)="onLongRest()">
-        <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
-             style="margin-right: 6px; vertical-align: -2px;">
-          <path d="M2 3a1 1 0 011-1h4a1 1 0 011 1v11M8 3a1 1 0 011-1h4a1 1 0 011 1v11M2 14h12"/>
-        </svg>
-        Long Rest
-      </button>
       <button class="btn" [class.ready]="readyToLevel" title="Advance a level" (click)="levelUpRequested.emit()">
         <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.4"
              style="margin-right: 6px; vertical-align: -2px;">
@@ -163,28 +156,6 @@
         [editable]="true"
         (pcChange)="onPcChange($event)">
       </app-survival-panel>
-      <app-equipment-panel *ngIf="!slotInventory" [pc]="pc"></app-equipment-panel>
-      <app-inventory-panel
-        [pc]="pc"
-        [editable]="showActions || inventoryEditable"
-        [addAllowed]="editable"
-        [shopOpenForMe]="shopOpenForMe"
-        [shopCategory]="shopCategory"
-        [slotInventory]="slotInventory"
-        (pcChange)="onPcChange($event)"
-        (itemGranted)="onItemGrant($event)"
-        (sellRequested)="sellRequested.emit($event)">
-      </app-inventory-panel>
-      <app-spellbook-panel
-        [pc]="pc"
-        [editable]="editable"
-        [strictComponents]="strictComponents"
-        [castable]="sessionLive"
-        [addAllowed]="editable"
-        (castRequested)="onCastRequested($event)"
-        (pcChange)="onPcChange($event)"
-        (spellsGranted)="onSpellsGrant($event)">
-      </app-spellbook-panel>
       <app-features-list    [pc]="pc" [addAllowed]="editable" (featureGranted)="onFeatureGrant($event)"></app-features-list>
       <app-coin-purse
         [pc]="pc"

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -3,8 +3,6 @@ import { PC, PcSpell, PcItem } from '../../models/pc';
 import { PCService } from '../../services/pc.service';
 import { GrantService } from '../../services/grant.service';
 import { tintFor } from '../../utils/character-math';
-import { SurvivalAction, applyConsumeToPc } from '../../utils/survival';
-import { applyLongRestToSlots } from '../../utils/spellcasting';
 import { CastRequest } from './panels/spellbook-panel/spellbook-panel.component';
 import { isReadyToLevel, xpForNextLevel, xpProgressPct } from '../../models/xp-thresholds';
 
@@ -136,30 +134,12 @@ export class CharacterSheetComponent implements OnChanges {
   }
 
   /**
-   * A survival action from the panel. In a live session the host owns it (the
-   * server decrements rations and bumps the poll version); on the plain sheet
-   * the local reducer applies the same rules and persists.
-   */
-  onSurvivalAction(action: SurvivalAction): void {
-    if (this.sessionLive) {
-      this.survivalActionRequested.emit(action);
-      return;
-    }
-    this.persist(applyConsumeToPc(this.pc, action));
-  }
-
-  /**
    * A cast from the spellbook panel — only reachable inside a live session (the
    * Cast buttons are hidden otherwise). The host forwards it to Session Mode,
    * which spends the slot, consumes the component, and bumps the poll version.
    */
   onCastRequested(ev: CastRequest): void {
     this.castRequested.emit(ev);
-  }
-
-  /** Long rest — restore every spent spell slot. HP/survival stay out of scope for now. */
-  onLongRest(): void {
-    this.persist({ ...this.pc, spellSlots: applyLongRestToSlots(this.pc.spellSlots) });
   }
 
   // ── Portrait helpers ────────────────────────────────────────────────────────
@@ -209,45 +189,6 @@ export class CharacterSheetComponent implements OnChanges {
       ? conditions.filter(c => c !== condition)
       : [...conditions, condition];
     this.persist({ ...this.pc, conditions: next });
-  }
-
-  // ── DM grants ────────────────────────────────────────────────────────────
-  // Grants go through GrantService's refetch-merge-save rather than persist() —
-  // the sheet's `pc` copy can be stale by the time the DM submits the form, and
-  // PUTting it directly risks clobbering a concurrent player edit.
-
-  onFeatureGrant(f: { name: string; source: string; desc: string }): void {
-    this.grantService
-      .grantToPc(this.pc.id, fresh => ({ ...fresh, features: [...(fresh.features ?? []), f] }))
-      .subscribe({ error: err => console.error('Failed to grant feature', err) });
-  }
-
-  onSpellsGrant(granted: PcSpell[]): void {
-    this.grantService
-      .grantToPc(this.pc.id, fresh => {
-        // Dedupe against the FRESH copy — the player may have learned one of these
-        // spells (e.g. via level-up) in the moments between the picker opening and
-        // the DM confirming the grant.
-        const known = new Set((fresh.spells ?? []).map(s => s.name.toLowerCase()));
-        const toAdd = granted.filter(s => !known.has(s.name.toLowerCase()));
-        return { ...fresh, spells: [...(fresh.spells ?? []), ...toAdd] };
-      })
-      .subscribe({ error: err => console.error('Failed to grant spells', err) });
-  }
-
-  onItemGrant(item: PcItem): void {
-    this.grantService
-      .grantToPc(this.pc.id, fresh => {
-        // Stack onto an existing catalog line (mirrors the backend purchase path);
-        // ad-hoc items have no catalogKey and always append. Granted items arrive
-        // unequipped, so there's no AC to recompute.
-        const inventory = (fresh.inventory ?? []).map(i => ({ ...i }));
-        const line = item.catalogKey ? inventory.find(i => i.catalogKey === item.catalogKey) : undefined;
-        if (line) line.qty = (line.qty ?? 0) + (item.qty ?? 1);
-        else inventory.push(item);
-        return { ...fresh, inventory };
-      })
-      .subscribe({ error: err => console.error('Failed to grant item', err) });
   }
 
   // ── DM grants ────────────────────────────────────────────────────────────

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
@@ -71,10 +71,6 @@
     Over capacity — {{ encumberedPenalty }}.
   </div>
 
-  <div *ngIf="slotInventory && encumbered" class="inv-empty" style="color: var(--crimson);">
-    Over capacity — {{ encumberedPenalty }}.
-  </div>
-
   <div class="inv-list">
     <div *ngIf="!items.length" class="inv-empty">
       No items yet — buy equipment at a shop during a session and it will appear here.

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -154,8 +154,6 @@
 
     <app-encounter-loader [state]="state" *ngIf="state.dm" style="display: block; margin-top: 16px;"></app-encounter-loader>
 
-    <app-encounter-loader [state]="state" *ngIf="state.dm" style="display: block; margin-top: 16px;"></app-encounter-loader>
-
     <app-shop-panel [state]="state"></app-shop-panel>
     <!-- DM-only: capture a note to the campaign log without leaving the table -->
     <div *ngIf="state.dm" class="panel session-note">


### PR DESCRIPTION
The survival-auto-consume branch was merged into develop twice, which duplicated content in four files: the character sheet gained a second copy of onFeatureGrant/onSpellsGrant/onItemGrant plus a resurrected SurvivalAction import and Long Rest button, the inventory and session-mode templates gained duplicate panels. Restores all four to the intended post-merge state (production build was broken).