### PR TITLE
feat: add DM spell reference carousel to session screen

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -53,6 +53,7 @@ import { SessionModeComponent } from './components/session-mode/session-mode.com
 import { InitiativePanelComponent } from './components/session-mode/initiative-panel/initiative-panel.component';
 import { ShopPanelComponent } from './components/session-mode/shop-panel/shop-panel.component';
 import { EncounterLoaderComponent } from './components/session-mode/encounter-loader/encounter-loader.component';
+import { SpellCarouselComponent } from './components/session-mode/spell-carousel/spell-carousel.component';
 import { SessionLiveBannerComponent } from './components/session-live-banner/session-live-banner.component';
 import { ToastComponent } from './components/toast/toast.component';
 
@@ -124,6 +125,7 @@ const routes: Routes = [
     InitiativePanelComponent,
     ShopPanelComponent,
     EncounterLoaderComponent,
+    SpellCarouselComponent,
     SessionLiveBannerComponent,
     ToastComponent,
   ],

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -10,6 +10,9 @@
   ></div>
   <div class="fade-in">
 
+    <!-- DM-only: pinned spell reference cards, ephemeral for this session. -->
+    <app-spell-carousel *ngIf="state.dm"></app-spell-carousel>
+
     <!-- Header -->
     <header class="sheet-header" style="grid-template-columns: 1fr auto;">
       <div class="sheet-id">

--- a/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.html
+++ b/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.html
@@ -1,0 +1,82 @@
+<div class="spell-carousel panel">
+
+  <!-- Header bar: always visible; chevron toggles the whole carousel. -->
+  <div class="carousel-header" (click)="toggleCollapsed()">
+    <button
+      type="button"
+      class="chevron-btn"
+      [attr.aria-expanded]="!collapsed"
+      [attr.aria-label]="collapsed ? 'Expand spell references' : 'Collapse spell references'"
+    >
+      <span class="chevron" [class.collapsed]="collapsed">▾</span>
+    </button>
+    <span class="carousel-title">Spells ({{ pinned.length }})</span>
+  </div>
+
+  <!-- Wrapping card row + trailing "+" silhouette; hidden while collapsed. -->
+  <div
+    class="card-row"
+    *ngIf="!collapsed"
+    cdkDropList
+    cdkDropListOrientation="horizontal"
+    (cdkDropListDropped)="drop($event)"
+  >
+    <div
+      class="spell-card"
+      *ngFor="let s of pinned; trackBy: trackByName"
+      cdkDrag
+      #cardEl
+      [class.is-focused]="focusedName === s.name"
+    >
+      <button type="button" class="card-remove" (click)="remove(s)" aria-label="Remove spell">×</button>
+      <span class="card-handle" cdkDragHandle title="Drag to reorder">⠿</span>
+
+      <div class="card-head">
+        <span class="card-name">{{ s.name }}</span>
+        <span class="card-sub">{{ s.level === 0 ? 'Cantrip' : 'Level ' + s.level }} · {{ s.school | titlecase }}</span>
+      </div>
+
+      <dl class="card-stats">
+        <div><dt>Casting Time</dt><dd>{{ (s.castingTime || s.actionType) | titlecase }}</dd></div>
+        <div><dt>Range</dt><dd>{{ s.range }}</dd></div>
+        <div><dt>Components</dt><dd>{{ componentLabel(s) }}</dd></div>
+        <div><dt>Duration</dt><dd>{{ s.concentration ? 'Concentration, ' : '' }}{{ s.duration }}</dd></div>
+      </dl>
+
+      <div class="card-tags" *ngIf="s.ritual || s.concentration">
+        <span class="tag" *ngIf="s.concentration">Concentration</span>
+        <span class="tag" *ngIf="s.ritual">Ritual</span>
+      </div>
+
+      <p class="card-desc">{{ s.description }}</p>
+      <p class="card-note" *ngIf="s.higherLevelSlot"><em>At Higher Levels.</em> {{ s.higherLevelSlot }}</p>
+      <p class="card-note" *ngIf="s.cantripUpgrade"><em>Cantrip Upgrade.</em> {{ s.cantripUpgrade }}</p>
+    </div>
+
+    <!-- Trailing silhouette: always the last item in the row. -->
+    <button type="button" class="add-silhouette" (click)="openSearch()" aria-label="Add a spell reference">
+      <span class="plus">+</span>
+      <span class="add-label">Add spell</span>
+    </button>
+  </div>
+
+  <!-- Search overlay: reuses the shared spell picker; pinned = selected. -->
+  <div class="search-overlay" *ngIf="searchOpen">
+    <div class="search-backdrop" (click)="closeSearch()"></div>
+    <div class="search-panel">
+      <div class="search-panel-head">
+        <span class="search-panel-title">Add a spell reference</span>
+        <button type="button" class="btn sm" (click)="closeSearch()">Close</button>
+      </div>
+      <app-spell-picker
+        [spells]="allSpells"
+        [selected]="pinned"
+        [cantripLimit]="null"
+        [spellLimit]="null"
+        [loading]="loadingSpells"
+        (selectedChange)="onSelectionChange($event)"
+      ></app-spell-picker>
+    </div>
+  </div>
+
+</div>

--- a/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.scss
+++ b/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.scss
@@ -1,0 +1,245 @@
+:host {
+  display: block;
+  margin-bottom: 16px;
+}
+
+.spell-carousel {
+  position: relative;
+}
+
+// ── Header bar ──────────────────────────────────────────────────────────────
+.carousel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chevron-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.chevron {
+  display: inline-block;
+  transition: transform 0.15s ease;
+
+  &.collapsed { transform: rotate(-90deg); }
+}
+
+.carousel-title {
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+// ── Card row (wraps onto multiple lines) ────────────────────────────────────
+.card-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.spell-card {
+  position: relative;
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-2);
+  box-shadow: var(--shadow);
+
+  &.is-focused {
+    border-color: var(--celestial);
+    animation: card-pulse 1.6s ease;
+  }
+
+  &.cdk-drag-preview {
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
+  }
+
+  &.cdk-drag-placeholder { opacity: 0.35; }
+}
+
+@keyframes card-pulse {
+  0%   { box-shadow: 0 0 0 0 var(--glow-gold); }
+  30%  { box-shadow: 0 0 0 4px var(--glow-gold); }
+  100% { box-shadow: var(--shadow); }
+}
+
+.card-remove {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover { color: var(--crimson); background: var(--surface-3); }
+}
+
+.card-handle {
+  position: absolute;
+  top: 8px;
+  right: 34px;
+  color: var(--text-dim);
+  cursor: grab;
+  user-select: none;
+
+  &:active { cursor: grabbing; }
+}
+
+.card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-right: 48px; // clear the remove/handle controls
+}
+
+.card-name {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.card-sub {
+  font-size: 0.72rem;
+  color: var(--celestial);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.card-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 10px;
+  margin: 0;
+
+  div { min-width: 0; }
+
+  dt {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--text);
+  }
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag {
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  color: var(--text-2);
+}
+
+.card-desc,
+.card-note {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text-2);
+  white-space: pre-line;
+}
+
+.card-note em { color: var(--text); font-style: italic; }
+
+// ── Trailing "+" silhouette ─────────────────────────────────────────────────
+.add-silhouette {
+  width: 260px;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+
+  &:hover {
+    border-color: var(--celestial);
+    color: var(--celestial);
+  }
+
+  .plus { font-size: 32px; line-height: 1; }
+  .add-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }
+}
+
+// ── Search overlay ──────────────────────────────────────────────────────────
+.search-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.search-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 10px;
+}
+
+.search-panel {
+  position: relative;
+  z-index: 1;
+  width: min(420px, 92%);
+  margin-top: 44px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-2);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+}
+
+.search-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.search-panel-title {
+  font-weight: 600;
+  color: var(--text);
+}

--- a/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.spec.ts
@@ -1,0 +1,81 @@
+import { of } from 'rxjs';
+import { DndSpell } from '../../../models/dnd-api.types';
+import { SpellCarouselComponent } from './spell-carousel.component';
+
+/**
+ * Class-only tests (no TestBed) — the carousel's behavior is pure state
+ * manipulation over the pinned list. DOM (scroll/flash) is exercised in-browser.
+ */
+function spell(name: string, over: Partial<DndSpell> = {}): DndSpell {
+  return {
+    name,
+    level: 1,
+    school: 'evocation',
+    classes: ['wizard'],
+    actionType: 'action',
+    concentration: false,
+    ritual: false,
+    range: '60 feet',
+    components: ['v', 's'],
+    duration: 'Instantaneous',
+    description: `${name} description`,
+    ...over,
+  };
+}
+
+describe('SpellCarouselComponent', () => {
+  let component: SpellCarouselComponent;
+  const fireball = spell('Fireball', { level: 3 });
+  const shield = spell('Shield', { components: ['v', 's'] });
+
+  beforeEach(() => {
+    const dndResources = { getSpells: () => of([fireball, shield]) };
+    component = new SpellCarouselComponent(dndResources as any);
+    component.ngOnInit();
+  });
+
+  it('loads candidate spells on init', () => {
+    expect(component.allSpells.length).toBe(2);
+    expect(component.loadingSpells).toBeFalse();
+  });
+
+  it('pins a newly selected spell and closes the overlay', () => {
+    component.openSearch();
+    component.onSelectionChange([fireball]);
+    expect(component.pinned).toEqual([fireball]);
+    expect(component.searchOpen).toBeFalse();
+    expect(component.focusedName).toBe('Fireball');
+  });
+
+  it('does not add a duplicate — focuses the existing card instead', () => {
+    component.pinned = [fireball];
+    // Picker emits a shorter array (an already-pinned spell was clicked).
+    component.onSelectionChange([]);
+    expect(component.pinned).toEqual([fireball]); // unchanged, not unpinned
+    expect(component.focusedName).toBe('Fireball');
+  });
+
+  it('removes a card by spell', () => {
+    component.pinned = [fireball, shield];
+    component.remove(fireball);
+    expect(component.pinned).toEqual([shield]);
+  });
+
+  it('reorders on drop', () => {
+    component.pinned = [fireball, shield];
+    component.drop({ previousIndex: 0, currentIndex: 1 } as any);
+    expect(component.pinned.map(s => s.name)).toEqual(['Shield', 'Fireball']);
+  });
+
+  it('toggles collapsed state', () => {
+    expect(component.collapsed).toBeFalse();
+    component.toggleCollapsed();
+    expect(component.collapsed).toBeTrue();
+  });
+
+  it('builds a component label with material text', () => {
+    const s = spell('Identify', { components: ['v', 's', 'm'], material: 'a pearl worth 100 gp' });
+    expect(component.componentLabel(s)).toBe('V, S, M (a pearl worth 100 gp)');
+    expect(component.componentLabel(shield)).toBe('V, S');
+  });
+});

--- a/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.ts
+++ b/src/app/charactermanager/components/session-mode/spell-carousel/spell-carousel.component.ts
@@ -1,0 +1,119 @@
+import { Component, ElementRef, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { DndSpell } from '../../../models/dnd-api.types';
+import { DndResourcesService } from '../../../services/dnd-resources.service';
+
+/**
+ * DM-screen Spell Reference Carousel — a wrapping row of always-expanded spell
+ * reference cards the DM pins for quick lookup during a live session.
+ *
+ * State is intentionally ephemeral: the pinned list lives only on this component
+ * instance. The component is mounted for the life of the session screen (it sits
+ * behind `state.dm`, which never flips mid-session), so the list survives the
+ * poll re-emits but is cleared the moment the DM leaves the session. There is no
+ * backend persistence — refresh or exit wipes the carousel, by design.
+ *
+ * The search overlay reuses {@link SpellPickerComponent}. We bind the pinned list
+ * as the picker's `selected`, so already-pinned spells render as checked. Picking
+ * an unchecked spell pins it; clicking an already-pinned (checked) spell never
+ * unpins — instead it focuses the existing card (the "no duplicates, move to it"
+ * rule). Cards are removed only via their own "x". Reorder is CDK drag-and-drop.
+ */
+@Component({
+  selector: 'app-spell-carousel',
+  templateUrl: './spell-carousel.component.html',
+  styleUrls: ['./spell-carousel.component.scss'],
+})
+export class SpellCarouselComponent implements OnInit {
+  /** Ordered, de-duplicated pinned spells. Ephemeral — session only. */
+  pinned: DndSpell[] = [];
+
+  /** All SRD spells, loaded once for the search overlay's candidate list. */
+  allSpells: DndSpell[] = [];
+  loadingSpells = false;
+
+  collapsed = false;
+  searchOpen = false;
+
+  /** Name of the card to flash (add / duplicate-select), cleared after the pulse. */
+  focusedName: string | null = null;
+  private focusTimer?: ReturnType<typeof setTimeout>;
+
+  @ViewChildren('cardEl') private cardEls!: QueryList<ElementRef<HTMLElement>>;
+
+  constructor(private dndResources: DndResourcesService) {}
+
+  ngOnInit(): void {
+    // Cached via shareReplay in the service, so this is cheap and warms the
+    // search list before the DM opens it.
+    this.loadingSpells = true;
+    this.dndResources.getSpells().subscribe({
+      next: spells => { this.allSpells = spells; this.loadingSpells = false; },
+      error: () => { this.loadingSpells = false; },
+    });
+  }
+
+  toggleCollapsed(): void { this.collapsed = !this.collapsed; }
+
+  openSearch(): void { this.searchOpen = true; }
+  closeSearch(): void { this.searchOpen = false; }
+
+  isPinned(spell: DndSpell): boolean {
+    return this.pinned.some(s => s.name === spell.name);
+  }
+
+  /**
+   * The picker toggled its selection (bound to `pinned`). A longer array means a
+   * new spell was picked → pin it. A shorter array means an already-pinned spell
+   * was clicked → don't unpin; focus the existing card instead. Either way the
+   * overlay closes so the DM sees the row update.
+   */
+  onSelectionChange(next: DndSpell[]): void {
+    if (next.length > this.pinned.length) {
+      const added = next.find(s => !this.isPinned(s));
+      this.closeSearch();
+      if (added) {
+        this.pinned = [...this.pinned, added];
+        this.focusCard(added.name);
+      }
+    } else {
+      const existing = this.pinned.find(p => !next.some(s => s.name === p.name));
+      this.closeSearch();
+      if (existing) this.focusCard(existing.name);
+    }
+  }
+
+  remove(spell: DndSpell): void {
+    this.pinned = this.pinned.filter(s => s.name !== spell.name);
+  }
+
+  drop(event: CdkDragDrop<DndSpell[]>): void {
+    moveItemInArray(this.pinned, event.previousIndex, event.currentIndex);
+    this.pinned = [...this.pinned];
+  }
+
+  trackByName(_: number, s: DndSpell): string { return s.name; }
+
+  /** Component string for the card, e.g. "V, S, M (a pinch of soot)". */
+  componentLabel(spell: DndSpell): string {
+    const letters = (spell.components ?? []).map(c => c.toUpperCase()).join(', ');
+    if (spell.material && spell.components?.includes('m')) {
+      return `${letters} (${spell.material})`;
+    }
+    return letters || '—';
+  }
+
+  /** Flash the named card and scroll it into view (used on add and on duplicate-select). */
+  private focusCard(name: string): void {
+    this.focusedName = name;
+    clearTimeout(this.focusTimer);
+    // Defer a tick so a just-pinned card exists in the DOM before we scroll to it.
+    setTimeout(() => {
+      const idx = this.pinned.findIndex(s => s.name === name);
+      this.cardEls?.get(idx)?.nativeElement.scrollIntoView({
+        behavior: 'smooth', inline: 'center', block: 'nearest',
+      });
+    });
+    this.focusTimer = setTimeout(() => { this.focusedName = null; }, 1600);
+  }
+}


### PR DESCRIPTION
Wrapping row of always-expanded spell reference cards on the DM session screen. Collapsible header shows the pinned count; a trailing + silhouette opens a search overlay reusing SpellPickerComponent. Selecting pins a card (deduped by name — a duplicate select focuses the existing card instead), cards remove via their x and reorder via CDK drag-and-drop. State is ephemeral component-local (DndSpell[]) — no backend persistence.