### PR TITLE
feat: add per-character activity log with Log tab

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -17,6 +17,7 @@ import { InventoryPanelComponent } from './components/character-sheet/panels/inv
 import { SurvivalPanelComponent } from './components/character-sheet/panels/survival-panel/survival-panel.component';
 import { SuppliesPanelComponent } from './components/character-sheet/panels/supplies-panel/supplies-panel.component';
 import { PcNotesComponent } from './components/character-sheet/panels/pc-notes/pc-notes.component';
+import { PcLogComponent } from './components/character-sheet/panels/pc-log/pc-log.component';
 import { SpellbookPanelComponent } from './components/character-sheet/panels/spellbook-panel/spellbook-panel.component';
 import { FeaturesListComponent } from './components/character-sheet/panels/features-list/features-list.component';
 import { CoinPurseComponent } from './components/character-sheet/panels/coin-purse/coin-purse.component';
@@ -108,6 +109,7 @@ const routes: Routes = [
     SurvivalPanelComponent,
     SuppliesPanelComponent,
     PcNotesComponent,
+    PcLogComponent,
     SpellbookPanelComponent,
     FeaturesListComponent,
     CoinPurseComponent,

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -131,6 +131,8 @@
             [attr.aria-selected]="activeTab === 'inventory'" (click)="setTab('inventory')">Inventory</button>
     <button type="button" class="sheet-tab" role="tab" [class.active]="activeTab === 'notes'"
             [attr.aria-selected]="activeTab === 'notes'" (click)="setTab('notes')">Notes</button>
+    <button type="button" class="sheet-tab" role="tab" [class.active]="activeTab === 'log'"
+            [attr.aria-selected]="activeTab === 'log'" (click)="setTab('log')">Log</button>
   </nav>
 
   <!-- Vitals stay visible on every tab (HP/AC always matter). -->
@@ -218,6 +220,11 @@
       [canWrite]="(showActions || inventoryEditable) && !editable"
       [sessionId]="noteSessionId">
     </app-pc-notes>
+  </div>
+
+  <!-- LOG TAB: read-only activity feed (server-authoritative, no write path) -->
+  <div class="sheet-tab-panel" *ngIf="activeTab === 'log'">
+    <app-pc-log [pc]="pc"></app-pc-log>
   </div>
 
 </div>

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -99,8 +99,8 @@ export class CharacterSheetComponent implements OnChanges {
 
   /** Active section tab. The sheet is split so Notes (and Spells/Inventory) get
    *  their own space; on mobile the tab bar is pinned to the bottom of the screen. */
-  activeTab: 'sheet' | 'spells' | 'inventory' | 'notes' = 'sheet';
-  setTab(tab: 'sheet' | 'spells' | 'inventory' | 'notes'): void { this.activeTab = tab; }
+  activeTab: 'sheet' | 'spells' | 'inventory' | 'notes' | 'log' = 'sheet';
+  setTab(tab: 'sheet' | 'spells' | 'inventory' | 'notes' | 'log'): void { this.activeTab = tab; }
 
   editingName = false;
   nameDraft = '';

--- a/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.html
@@ -1,0 +1,15 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Activity Log</span>
+    <span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      recent updates to this character
+    </span>
+  </div>
+
+  <div *ngFor="let entry of entries" style="padding: 6px 0; border-bottom: 1px solid var(--line, rgba(255,255,255,0.06));">
+    <div>{{ entry.description }}</div>
+    <div class="equip-item-meta" style="margin-top: 2px;">{{ entryDate(entry) }}</div>
+  </div>
+
+  <div *ngIf="!entries.length" class="equip-item-meta">No activity yet.</div>
+</div>

--- a/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.spec.ts
@@ -1,0 +1,101 @@
+import { of, throwError } from 'rxjs';
+import { SimpleChange } from '@angular/core';
+import { PcLogComponent } from './pc-log.component';
+import { PCService } from '../../../../services/pc.service';
+import { PC } from '../../../../models/pc';
+import { PcActivityLogEntry } from '../../../../models/pc-activity-log';
+
+describe('PcLogComponent', () => {
+  let pcService: jasmine.SpyObj<PCService>;
+  let component: PcLogComponent;
+
+  const pc = (id: number): PC =>
+    ({ id, name: 'X', clazz: 'Rogue', level: 2, playerName: 'P' } as PC);
+
+  const entry = (id: number, description: string, createdAt = '2026-07-04T12:00:00Z'): PcActivityLogEntry =>
+    ({ id, pcId: 1, actionType: 'LEVEL_UP', description, createdAt });
+
+  beforeEach(() => {
+    pcService = jasmine.createSpyObj<PCService>('PCService', ['getLog']);
+    component = new PcLogComponent(pcService);
+  });
+
+  function bind(newPc: PC, previous?: PC): void {
+    component.pc = newPc;
+    component.ngOnChanges({ pc: new SimpleChange(previous, newPc, previous == null) });
+  }
+
+  it('loads the log entries when a character binds, in server order', () => {
+    pcService.getLog.and.returnValue(of([entry(2, 'Bought Rope for 1 gp'), entry(1, 'Leveled up to 3')]));
+
+    bind(pc(1));
+
+    expect(pcService.getLog).toHaveBeenCalledWith(1);
+    expect(component.entries.map(e => e.description)).toEqual(['Bought Rope for 1 gp', 'Leveled up to 3']);
+  });
+
+  it('does not reload for same-character change events, but does for a new character', () => {
+    pcService.getLog.and.returnValue(of([]));
+    bind(pc(1));
+    bind(pc(1), pc(1)); // live overlay refresh of the same PC
+    expect(pcService.getLog).toHaveBeenCalledTimes(1);
+
+    bind(pc(2), pc(1));
+    expect(pcService.getLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the list empty when the log is not readable (stranger)', () => {
+    pcService.getLog.and.returnValue(throwError(() => new Error('403')));
+
+    bind(pc(1));
+
+    expect(component.entries).toEqual([]);
+  });
+
+  describe('entryDate', () => {
+    let realDateNow: () => number;
+
+    beforeEach(() => {
+      realDateNow = Date.now;
+    });
+
+    afterEach(() => {
+      Date.now = realDateNow;
+    });
+
+    it('labels an entry from today as "Today, <time>"', () => {
+      const now = new Date('2026-07-07T18:00:00Z');
+      Date.now = () => now.getTime();
+
+      const result = component.entryDate(entry(1, 'x', new Date('2026-07-07T12:00:00Z').toISOString()));
+
+      expect(result).toContain('Today,');
+    });
+
+    it('labels an entry from yesterday as "Yesterday, <time>"', () => {
+      const now = new Date('2026-07-07T18:00:00Z');
+      Date.now = () => now.getTime();
+
+      const result = component.entryDate(entry(1, 'x', new Date('2026-07-06T09:00:00Z').toISOString()));
+
+      expect(result).toContain('Yesterday,');
+    });
+
+    it('shows a short date for older entries', () => {
+      const now = new Date('2026-07-07T18:00:00Z');
+      Date.now = () => now.getTime();
+
+      const result = component.entryDate(entry(1, 'x', new Date('2026-06-01T09:00:00Z').toISOString()));
+
+      expect(result).not.toContain('Today');
+      expect(result).not.toContain('Yesterday');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('is tolerant of a bad date, returning an empty string', () => {
+      const result = component.entryDate(entry(1, 'x', 'not-a-date'));
+
+      expect(result).toBe('');
+    });
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/pc-log/pc-log.component.ts
@@ -1,0 +1,54 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { PC } from '../../../../models/pc';
+import { PcActivityLogEntry } from '../../../../models/pc-activity-log';
+import { PCService } from '../../../../services/pc.service';
+
+/**
+ * Per-character activity log — the latest 10 server-recorded events
+ * (level-ups, shop purchases/sales, DM XP awards, long rests, DM sheet
+ * edits), newest first. Entirely read-only: every row is written by a
+ * backend mutation, never by the client, so there is no `canWrite` input
+ * (unlike {@link PcNotesComponent} — the server enforces who could have
+ * caused each entry, not this panel). Self-serviced via PCService, mirroring
+ * the pc-notes panel's data-flow pattern.
+ */
+@Component({
+  selector: 'app-pc-log',
+  templateUrl: './pc-log.component.html',
+})
+export class PcLogComponent implements OnChanges {
+  @Input() pc!: PC;
+
+  entries: PcActivityLogEntry[] = [];
+
+  constructor(private pcService: PCService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const previous = changes['pc']?.previousValue as PC | undefined;
+    if (changes['pc'] && this.pc?.id != null && this.pc.id !== previous?.id) {
+      this.load();
+    }
+  }
+
+  entryDate(entry: PcActivityLogEntry): string {
+    const d = new Date(entry.createdAt);
+    if (isNaN(d.getTime())) return '';
+
+    const now = new Date();
+    const startOfDay = (date: Date) => new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+    const dayDiff = Math.round((startOfDay(now) - startOfDay(d)) / (1000 * 60 * 60 * 24));
+
+    const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    if (dayDiff === 0) return `Today, ${time}`;
+    if (dayDiff === 1) return `Yesterday, ${time}`;
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  private load(): void {
+    this.entries = [];
+    this.pcService.getLog(this.pc.id).subscribe({
+      next: entries => { this.entries = entries; },
+      error: () => { /* not readable (stranger) — leave the list empty */ },
+    });
+  }
+}

--- a/src/app/charactermanager/models/pc-activity-log.ts
+++ b/src/app/charactermanager/models/pc-activity-log.ts
@@ -1,0 +1,14 @@
+/**
+ * A single entry in a character's read-only activity log — a pre-rendered
+ * display string recorded server-side at a notable mutation (level-up, shop
+ * purchase/sale, DM XP award, long rest, DM edit). Client mirror of the
+ * backend PcActivityLog entity.
+ */
+export interface PcActivityLogEntry {
+  id: number | string;
+  pcId: number;
+  actionType: string;      // 'LEVEL_UP' | 'PURCHASE' | 'SALE' | 'XP_AWARD' | 'LONG_REST' | 'DM_EDIT'
+  description: string;
+  actorUserId?: string;
+  createdAt: string;       // ISO-8601
+}

--- a/src/app/charactermanager/services/pc.demo-data.ts
+++ b/src/app/charactermanager/services/pc.demo-data.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 import { PC } from '../models/pc';
+import { PcActivityLogEntry } from '../models/pc-activity-log';
 import { hitDieFor, modFromScore } from '../utils/character-math';
 
 // ---------------------------------------------------------------------------
@@ -197,6 +198,42 @@ export const DEMO_PCS: PC[] = [
     notes: 'Familiar: Ash (raven). Bounty in three cities.',
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Demo activity log seed — a few plausible recent entries per demo PC, newest
+// first, so the Log tab isn't empty when the demo boots. Mirrors the backend's
+// pre-rendered display-string convention; not an audit of anything real.
+// ---------------------------------------------------------------------------
+export const DEMO_ACTIVITY_LOGS: { [pcId: number]: PcActivityLogEntry[] } = {
+  1: [
+    { id: 'demo-1-4', pcId: 1, actionType: 'DM_EDIT', description: 'DM changed AC 14 → 15',
+      createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString() },
+    { id: 'demo-1-3', pcId: 1, actionType: 'PURCHASE', description: 'Bought Potion of Healing for 50 gp',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString() },
+    { id: 'demo-1-2', pcId: 1, actionType: 'XP_AWARD', description: 'Awarded 450 XP',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString() },
+    { id: 'demo-1-1', pcId: 1, actionType: 'LEVEL_UP', description: 'Leveled up to 7',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString() },
+  ],
+  2: [
+    { id: 'demo-2-3', pcId: 2, actionType: 'LONG_REST', description: 'Completed a long rest',
+      createdAt: new Date(Date.now() - 1000 * 60 * 45).toISOString() },
+    { id: 'demo-2-2', pcId: 2, actionType: 'DM_EDIT', description: 'DM added feature Darkvision',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 8).toISOString() },
+    { id: 'demo-2-1', pcId: 2, actionType: 'SALE', description: 'Sold Handaxe for 2 gp 5 sp',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 30).toISOString() },
+  ],
+  5: [
+    { id: 'demo-5-4', pcId: 5, actionType: 'XP_AWARD', description: 'Awarded 300 XP',
+      createdAt: new Date(Date.now() - 1000 * 60 * 20).toISOString() },
+    { id: 'demo-5-3', pcId: 5, actionType: 'PURCHASE', description: 'Bought Caltrops (10) for 1 gp',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString() },
+    { id: 'demo-5-2', pcId: 5, actionType: 'LONG_REST', description: 'Completed a long rest',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 20).toISOString() },
+    { id: 'demo-5-1', pcId: 5, actionType: 'LEVEL_UP', description: 'Leveled up to 5',
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 2).toISOString() },
+  ],
+};
 
 // ---------------------------------------------------------------------------
 // Demo-mode level-up shim — pure helpers.

--- a/src/app/charactermanager/services/pc.service.spec.ts
+++ b/src/app/charactermanager/services/pc.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 
 import { PCService } from './pc.service';
 import { PC } from '../models/pc';
+import { DEMO_MODE_KEY } from 'src/environments/environment';
 
 /** Minimal valid PC fixture for serialization tests. */
 function makePC(overrides: Partial<PC> = {}): PC {
@@ -344,4 +345,77 @@ describe('PCService', () => {
     });
   });
 
+});
+
+// ── Demo mode: activity log ────────────────────────────────────────────────
+// demoMode reads localStorage live (see environment.ts), so these run in a
+// separate TestBed with the flag set before the service is constructed —
+// PCService seeds `this.pcs` from DEMO_PCS only when demoMode is already true.
+
+describe('PCService (demo mode)', () => {
+  let service: PCService;
+
+  beforeEach(() => {
+    localStorage.setItem(DEMO_MODE_KEY, 'true');
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PCService],
+    });
+    service = TestBed.inject(PCService);
+  });
+
+  afterEach(() => localStorage.removeItem(DEMO_MODE_KEY));
+
+  describe('getLog', () => {
+    it('returns the seeded demo log for a known PC', (done) => {
+      service.getLog(1).subscribe(entries => {
+        expect(entries.length).toBeGreaterThan(0);
+        expect(entries[0].pcId).toBe(1);
+        done();
+      });
+    });
+
+    it('returns an empty list for a PC with no seeded log', (done) => {
+      service.getLog(999).subscribe(entries => {
+        expect(entries).toEqual([]);
+        done();
+      });
+    });
+  });
+
+  describe('demo level-up', () => {
+    it('prepends a LEVEL_UP entry to the log', (done) => {
+      service.getLog(1).subscribe(before => {
+        const beforeCount = before.length;
+        service.levelUp(1).subscribe(updated => {
+          service.getLog(1).subscribe(after => {
+            expect(after.length).toBe(Math.min(beforeCount + 1, 10));
+            expect(after[0].actionType).toBe('LEVEL_UP');
+            expect(after[0].description).toBe('Leveled up to ' + updated.level);
+            done();
+          });
+        });
+      });
+    });
+
+    it('caps the demo log at 10 entries', (done) => {
+      // Level up repeatedly past the cap and confirm the log never exceeds 10.
+      const levelUpsNeeded = 12;
+      let completed = 0;
+      const doNext = () => {
+        if (completed === levelUpsNeeded) {
+          service.getLog(1).subscribe(entries => {
+            expect(entries.length).toBeLessThanOrEqual(10);
+            done();
+          });
+          return;
+        }
+        service.levelUp(1).subscribe(() => {
+          completed++;
+          doNext();
+        });
+      };
+      doNext();
+    });
+  });
 });

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { PC } from '../models/pc';
 import { PcNote } from '../models/pc-note';
+import { PcActivityLogEntry } from '../models/pc-activity-log';
 import { LevelUpPreview, LevelUpChoices } from '../models/level-up';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
@@ -9,6 +10,7 @@ import { environment } from 'src/environments/environment';
 import { hitDieFor, modFromScore } from '../utils/character-math';
 import {
   DEMO_PCS,
+  DEMO_ACTIVITY_LOGS,
   DEMO_GENERAL_FEATS,
   demoProfBonus,
   demoLevelUpFields,
@@ -178,6 +180,21 @@ export class PCService {
       return of([...(this.demoNotes[pcId] ?? [])]).pipe(delay(50));
     }
     return this.http.get<PcNote[]>(`${this.pcUrl}${pcId}/notes`);
+  }
+
+  // ── Per-character activity log ─────────────────────────────────────────────
+  // Read-only: written by backend mutations (level-up, shop, XP, long rest, DM
+  // edit), never by the client. Demo mode seeds a per-PC log from
+  // DEMO_ACTIVITY_LOGS and appends a LEVEL_UP entry on demo level-up.
+
+  private demoLog: { [pcId: number]: PcActivityLogEntry[] } =
+    JSON.parse(JSON.stringify(DEMO_ACTIVITY_LOGS));
+
+  getLog(pcId: number): Observable<PcActivityLogEntry[]> {
+    if (environment.demoMode) {
+      return of([...(this.demoLog[pcId] ?? [])]).pipe(delay(50));
+    }
+    return this.http.get<PcActivityLogEntry[]>(`${this.pcUrl}${pcId}/log`);
   }
 
   addNote(pcId: number, body: string, sessionId?: number | string | null): Observable<PcNote> {
@@ -355,6 +372,14 @@ export class PCService {
     if (active && active.id === id) {
       this.activePCSubject.next(updated);
     }
+
+    // Mirror the server's level-up log entry so the demo Log tab reflects it too.
+    const entry: PcActivityLogEntry = {
+      id: 'demo-levelup-' + Date.now(), pcId: id, actionType: 'LEVEL_UP',
+      description: 'Leveled up to ' + newLevel, createdAt: new Date().toISOString(),
+    };
+    this.demoLog[id] = [entry, ...(this.demoLog[id] ?? [])].slice(0, 10);
+
     return of(updated);
   }
 


### PR DESCRIPTION
Adds a read-only Log tab (after Notes) showing the 10 most recent character events — level-ups, shop purchases/sales, DM XP awards, long rests, and DM sheet edits — served by the new manager-service endpoint. Demo mode seeds a per-PC log for the three demo characters and appends a level-up entry on demo level-up, capped at 10.