### PR TITLE
fix: match party location tag to sheet subtitle style

### DIFF
--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -46,7 +46,7 @@
         >{{ pc.level }}</app-editable-number>
         <ng-container *ngIf="location">
           <span class="dot">✦</span>
-          <span class="sheet-location-tag" [attr.data-loc-type]="location.type"
+          <span class="sheet-location-tag"
                 title="Party location">📍 {{ location.name }}({{ location.type }})</span>
         </ng-container>
         <span *ngIf="readyToLevel" class="level-ready-badge" title="Enough XP to advance — use Level Up">

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.scss
@@ -91,23 +91,17 @@
   border-color: var(--gold, #d9b25f);
 }
 
-// XP bar + party location on one line beneath the subtitle.
+// XP bar on one line beneath the subtitle (party location now lives in .sheet-subtitle itself).
 .xp-row {
   display: flex;
   align-items: center;
   gap: 12px;
   margin-top: 10px;
 }
-// The party location, shown as "Name(Type)" beside the XP bar; tinted by type.
+// The party location, shown as "Name(Type)" beside the XP bar; matches the
+// Level/class/species subtitle style (inherited — it lives inside .sheet-subtitle).
 .sheet-location-tag {
-  font-family: 'Newsreader', serif;
-  font-size: 13px;
   white-space: nowrap;
-  color: var(--text-dim);
-
-  &[data-loc-type='Settlement'] { color: var(--celestial); }
-  &[data-loc-type='Wilderness'] { color: var(--emerald, #4ea36b); }
-  &[data-loc-type='Dungeon']    { color: var(--crimson); }
 }
 
 // XP progress bar — fills through the current level toward the next. Basis keeps


### PR DESCRIPTION
Location tag already lived inside .sheet-subtitle; drop the per-type color overrides and font overrides so it inherits the same Level/class/species styling instead of looking like a separate element.