### PR TITLE
feat: feat typeahead with auto-fill on the DM grant form

### DIFF
--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.html
@@ -5,10 +5,17 @@
   </div>
 
   <div *ngIf="grantFormOpen" class="grant-form">
-    <div class="field">
+    <div class="field feat-combobox">
       <label>Name</label>
       <input type="text" [(ngModel)]="nameDraft" placeholder="e.g. Blessing of the Old Gods"
-             (keydown.enter)="submitGrant()" (keydown.escape)="cancelGrant()" autofocus>
+             role="combobox" aria-haspopup="listbox" [attr.aria-expanded]="featDropdownOpen"
+             (focus)="onNameFocus()" (input)="onNameInput()" (blur)="onNameBlur()"
+             (keydown.enter)="submitGrant()" (keydown.escape)="onNameEscape()" autofocus>
+      <ul class="feat-options" role="listbox" *ngIf="featDropdownOpen && filteredFeats.length">
+        <li *ngFor="let n of filteredFeats" role="option">
+          <button type="button" class="feat-option" (mousedown)="$event.preventDefault(); selectFeat(n)">{{ n }}</button>
+        </li>
+      </ul>
     </div>
     <div class="field">
       <label>Source</label>

--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.scss
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.scss
@@ -29,3 +29,40 @@
   gap: 8px;
   justify-content: flex-end;
 }
+
+// Name field typeahead — filtered feat list dropdown anchored below the input.
+.feat-combobox {
+  position: relative;
+}
+
+.feat-options {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 2px 0 0;
+  padding: 4px 0;
+  list-style: none;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.45);
+}
+
+.feat-option {
+  display: block;
+  width: 100%;
+  padding: 7px 12px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: 'Newsreader', serif;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover { color: var(--gold); }
+}

--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.spec.ts
@@ -7,8 +7,10 @@ describe('FeaturesListComponent', () => {
   let dndResources: jasmine.SpyObj<DndResourcesService>;
 
   beforeEach(() => {
-    dndResources = jasmine.createSpyObj<DndResourcesService>('DndResourcesService', ['getFeatDescription']);
+    dndResources = jasmine.createSpyObj<DndResourcesService>(
+      'DndResourcesService', ['getFeatDescription', 'getFeatNames']);
     dndResources.getFeatDescription.and.returnValue('Looked-up feat text.');
+    dndResources.getFeatNames.and.returnValue(['Alert', 'Lucky', 'Skilled']);
     component = new FeaturesListComponent(dndResources);
     component.pc = { id: 1, name: 'X', clazz: 'Fighter', level: 4, playerName: 'P' } as PC;
   });
@@ -107,5 +109,74 @@ describe('FeaturesListComponent', () => {
     expect(emitted).not.toHaveBeenCalled();
     expect(component.grantFormOpen).toBeFalse();
     expect(component.nameDraft).toBe('');
+  });
+
+  // --- Feat typeahead ---
+
+  it('shows the full feat list when the name draft is blank', () => {
+    component.nameDraft = '';
+    expect(component.filteredFeats).toEqual(['Alert', 'Lucky', 'Skilled']);
+  });
+
+  it('narrows the feat list case-insensitively', () => {
+    component.nameDraft = 'al';
+    expect(component.filteredFeats).toEqual(['Alert']);
+  });
+
+  it('opens the dropdown on focus and input, closes on blur', () => {
+    component.onNameFocus();
+    expect(component.featDropdownOpen).toBeTrue();
+    component.onNameBlur();
+    expect(component.featDropdownOpen).toBeFalse();
+    component.onNameInput();
+    expect(component.featDropdownOpen).toBeTrue();
+  });
+
+  it('selectFeat fills name, source, and description, and closes the dropdown', () => {
+    component.featDropdownOpen = true;
+    component.selectFeat('Alert');
+
+    expect(component.nameDraft).toBe('Alert');
+    expect(component.sourceDraft).toBe('Feat');
+    expect(component.descDraft).toBe('Looked-up feat text.');
+    expect(component.featDropdownOpen).toBeFalse();
+    expect(dndResources.getFeatDescription).toHaveBeenCalledWith('Alert');
+  });
+
+  it('submits non-matching typed text as a custom feat, unchanged', () => {
+    component.addAllowed = true;
+    component.openGrantForm();
+    const emitted = jasmine.createSpy('emitted');
+    component.featureGranted.subscribe(emitted);
+
+    component.nameDraft = 'Homebrew Boon';
+    component.submitGrant();
+
+    expect(emitted).toHaveBeenCalledWith({ name: 'Homebrew Boon', source: 'DM Grant', desc: '' });
+  });
+
+  it('Escape closes the dropdown first, then cancels the form on a second Escape', () => {
+    component.addAllowed = true;
+    component.openGrantForm();
+    component.nameDraft = 'Half-typed';
+    component.featDropdownOpen = true;
+
+    component.onNameEscape();
+    expect(component.featDropdownOpen).toBeFalse();
+    expect(component.grantFormOpen).toBeTrue();
+
+    component.onNameEscape();
+    expect(component.grantFormOpen).toBeFalse();
+    expect(component.nameDraft).toBe('');
+  });
+
+  it('reset (via cancel) closes the dropdown too', () => {
+    component.addAllowed = true;
+    component.openGrantForm();
+    component.featDropdownOpen = true;
+
+    component.cancelGrant();
+
+    expect(component.featDropdownOpen).toBeFalse();
   });
 });

--- a/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/features-list/features-list.component.ts
@@ -43,12 +43,52 @@ export class FeaturesListComponent {
   sourceDraft = 'DM Grant';
   descDraft = '';
 
+  /** All known Origin feat names, loaded once — backs the Name field typeahead. */
+  allFeatNames: string[] = this.dndResources.getFeatNames();
+  featDropdownOpen = false;
+
   openGrantForm(): void {
     this.grantFormOpen = true;
   }
 
   cancelGrant(): void {
     this.resetGrantForm();
+  }
+
+  /** Feat names matching the current Name draft; blank query shows the full list. */
+  get filteredFeats(): string[] {
+    const q = this.nameDraft.trim().toLowerCase();
+    if (!q) return this.allFeatNames;
+    return this.allFeatNames.filter(n => n.toLowerCase().includes(q));
+  }
+
+  onNameFocus(): void {
+    this.featDropdownOpen = true;
+  }
+
+  onNameInput(): void {
+    this.featDropdownOpen = true;
+  }
+
+  onNameBlur(): void {
+    this.featDropdownOpen = false;
+  }
+
+  /** Escape closes the dropdown first; a second Escape (dropdown already closed) cancels the form. */
+  onNameEscape(): void {
+    if (this.featDropdownOpen) {
+      this.featDropdownOpen = false;
+      return;
+    }
+    this.cancelGrant();
+  }
+
+  /** Selecting a feat from the dropdown auto-fills Name/Source/Description. */
+  selectFeat(name: string): void {
+    this.nameDraft = name;
+    this.sourceDraft = 'Feat';
+    this.descDraft = this.dndResources.getFeatDescription(name);
+    this.featDropdownOpen = false;
   }
 
   submitGrant(): void {
@@ -65,5 +105,6 @@ export class FeaturesListComponent {
     this.nameDraft = '';
     this.sourceDraft = 'DM Grant';
     this.descDraft = '';
+    this.featDropdownOpen = false;
   }
 }

--- a/src/app/charactermanager/services/dnd-resources.service.spec.ts
+++ b/src/app/charactermanager/services/dnd-resources.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { DndResourcesService, SPELL_COUNTS, SPELLCASTING_CLASSES } from './dnd-resources.service';
+import { DndResourcesService, SPELL_COUNTS, SPELLCASTING_CLASSES, FEAT_DESCRIPTIONS } from './dnd-resources.service';
 import { DndSpell } from '../models/dnd-api.types';
 
 describe('DndResourcesService', () => {
@@ -90,6 +90,24 @@ describe('DndResourcesService', () => {
 
     it('returns empty string for unknown feat', () => {
       expect(service.getFeatDescription('Super Punch')).toBe('');
+    });
+  });
+
+  // ── Origin feat names ───────────────────────────────────────────────────────
+
+  describe('getFeatNames', () => {
+    it('returns names sorted alphabetically', () => {
+      const names = service.getFeatNames();
+      const sorted = [...names].sort((a, b) => a.localeCompare(b));
+      expect(names).toEqual(sorted);
+    });
+
+    it('contains Alert', () => {
+      expect(service.getFeatNames()).toContain('Alert');
+    });
+
+    it('length matches the number of known feats', () => {
+      expect(service.getFeatNames().length).toBe(Object.keys(FEAT_DESCRIPTIONS).length);
     });
   });
 

--- a/src/app/charactermanager/services/dnd-resources.service.ts
+++ b/src/app/charactermanager/services/dnd-resources.service.ts
@@ -458,6 +458,11 @@ export class DndResourcesService {
     return FEAT_DESCRIPTIONS[featName] ?? '';
   }
 
+  /** All known Origin feat names, alphabetized — backs the grant-form typeahead. */
+  getFeatNames(): string[] {
+    return Object.keys(FEAT_DESCRIPTIONS).sort((a, b) => a.localeCompare(b));
+  }
+
   /** Class skill proficiency choices for step 5 of the wizard. */
   getClassSkillChoices(className: string): { choose: number; from: string[] } {
     return CLASS_SKILL_CHOICES[className.toLowerCase()] ?? { choose: 2, from: [] };


### PR DESCRIPTION
Name field on the class-features grant form is now a filter-as-you-type combobox over the existing FEAT_DESCRIPTIONS map. Selecting an option auto-fills Name/Source/Description; typing non-matching text still submits as a custom feat, unchanged from today's behavior.