### PR TITLE
feat: open character sheets from the session initiative panel

### DIFF
--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.html
@@ -42,7 +42,8 @@
         <ng-template #initRead>{{ p.initRolled ? p.initiative : '—' }}</ng-template>
       </div>
 
-      <div class="board-hero">
+      <div class="board-hero" [class.linkable]="canOpenSheet(p)" (click)="onHeroClick(p)"
+           [attr.title]="canOpenSheet(p) ? 'Open character sheet' : null">
         <div class="portrait" [style.background]="tintFor(p)">{{ initialsFor(p) }}</div>
         <div style="min-width: 0;">
           <div class="board-hero-name">{{ p.name }}</div>

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.scss
@@ -243,3 +243,10 @@
     &[disabled] { opacity: 0.45; cursor: not-allowed; }
   }
 }
+
+// DM-only, PC-only cross-link into the full character sheet.
+.board-hero.linkable {
+  cursor: pointer;
+
+  &:hover .board-hero-name { color: var(--celestial); }
+}

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.spec.ts
@@ -1,0 +1,115 @@
+import { InitiativePanelComponent } from './initiative-panel.component';
+import { SessionService } from '../../../services/session.service';
+import { NotificationService } from '../../../services/notification.service';
+import { ParticipantView } from '../../../models/session';
+
+// Class-only test (no TestBed/DOM). SessionService.isMuted is called from the
+// ctor, so the spy must stub it even though most tests below never touch it.
+describe('InitiativePanelComponent', () => {
+  let component: InitiativePanelComponent;
+  let sessionService: jasmine.SpyObj<SessionService>;
+  let notifications: jasmine.SpyObj<NotificationService>;
+
+  beforeEach(() => {
+    sessionService = jasmine.createSpyObj<SessionService>('SessionService', ['isMuted']);
+    sessionService.isMuted.and.returnValue(false);
+    notifications = jasmine.createSpyObj<NotificationService>('NotificationService', ['notify']);
+    component = new InitiativePanelComponent(sessionService, notifications);
+  });
+
+  const participant = (overrides: Partial<ParticipantView> = {}): ParticipantView => ({
+    participantId: 1,
+    pcId: 7,
+    npc: false,
+    ownedByMe: false,
+    currentTurn: false,
+    name: 'Aria',
+    clazz: 'Bard',
+    level: 3,
+    portraitTint: null,
+    portraitInitials: null,
+    initiative: null,
+    initRolled: false,
+    dexModifier: null,
+    orderIndex: 0,
+    hpMax: 20,
+    hpCurrent: 20,
+    hpTemp: null,
+    ac: 14,
+    conditions: [],
+    survival: null,
+    spellSlots: null,
+    deathSaveSuccesses: 0,
+    deathSaveFailures: 0,
+    ...overrides,
+  });
+
+  // --- canOpenSheet ---
+
+  describe('canOpenSheet', () => {
+    it('is false for a non-DM viewer', () => {
+      component.dm = false;
+      expect(component.canOpenSheet(participant())).toBeFalse();
+    });
+
+    it('is false for an NPC row', () => {
+      component.dm = true;
+      expect(component.canOpenSheet(participant({ npc: true }))).toBeFalse();
+    });
+
+    it('is false when the row has no pcId', () => {
+      component.dm = true;
+      expect(component.canOpenSheet(participant({ pcId: null }))).toBeFalse();
+    });
+
+    it('is true for a DM viewing a PC row', () => {
+      component.dm = true;
+      expect(component.canOpenSheet(participant())).toBeTrue();
+    });
+  });
+
+  // --- onHeroClick ---
+
+  describe('onHeroClick', () => {
+    it('emits openPc when allowed', () => {
+      component.dm = true;
+      const p = participant();
+      const emitted = jasmine.createSpy('emitted');
+      component.openPc.subscribe(emitted);
+
+      component.onHeroClick(p);
+
+      expect(emitted).toHaveBeenCalledWith(p);
+    });
+
+    it('does not emit when not allowed (non-DM)', () => {
+      component.dm = false;
+      const emitted = jasmine.createSpy('emitted');
+      component.openPc.subscribe(emitted);
+
+      component.onHeroClick(participant());
+
+      expect(emitted).not.toHaveBeenCalled();
+    });
+
+    it('does not emit for an NPC row even as DM', () => {
+      component.dm = true;
+      const emitted = jasmine.createSpy('emitted');
+      component.openPc.subscribe(emitted);
+
+      component.onHeroClick(participant({ npc: true }));
+
+      expect(emitted).not.toHaveBeenCalled();
+    });
+
+    it('does not emit when pcId is null', () => {
+      component.dm = true;
+      const emitted = jasmine.createSpy('emitted');
+      component.openPc.subscribe(emitted);
+
+      component.onHeroClick(participant({ pcId: null }));
+
+      expect(emitted).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/initiative-panel/initiative-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ParticipantView, SessionStatus } from '../../../models/session';
 import { SessionService, TURN_SOUNDS } from '../../../services/session.service';
 import { NotificationService } from '../../../services/notification.service';
@@ -39,6 +39,13 @@ export class InitiativePanelComponent {
    *  rows then show compact hunger/thirst/fatigue chips so time can be
    *  advanced with the party's state in view. */
   @Input() survivalConditions = false;
+
+  /**
+   * A DM clicked a PC row's hero cell to open that character's full sheet.
+   * DM-only, PC-only (players' own sheet is already embedded in session mode,
+   * and NPCs have no sheet to open). SessionModeComponent owns the actual open.
+   */
+  @Output() openPc = new EventEmitter<ParticipantView>();
 
   /** Per-row amount typed into the DM's damage/heal box, keyed by participant id. */
   amounts: { [participantId: number]: number | null } = {};
@@ -116,6 +123,15 @@ export class InitiativePanelComponent {
     if (this.dm) return true;
     if (!p.ownedByMe) return false;
     return this.status === 'LOBBY' || !p.initRolled;
+  }
+
+  /** DM-only, PC-only: whether clicking this row's hero cell should open the sheet. */
+  canOpenSheet(p: ParticipantView): boolean {
+    return this.dm && !p.npc && p.pcId != null;
+  }
+
+  onHeroClick(p: ParticipantView): void {
+    if (this.canOpenSheet(p)) this.openPc.emit(p);
   }
 
   isActive(p: ParticipantView): boolean {

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -173,6 +173,7 @@
       [enemiesHidden]="state.enemiesHidden"
       [turnSound]="state.turnSound"
       [survivalConditions]="survivalConditions"
+      (openPc)="openPcSheet($event)"
     ></app-initiative-panel>
 
     <app-encounter-loader [state]="state" *ngIf="state.dm" style="display: block; margin-top: 16px;"></app-encounter-loader>

--- a/src/app/charactermanager/components/session-mode/session-mode.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.spec.ts
@@ -1,6 +1,10 @@
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { SessionModeComponent } from './session-mode.component';
-import { SessionState } from '../../models/session';
+import { ParticipantView, SessionState } from '../../models/session';
+import { PCService } from '../../services/pc.service';
+import { UiStateService } from '../../services/ui-state.service';
+import { NotificationService } from '../../services/notification.service';
+import { PC } from '../../models/pc';
 
 // Class-only test of the initiative-visibility predicate (no TestBed; only
 // sessionService.state$ is touched during construction, so stub just that).
@@ -21,5 +25,78 @@ describe('SessionModeComponent.showInitiative', () => {
     expect(component.showInitiative(state(false, 'LOBBY'))).toBeFalse();
     expect(component.showInitiative(state(false, 'ACTIVE'))).toBeTrue();
     expect(component.showInitiative(state(false, 'ENDED'))).toBeFalse();
+  });
+});
+
+describe('SessionModeComponent.openPcSheet', () => {
+  let component: SessionModeComponent;
+  let pcService: jasmine.SpyObj<PCService>;
+  let uiState: jasmine.SpyObj<UiStateService>;
+  let notifications: jasmine.SpyObj<NotificationService>;
+
+  const participant = (overrides: Partial<ParticipantView> = {}): ParticipantView =>
+    ({ participantId: 1, pcId: 7, npc: false, ownedByMe: false, name: 'Aria', ...overrides } as ParticipantView);
+
+  beforeEach(() => {
+    pcService = jasmine.createSpyObj<PCService>('PCService', ['getPCById', 'getPCByIdAsDm', 'setActivePC']);
+    uiState = jasmine.createSpyObj<UiStateService>('UiStateService', ['viewHeroAsDm']);
+    notifications = jasmine.createSpyObj<NotificationService>('NotificationService', ['notify']);
+    const sessionServiceStub = { state$: of(null) } as never;
+    component = new SessionModeComponent(
+      sessionServiceStub, uiState, pcService, notifications, null as never, null as never);
+  });
+
+  it('owned PC: opens from the local store with no HTTP fetch', () => {
+    const owned = { id: 7, name: 'Aria' } as PC;
+    pcService.getPCById.and.returnValue(owned);
+
+    component.openPcSheet(participant());
+
+    expect(pcService.getPCById).toHaveBeenCalledWith(7);
+    expect(pcService.getPCByIdAsDm).not.toHaveBeenCalled();
+    expect(pcService.setActivePC).toHaveBeenCalledWith(owned);
+    expect(uiState.viewHeroAsDm).toHaveBeenCalled();
+  });
+
+  it('unowned PC: fetches via the DM-authorized path', () => {
+    pcService.getPCById.and.returnValue(undefined);
+    const full = { id: 7, name: 'Aria' } as PC;
+    pcService.getPCByIdAsDm.and.returnValue(of(full));
+
+    component.openPcSheet(participant());
+
+    expect(pcService.getPCByIdAsDm).toHaveBeenCalledWith(7);
+    expect(pcService.setActivePC).toHaveBeenCalledWith(full);
+    expect(uiState.viewHeroAsDm).toHaveBeenCalled();
+  });
+
+  it('fetch error: notifies and stays in the session (no sheet open)', () => {
+    pcService.getPCById.and.returnValue(undefined);
+    pcService.getPCByIdAsDm.and.returnValue(throwError(() => new Error('boom')));
+
+    component.openPcSheet(participant());
+
+    expect(notifications.notify).toHaveBeenCalledWith('Could not open that character sheet.');
+    expect(pcService.setActivePC).not.toHaveBeenCalled();
+    expect(uiState.viewHeroAsDm).not.toHaveBeenCalled();
+  });
+
+  it('empty fetch result: notifies and stays in the session', () => {
+    pcService.getPCById.and.returnValue(undefined);
+    pcService.getPCByIdAsDm.and.returnValue(of({} as PC));
+
+    component.openPcSheet(participant());
+
+    expect(notifications.notify).toHaveBeenCalledWith('Could not open that character sheet.');
+    expect(pcService.setActivePC).not.toHaveBeenCalled();
+    expect(uiState.viewHeroAsDm).not.toHaveBeenCalled();
+  });
+
+  it('null pcId: no-op', () => {
+    component.openPcSheet(participant({ pcId: null }));
+
+    expect(pcService.getPCById).not.toHaveBeenCalled();
+    expect(pcService.getPCByIdAsDm).not.toHaveBeenCalled();
+    expect(uiState.viewHeroAsDm).not.toHaveBeenCalled();
   });
 });

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -13,6 +13,7 @@ import { LocationType, LOCATION_TYPES, TimeOfDay } from '../../models/campaign';
 import { advanceGameTime, describeGameTime } from '../../utils/survival';
 import { CastRequest } from '../character-sheet/panels/spellbook-panel/spellbook-panel.component';
 import { withRecomputedAc } from '../../utils/armor-math';
+import { ParticipantView } from '../../models/session';
 
 /**
  * Session Mode screen — a full-width overlay (chosen in the sidenav over the
@@ -281,6 +282,39 @@ export class SessionModeComponent implements OnInit, OnDestroy {
   close(): void {
     this.sessionService.clear();
     this.uiState.closeSession();
+  }
+
+  /**
+   * DM clicked a PC row in the initiative panel — open that character's full
+   * sheet, editable, while the session keeps running underneath (mirrors
+   * CampaignDashboardComponent.openHero). For the DM's own characters the full
+   * PC is already in the local store; other players' members need the
+   * DM-authorized fetch, since the session snapshot only carries the
+   * privacy-limited projection. The session isn't torn down — sidenav's render
+   * precedence just swaps in the sheet until the DM returns.
+   */
+  openPcSheet(p: ParticipantView): void {
+    if (p.pcId == null) return;
+    const owned = this.pcService.getPCById(p.pcId);
+    if (owned) {
+      this.pcService.setActivePC(owned);
+      this.uiState.viewHeroAsDm();
+      return;
+    }
+    this.pcService.getPCByIdAsDm(p.pcId).subscribe({
+      next: full => {
+        if (!full?.id) {
+          this.notifications.notify('Could not open that character sheet.');
+          return;
+        }
+        this.pcService.setActivePC(full);
+        this.uiState.viewHeroAsDm();
+      },
+      error: err => {
+        console.error('Failed to load full character for DM edit', err);
+        this.notifications.notify('Could not open that character sheet.');
+      },
+    });
   }
 
   /** The requesting player's own participant id in this session, if any. */

--- a/src/app/charactermanager/components/sidenav/sidenav.component.html
+++ b/src/app/charactermanager/components/sidenav/sidenav.component.html
@@ -147,29 +147,35 @@
     </div>
 
     <div class="main-inner">
-      <!-- Session Mode overlays both Player and DM views while a session is live -->
-      <ng-container *ngIf="(activeSessionId$ | async) as sessionId; else normalView">
-        <app-session-mode [sessionId]="sessionId"></app-session-mode>
-      </ng-container>
-      <ng-template #normalView>
-        <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
-          <!-- Shown when a DM cross-linked into a member's sheet -->
-          <button *ngIf="dmReturn$ | async" class="btn dm-return-bar" (click)="backToCampaign()"
-                  style="margin-bottom: 16px;">
-            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"
-                 stroke-linecap="round" stroke-linejoin="round"
-                 style="margin-right: 8px; vertical-align: -2px;">
-              <path d="M10 3L5 8l5 5"/>
-            </svg>
-            Back to Campaign
-          </button>
-          <app-session-live-banner></app-session-live-banner>
-          <router-outlet></router-outlet>
+      <!-- Session Mode overlays both Player and DM views while a session is live —
+           EXCEPT when the DM has cross-linked from the session into a member's
+           sheet (dmReturn), in which case the sheet takes over and the session
+           keeps running underneath (re-entered via the bar below). -->
+      <ng-container *ngIf="{ sessionId: activeSessionId$ | async, dmReturn: dmReturn$ | async } as vm">
+        <ng-container *ngIf="vm.sessionId && !vm.dmReturn; else normalView">
+          <app-session-mode [sessionId]="vm.sessionId"></app-session-mode>
         </ng-container>
-        <ng-template #dmMain>
-          <app-campaign-dashboard></app-campaign-dashboard>
+        <ng-template #normalView>
+          <ng-container *ngIf="(role$ | async) === 'player'; else dmMain">
+            <!-- Shown when a DM cross-linked into a member's sheet, either from the
+                 campaign dashboard or from a live session's initiative panel. -->
+            <button *ngIf="vm.dmReturn" class="btn dm-return-bar" (click)="backToCampaign()"
+                    style="margin-bottom: 16px;">
+              <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"
+                   stroke-linecap="round" stroke-linejoin="round"
+                   style="margin-right: 8px; vertical-align: -2px;">
+                <path d="M10 3L5 8l5 5"/>
+              </svg>
+              {{ vm.sessionId ? 'Back to Session' : 'Back to Campaign' }}
+            </button>
+            <app-session-live-banner *ngIf="!vm.dmReturn"></app-session-live-banner>
+            <router-outlet></router-outlet>
+          </ng-container>
+          <ng-template #dmMain>
+            <app-campaign-dashboard></app-campaign-dashboard>
+          </ng-template>
         </ng-template>
-      </ng-template>
+      </ng-container>
     </div>
   </main>
 


### PR DESCRIPTION
DM clicks a PC's hero cell in the session initiative panel to open that character's full sheet, editable in place; a "Back to Session" bar returns to the live tracker. DM-only, PC-only — NPC rows and players' own rows (already embedded in session mode) are not linkable.

sidenav's render precedence now checks dmReturn alongside the active session id so the sheet can take over while the session keeps polling underneath. ui-state.service.ts is untouched — the existing overlay stack already supports session + dmHero stacking.

Trade-off: returning to the session remounts session-mode (ngOnInit restarts polling), so any transient in-session UI state (drafts, open edit forms) resets. Acceptable for this feature.