### PR TITLE
feat: DM edit modal with custom activity log description

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -33,6 +33,7 @@ import { SpellsStepComponent } from './components/create-character-modal/steps/s
 import { EquipmentStepComponent } from './components/create-character-modal/steps/equipment-step/equipment-step.component';
 import { ReviewStepComponent } from './components/create-character-modal/steps/review-step/review-step.component';
 import { DeleteConfirmationModalComponent } from './components/main-content/delete-confirmation-modal/delete-confirmation-modal.component';
+import { DmEditModalComponent } from './components/character-sheet/dm-edit-modal/dm-edit-modal.component';
 import { DiceRollerModalComponent } from './components/dice-roller-modal/dice-roller-modal.component';
 import { LevelUpModalComponent } from './components/level-up-modal/level-up-modal.component';
 import { SpellPickerComponent } from './components/spell-picker/spell-picker.component';
@@ -84,6 +85,7 @@ const routes: Routes = [
     MainContentComponent,
     SidenavComponent,
     DeleteConfirmationModalComponent,
+    DmEditModalComponent,
     CreateCharacterModalComponent,
     IdentityStepComponent,
     SpeciesStepComponent,

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.html
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.html
@@ -41,6 +41,7 @@
           [value]="pc.level"
           [editable]="editable"
           [min]="1" [max]="20"
+          [intercept]="true" (editRequested)="requestLevel()"
           label="level"
           (committed)="onLevelCommit($event)"
         >{{ pc.level }}</app-editable-number>
@@ -139,7 +140,8 @@
   <app-vitals-strip
     [pc]="pc"
     [editable]="editable"
-    (pcChange)="onPcChange($event)">
+    (pcChange)="onPcChange($event)"
+    (editRequested)="onDmEditRequested($event)">
   </app-vitals-strip>
 
   <!-- SHEET TAB: abilities, skills, conditions, survival, features, wealth, bio -->
@@ -148,7 +150,8 @@
       <app-ability-scores
         [pc]="pc"
         [editable]="editable"
-        (pcChange)="onPcChange($event)">
+        (pcChange)="onPcChange($event)"
+        (editRequested)="onDmEditRequested($event)">
       </app-ability-scores>
       <app-skills-list    [pc]="pc"></app-skills-list>
     </div>
@@ -169,7 +172,8 @@
       <app-coin-purse
         [pc]="pc"
         [editable]="editable"
-        (pcChange)="onPcChange($event)">
+        (pcChange)="onPcChange($event)"
+        (editRequested)="onDmEditRequested($event)">
       </app-coin-purse>
       <app-background-story [pc]="pc"></app-background-story>
     </div>
@@ -227,4 +231,15 @@
     <app-pc-log [pc]="pc"></app-pc-log>
   </div>
 
+</div>
+
+<!-- DM edit modal overlay — opened by any intercepted app-editable-number on
+     this sheet (level here, or bubbled up from vitals-strip/coin-purse/ability-scores). -->
+<div *ngIf="dmEdit" class="modal-backdrop" (click)="closeDmEdit()">
+  <app-dm-edit-modal
+    [request]="dmEdit"
+    (click)="$event.stopPropagation()"
+    (confirm)="onDmEditConfirmed($event)"
+    (close)="closeDmEdit()">
+  </app-dm-edit-modal>
 </div>

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.spec.ts
@@ -166,4 +166,77 @@ describe('CharacterSheetComponent', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith('Failed to grant item', error);
   });
+
+  // --- persist / onPcChange: DM cross-link vs. player path ---
+
+  it('DM cross-link (editable): onPcChange saves via the 2-arg DM-authorized path with no description', () => {
+    component.editable = true;
+    pcService.updatePCAsDm.and.returnValue(of(makePC()));
+
+    const updated = makePC({ ac: 16 });
+    component.onPcChange(updated);
+
+    expect(pcService.updatePCAsDm).toHaveBeenCalledWith(updated, null);
+    expect(pcService.updatePC).not.toHaveBeenCalled();
+  });
+
+  it('player path (not editable): onPcChange still calls updatePC only — regression guard', () => {
+    component.editable = false;
+    pcService.updatePC.and.returnValue(of(makePC()));
+
+    const updated = makePC({ ac: 16 });
+    component.onPcChange(updated);
+
+    expect(pcService.updatePC).toHaveBeenCalledWith(updated);
+    expect(pcService.updatePCAsDm).not.toHaveBeenCalled();
+  });
+
+  // --- DM edit modal ---
+
+  it('onDmEditRequested stores the request, opening the modal', () => {
+    const request = { label: 'AC', value: 15, min: 0, max: null, apply: (v: number) => makePC({ ac: v }) };
+
+    component.onDmEditRequested(request);
+
+    expect(component.dmEdit).toBe(request);
+  });
+
+  it('onDmEditConfirmed applies the request and persists with the DM-authored description', () => {
+    component.editable = true;
+    pcService.updatePCAsDm.and.returnValue(of(makePC()));
+    const applied = makePC({ ac: 16 });
+    const request = { label: 'AC', value: 15, min: 0, max: null, apply: (v: number) => applied };
+    component.onDmEditRequested(request);
+
+    component.onDmEditConfirmed({ value: 16, description: 'DM changed AC 15 → 16 for cover' });
+
+    expect(pcService.updatePCAsDm).toHaveBeenCalledWith(applied, 'DM changed AC 15 → 16 for cover');
+    expect(component.dmEdit).toBeNull();
+  });
+
+  it('onDmEditConfirmed with a null description still saves (backend falls back to auto-diff)', () => {
+    component.editable = true;
+    pcService.updatePCAsDm.and.returnValue(of(makePC()));
+    const applied = makePC({ ac: 16 });
+    component.onDmEditRequested({ label: 'AC', value: 15, min: 0, max: null, apply: () => applied });
+
+    component.onDmEditConfirmed({ value: 16, description: null });
+
+    expect(pcService.updatePCAsDm).toHaveBeenCalledWith(applied, null);
+  });
+
+  it('onDmEditConfirmed does nothing when no request is pending', () => {
+    component.onDmEditConfirmed({ value: 16, description: 'x' });
+
+    expect(pcService.updatePCAsDm).not.toHaveBeenCalled();
+  });
+
+  it('closeDmEdit clears the pending request without saving', () => {
+    component.onDmEditRequested({ label: 'AC', value: 15, min: 0, max: null, apply: (v: number) => makePC({ ac: v }) });
+
+    component.closeDmEdit();
+
+    expect(component.dmEdit).toBeNull();
+    expect(pcService.updatePCAsDm).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
+++ b/src/app/charactermanager/components/character-sheet/character-sheet.component.ts
@@ -6,6 +6,8 @@ import { GrantService } from '../../services/grant.service';
 import { tintFor } from '../../utils/character-math';
 import { CastRequest } from './panels/spellbook-panel/spellbook-panel.component';
 import { isReadyToLevel, xpForNextLevel, xpProgressPct } from '../../models/xp-thresholds';
+import { DmEditRequest } from './dm-edit-modal/dm-edit-request';
+import { DmEditConfirm } from './dm-edit-modal/dm-edit-modal.component';
 
 @Component({
   selector: 'app-character-sheet',
@@ -123,11 +125,14 @@ export class CharacterSheetComponent implements OnChanges {
    * Persist an updated PC. In editable (DM cross-link) mode this goes through the
    * DM-authorized path so a DM may save another player's character; otherwise it
    * uses the owner path. PCService pushes the result into activePC$, so the sheet
-   * refreshes itself.
+   * refreshes itself. `description`, when given, is a DM-authored log entry that
+   * replaces the backend's automatic before/after diff — only ever passed from
+   * the DM edit modal; every other call site (name/level/conditions/pcChange)
+   * omits it and keeps the auto-diff behavior unchanged.
    */
-  private persist(updated: PC): void {
+  private persist(updated: PC, description: string | null = null): void {
     const save$ = this.editable
-      ? this.pcService.updatePCAsDm(updated)
+      ? this.pcService.updatePCAsDm(updated, description)
       : this.pcService.updatePC(updated);
     save$.subscribe({ error: err => console.error('Failed to save character', err) });
   }
@@ -183,6 +188,39 @@ export class CharacterSheetComponent implements OnChanges {
 
   onLevelCommit(level: number): void {
     this.persist({ ...this.pc, level });
+  }
+
+  /** DM clicked (intercepted) the level number — request the edit modal instead
+   *  of the inline editor. Label matches the backend's own diff vocabulary. */
+  requestLevel(): void {
+    this.onDmEditRequested({
+      label: 'level',
+      value: this.pc.level ?? null,
+      min: 1,
+      max: 20,
+      apply: v => ({ ...this.pc, level: v }),
+    });
+  }
+
+  // ── DM edit modal ────────────────────────────────────────────────────────
+  // Opened when any intercepted app-editable-number on this sheet (level here,
+  // or one bubbled up from vitals-strip/coin-purse/ability-scores) is clicked
+  // in DM cross-link mode, instead of that control's own inline editor.
+
+  dmEdit: DmEditRequest | null = null;
+
+  onDmEditRequested(request: DmEditRequest): void {
+    this.dmEdit = request;
+  }
+
+  onDmEditConfirmed(result: DmEditConfirm): void {
+    if (!this.dmEdit) return;
+    this.persist(this.dmEdit.apply(result.value), result.description);
+    this.dmEdit = null;
+  }
+
+  closeDmEdit(): void {
+    this.dmEdit = null;
   }
 
   // ── Conditions (wired fully in Phase 5) ─────────────────────────────────────

--- a/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.html
+++ b/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.html
@@ -1,0 +1,34 @@
+<div class="modal" style="border-color: var(--celestial);" (click)="$event.stopPropagation()">
+  <div class="modal-title" style="color: var(--celestial-2);">Edit {{ request.label }}</div>
+
+  <div class="field">
+    <label>{{ request.label | titlecase }}</label>
+    <input
+      type="number"
+      [(ngModel)]="valueDraft"
+      [min]="request.min"
+      [max]="request.max"
+      (ngModelChange)="onValueChange()"
+      (keydown.enter)="save()"
+      (keydown.escape)="cancel()"
+      autofocus
+    >
+  </div>
+
+  <div class="field">
+    <label>Log entry (leave blank for the automatic one)</label>
+    <textarea
+      rows="2"
+      [(ngModel)]="descDraft"
+      [maxLength]="descMaxLength"
+      (ngModelChange)="onDescInput()"
+      (keydown.escape)="cancel()"
+      placeholder="What happened…"
+    ></textarea>
+  </div>
+
+  <div class="modal-actions">
+    <button class="btn" type="button" (click)="cancel()">Cancel</button>
+    <button class="btn primary" type="button" [disabled]="!canSave" (click)="save()">Save</button>
+  </div>
+</div>

--- a/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.scss
+++ b/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.scss
@@ -1,0 +1,18 @@
+/* .field styles input/select globally but not textarea — extend it here
+   (mirrors features-list.component.scss's grant-form textarea). */
+.field textarea {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 9px 12px;
+  font-family: 'Newsreader', serif;
+  font-size: 15px;
+  border-radius: 2px;
+  outline: none;
+  resize: vertical;
+}
+.field textarea:focus {
+  border-color: var(--gold);
+  box-shadow: var(--glow-gold);
+}

--- a/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.spec.ts
@@ -1,0 +1,168 @@
+import { DmEditModalComponent } from './dm-edit-modal.component';
+import { DmEditRequest } from './dm-edit-request';
+import { PC } from '../../../models/pc';
+
+describe('DmEditModalComponent', () => {
+  let component: DmEditModalComponent;
+
+  const request = (overrides: Partial<DmEditRequest> = {}): DmEditRequest => ({
+    label: 'AC',
+    value: 15,
+    min: 0,
+    max: null,
+    apply: (v: number) => ({ ac: v } as PC),
+    ...overrides,
+  });
+
+  const setRequest = (req: DmEditRequest): void => {
+    component.request = req;
+    component.ngOnChanges({ request: { currentValue: req, previousValue: null, firstChange: true, isFirstChange: () => true } });
+  };
+
+  beforeEach(() => {
+    component = new DmEditModalComponent();
+  });
+
+  // --- init / auto text ---
+
+  it('initializes the value draft and auto-generated description from the request', () => {
+    setRequest(request());
+    expect(component.valueDraft).toBe(15);
+    // Draft starts equal to the current value, so the auto-text initially reads "same → same".
+    expect(component.descDraft).toBe('DM changed AC 15 → 15');
+  });
+
+  it('renders a null old value as an em dash, mirroring the backend', () => {
+    setRequest(request({ value: null, label: 'gp' }));
+    component.valueDraft = 10;
+    expect(component.autoText).toBe('DM changed gp — → 10');
+  });
+
+  // --- live-update / pin / re-arm ---
+
+  it('live-updates the description as the value changes while untouched', () => {
+    setRequest(request());
+    component.valueDraft = 18;
+    component.onValueChange();
+    expect(component.descDraft).toBe('DM changed AC 15 → 18');
+  });
+
+  it('pins the description once the DM hand-edits it, and stops auto-updating', () => {
+    setRequest(request());
+    component.descDraft = 'Took a hit from the trap';
+    component.onDescInput();
+    expect(component.descTouched).toBeTrue();
+
+    component.valueDraft = 20;
+    component.onValueChange();
+    expect(component.descDraft).toBe('Took a hit from the trap');
+  });
+
+  it('re-arms auto-fill when the DM clears the description back to blank', () => {
+    setRequest(request());
+    component.descDraft = 'Custom note';
+    component.onDescInput();
+    expect(component.descTouched).toBeTrue();
+
+    component.descDraft = '';
+    component.onDescInput();
+    expect(component.descTouched).toBeFalse();
+
+    component.valueDraft = 20;
+    component.onValueChange();
+    expect(component.descDraft).toBe('DM changed AC 15 → 20');
+  });
+
+  it('does not mark touched when the typed text exactly matches the current auto-text', () => {
+    setRequest(request());
+    component.descDraft = component.autoText;
+    component.onDescInput();
+    expect(component.descTouched).toBeFalse();
+  });
+
+  // --- clamping ---
+
+  it('clamps the draft value using min/max, rounding first', () => {
+    setRequest(request({ min: 0, max: 20 }));
+    component.valueDraft = 25.6;
+    expect(component.clamped).toBe(20);
+
+    component.valueDraft = -3;
+    expect(component.clamped).toBe(0);
+  });
+
+  it('clamped is null for a blank or non-numeric draft', () => {
+    setRequest(request());
+    component.valueDraft = null;
+    expect(component.clamped).toBeNull();
+  });
+
+  // --- canSave ---
+
+  it('canSave is false when the clamped value equals the original', () => {
+    setRequest(request({ value: 15 }));
+    component.valueDraft = 15;
+    expect(component.canSave).toBeFalse();
+  });
+
+  it('canSave is true when the clamped value differs from the original', () => {
+    setRequest(request({ value: 15 }));
+    component.valueDraft = 16;
+    expect(component.canSave).toBeTrue();
+  });
+
+  it('canSave is false when the draft is invalid', () => {
+    setRequest(request());
+    component.valueDraft = null;
+    expect(component.canSave).toBeFalse();
+  });
+
+  // --- save ---
+
+  it('save emits the clamped value and null description when left blank', () => {
+    setRequest(request({ value: 15 }));
+    component.valueDraft = 18;
+    component.descDraft = '   ';
+    const emitted = jasmine.createSpy('emitted');
+    component.confirm.subscribe(emitted);
+
+    component.save();
+
+    expect(emitted).toHaveBeenCalledWith({ value: 18, description: null });
+  });
+
+  it('save emits the trimmed hand-typed description when present', () => {
+    setRequest(request({ value: 15 }));
+    component.valueDraft = 18;
+    component.descDraft = '  Took a hit  ';
+    const emitted = jasmine.createSpy('emitted');
+    component.confirm.subscribe(emitted);
+
+    component.save();
+
+    expect(emitted).toHaveBeenCalledWith({ value: 18, description: 'Took a hit' });
+  });
+
+  it('save does nothing when canSave is false', () => {
+    setRequest(request({ value: 15 }));
+    component.valueDraft = 15;
+    const emitted = jasmine.createSpy('emitted');
+    component.confirm.subscribe(emitted);
+
+    component.save();
+
+    expect(emitted).not.toHaveBeenCalled();
+  });
+
+  // --- cancel ---
+
+  it('cancel emits close', () => {
+    setRequest(request());
+    const emitted = jasmine.createSpy('emitted');
+    component.close.subscribe(emitted);
+
+    component.cancel();
+
+    expect(emitted).toHaveBeenCalled();
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.ts
+++ b/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-modal.component.ts
@@ -1,0 +1,96 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { DmEditRequest } from './dm-edit-request';
+
+/** What the modal hands back on Save: the clamped value and, if the DM typed
+ *  one, their own log description (null lets the backend fall back to its
+ *  automatic before/after diff). */
+export interface DmEditConfirm {
+  value: number;
+  description: string | null;
+}
+
+/**
+ * DM edit modal — opened when a DM clicks an intercepted `app-editable-number`
+ * on a cross-linked character sheet. Prefills the value and an auto-generated
+ * log line ("DM changed AC 15 → 16") that live-updates as the value changes,
+ * until the DM hand-edits the description; from then on their text is pinned
+ * and clearing the textarea re-arms the auto-fill. Saving with a blank
+ * description sends `null` so the backend computes its usual diff instead.
+ */
+@Component({
+  selector: 'app-dm-edit-modal',
+  templateUrl: './dm-edit-modal.component.html',
+  styleUrls: ['./dm-edit-modal.component.scss'],
+})
+export class DmEditModalComponent implements OnChanges {
+  @Input() request!: DmEditRequest;
+  @Output() confirm = new EventEmitter<DmEditConfirm>();
+  @Output() close = new EventEmitter<void>();
+
+  readonly descMaxLength = 500;
+
+  valueDraft: number | null = null;
+  descDraft = '';
+  /** True once the DM has typed something that diverges from the auto-text —
+   *  from then on value changes no longer overwrite their words. */
+  descTouched = false;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['request'] && this.request) {
+      this.valueDraft = this.request.value;
+      this.descTouched = false;
+      this.descDraft = this.autoText;
+    }
+  }
+
+  /** "DM changed AC 15 → 16" — mirrors PcActivityLogService's diffScalar wording. */
+  get autoText(): string {
+    const before = this.render(this.request.value);
+    const after = this.render(this.clamped);
+    return `DM changed ${this.request.label} ${before} → ${after}`;
+  }
+
+  private render(value: number | null): string {
+    return value == null ? '—' : String(value);
+  }
+
+  /** The typed value, clamped the same way EditableNumberComponent does (round + min/max). */
+  get clamped(): number | null {
+    if (this.valueDraft === null || this.valueDraft === undefined || isNaN(Number(this.valueDraft))) {
+      return null;
+    }
+    let v = Math.round(Number(this.valueDraft));
+    if (this.request.min !== null) v = Math.max(this.request.min, v);
+    if (this.request.max !== null) v = Math.min(this.request.max, v);
+    return v;
+  }
+
+  get canSave(): boolean {
+    return this.clamped !== null && this.clamped !== this.request.value;
+  }
+
+  /** Value changed — keep the auto-text in sync unless the DM has hand-edited it. */
+  onValueChange(): void {
+    if (!this.descTouched) this.descDraft = this.autoText;
+  }
+
+  /** Description keystroke — pin it once it diverges from the auto-text; an
+   *  empty textarea re-arms auto-fill on the next value change. */
+  onDescInput(): void {
+    if (this.descDraft.trim() === '') {
+      this.descTouched = false;
+      return;
+    }
+    this.descTouched = this.descDraft !== this.autoText;
+  }
+
+  save(): void {
+    if (!this.canSave || this.clamped === null) return;
+    const description = this.descDraft.trim();
+    this.confirm.emit({ value: this.clamped, description: description || null });
+  }
+
+  cancel(): void {
+    this.close.emit();
+  }
+}

--- a/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-request.ts
+++ b/src/app/charactermanager/components/character-sheet/dm-edit-modal/dm-edit-request.ts
@@ -1,0 +1,19 @@
+import { PC } from '../../../models/pc';
+
+/**
+ * A DM's request to edit one numeric value on a character sheet, captured by
+ * an `app-editable-number` in intercept mode instead of opening its own
+ * inline editor. `label` matches the backend diff vocabulary in
+ * PcActivityLogService (e.g. 'AC', 'current HP', 'STR', 'gp', 'level') so the
+ * modal's auto-generated description reads the same as the server's own
+ * before/after diff. `apply` is a pure builder — spreads the current PC with
+ * the edited field set, mirroring the existing `set*`/`request*` mutators on
+ * each surface component.
+ */
+export interface DmEditRequest {
+  label: string;
+  value: number | null;
+  min: number | null;
+  max: number | null;
+  apply: (value: number) => PC;
+}

--- a/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.spec.ts
@@ -1,0 +1,46 @@
+import { EditableNumberComponent } from './editable-number.component';
+
+describe('EditableNumberComponent', () => {
+  let component: EditableNumberComponent;
+
+  beforeEach(() => {
+    component = new EditableNumberComponent();
+  });
+
+  it('start() does nothing when not editable, intercept or not', () => {
+    component.editable = false;
+    component.intercept = true;
+    const emitted = jasmine.createSpy('emitted');
+    component.editRequested.subscribe(emitted);
+
+    component.start();
+
+    expect(emitted).not.toHaveBeenCalled();
+    expect(component.editing).toBeFalse();
+  });
+
+  it('start() emits editRequested and skips the inline editor when intercept is true', () => {
+    component.editable = true;
+    component.intercept = true;
+    const emitted = jasmine.createSpy('emitted');
+    component.editRequested.subscribe(emitted);
+
+    component.start();
+
+    expect(emitted).toHaveBeenCalled();
+    expect(component.editing).toBeFalse();
+  });
+
+  it('start() opens the inline editor as before when intercept is false (default)', () => {
+    component.editable = true;
+    component.value = 15;
+    const emitted = jasmine.createSpy('emitted');
+    component.editRequested.subscribe(emitted);
+
+    component.start();
+
+    expect(emitted).not.toHaveBeenCalled();
+    expect(component.editing).toBeTrue();
+    expect(component.draft).toBe(15);
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.ts
+++ b/src/app/charactermanager/components/character-sheet/editable-number/editable-number.component.ts
@@ -27,8 +27,16 @@ export class EditableNumberComponent {
   @Input() max: number | null = null;
   /** Accessible label, also used for the click hint. */
   @Input() label = 'value';
+  /**
+   * Opt-in: when true (and editable), a click emits {@link editRequested}
+   * instead of opening the inline editor — the parent owns a richer edit
+   * surface (e.g. the DM edit modal) instead. Inert when editable is false,
+   * so player flows are completely untouched.
+   */
+  @Input() intercept = false;
 
   @Output() committed = new EventEmitter<number>();
+  @Output() editRequested = new EventEmitter<void>();
 
   @ViewChild('input') inputRef?: ElementRef<HTMLInputElement>;
 
@@ -37,6 +45,10 @@ export class EditableNumberComponent {
 
   start(): void {
     if (!this.editable) return;
+    if (this.intercept) {
+      this.editRequested.emit();
+      return;
+    }
     this.draft = this.value ?? 0;
     this.editing = true;
     // Input renders after this change-detection pass; focus + select on the next tick.

--- a/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.html
@@ -13,6 +13,7 @@
       <div class="ability-mod">{{ row.mod }}</div>
       <div class="ability-score"><app-editable-number
         [value]="row.score" [editable]="editable" [min]="1" [max]="30"
+        [intercept]="true" (editRequested)="requestScore(row.key, row.score)"
         [label]="row.label + ' score'" (committed)="setScore(row.key, $event)"
       >{{ row.score }}</app-editable-number></div>
     </div>

--- a/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.spec.ts
@@ -1,0 +1,39 @@
+import { AbilityScoresComponent } from './ability-scores.component';
+import { PC } from '../../../../models/pc';
+
+describe('AbilityScoresComponent', () => {
+  let component: AbilityScoresComponent;
+
+  const basePc = (): PC =>
+    ({ id: 1, name: 'X', clazz: 'Fighter', level: 4, playerName: 'P', stats: { STR: 16, DEX: 12, CON: 14, INT: 8, WIS: 10, CHA: 13 } } as PC);
+
+  beforeEach(() => {
+    component = new AbilityScoresComponent();
+    component.pc = basePc();
+    component.ngOnChanges();
+  });
+
+  describe('requestScore', () => {
+    it('label is the ability key itself (matches the backend diff vocabulary), min 1 max 30', () => {
+      const emitted = jasmine.createSpy('emitted');
+      component.editRequested.subscribe(emitted);
+
+      component.requestScore('STR', 16);
+
+      expect(emitted).toHaveBeenCalledWith(jasmine.objectContaining({ label: 'STR', value: 16, min: 1, max: 30 }));
+    });
+
+    it('apply is a pure builder for that ability', () => {
+      let captured: any;
+      component.editRequested.subscribe(r => (captured = r));
+
+      component.requestScore('STR', 16);
+      const result = captured.apply(18);
+
+      expect(result.stats.STR).toBe(18);
+      expect(component.pc.stats?.STR).toBe(16); // original untouched
+      // Other abilities preserved.
+      expect(result.stats.DEX).toBe(12);
+    });
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/ability-scores/ability-scores.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { PC } from '../../../../models/pc';
 import { modFromScore, fmtMod } from '../../../../utils/character-math';
+import { DmEditRequest } from '../../dm-edit-modal/dm-edit-request';
 
 interface AbilityRow {
   key: string;
@@ -21,6 +22,8 @@ export class AbilityScoresComponent implements OnChanges {
   /** DM cross-link: makes each ability score click-to-edit. */
   @Input() editable = false;
   @Output() pcChange = new EventEmitter<PC>();
+  /** A DM clicked an intercepted ability score — the parent opens the DM edit modal. */
+  @Output() editRequested = new EventEmitter<DmEditRequest>();
 
   rows: AbilityRow[] = [];
 
@@ -43,13 +46,31 @@ export class AbilityScoresComponent implements OnChanges {
     });
   }
 
-  /** Edit one ability score; the modifier display recomputes on the refresh. */
-  setScore(key: string, value: number): void {
+  /** Pure builder: apply one ability score. */
+  private buildScore(key: string, value: number): PC {
     const stats = {
       STR: 10, DEX: 10, CON: 10, INT: 10, WIS: 10, CHA: 10,
       ...(this.pc.stats ?? {}),
     } as NonNullable<PC['stats']>;
     stats[key as keyof typeof stats] = value;
-    this.pcChange.emit({ ...this.pc, stats });
+    return { ...this.pc, stats };
+  }
+
+  /** Edit one ability score; the modifier display recomputes on the refresh. */
+  setScore(key: string, value: number): void {
+    this.pcChange.emit(this.buildScore(key, value));
+  }
+
+  /** DM clicked (intercepted) an ability score — request the edit modal instead of
+   *  the inline editor. Label is the ability key itself (STR/DEX/…), matching the
+   *  backend's own diff vocabulary. */
+  requestScore(key: string, score: number): void {
+    this.editRequested.emit({
+      label: key,
+      value: score,
+      min: 1,
+      max: 30,
+      apply: v => this.buildScore(key, v),
+    });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.html
@@ -9,6 +9,7 @@
     <div *ngFor="let coin of coinTypes" class="coin {{ coin.key }}">
       <div class="coin-amt numeric"><app-editable-number
         [value]="coinAmt(coin.key)" [editable]="editable" [min]="0"
+        [intercept]="true" (editRequested)="requestCoin(coin.key)"
         [label]="coin.label + ' coins'" (committed)="setCoin(coin.key, $event)"
       >{{ coinAmt(coin.key) }}</app-editable-number></div>
       <div class="coin-name">{{ coin.label }}</div>

--- a/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.spec.ts
@@ -1,0 +1,44 @@
+import { CoinPurseComponent } from './coin-purse.component';
+import { PC } from '../../../../models/pc';
+
+describe('CoinPurseComponent', () => {
+  let component: CoinPurseComponent;
+
+  const basePc = (): PC =>
+    ({ id: 1, name: 'X', clazz: 'Fighter', level: 4, playerName: 'P', coins: { cp: 1, sp: 2, ep: 0, gp: 10, pp: 0 } } as PC);
+
+  beforeEach(() => {
+    component = new CoinPurseComponent();
+    component.pc = basePc();
+  });
+
+  describe('gpEquiv', () => {
+    it('converts every denomination to its gp value', () => {
+      expect(component.gpEquiv).toBe((1 / 100 + 2 / 10 + 0 / 2 + 10 + 0 * 10).toFixed(2));
+    });
+  });
+
+  describe('requestCoin', () => {
+    it('label is the denomination key itself, min 0, unbounded max', () => {
+      const emitted = jasmine.createSpy('emitted');
+      component.editRequested.subscribe(emitted);
+
+      component.requestCoin('gp');
+
+      expect(emitted).toHaveBeenCalledWith(jasmine.objectContaining({ label: 'gp', value: 10, min: 0, max: null }));
+    });
+
+    it('apply is a pure builder for that denomination', () => {
+      let captured: any;
+      component.editRequested.subscribe(r => (captured = r));
+
+      component.requestCoin('gp');
+      const result = captured.apply(25);
+
+      expect(result.coins.gp).toBe(25);
+      expect(component.pc.coins?.gp).toBe(10); // original untouched
+      // Other denominations preserved.
+      expect(result.coins.sp).toBe(2);
+    });
+  });
+});

--- a/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/coin-purse/coin-purse.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PC } from '../../../../models/pc';
+import { DmEditRequest } from '../../dm-edit-modal/dm-edit-request';
 
 @Component({
   selector: 'app-coin-purse',
@@ -11,6 +12,8 @@ export class CoinPurseComponent {
   /** DM cross-link: makes each coin amount click-to-edit. */
   @Input() editable = false;
   @Output() pcChange = new EventEmitter<PC>();
+  /** A DM clicked an intercepted coin amount — the parent opens the DM edit modal. */
+  @Output() editRequested = new EventEmitter<DmEditRequest>();
 
   readonly coinTypes = [
     { key: 'cp', label: 'Copper' },
@@ -30,10 +33,28 @@ export class CoinPurseComponent {
     return (this.pc.coins as any)?.[key] ?? 0;
   }
 
-  /** Edit one coin denomination; the gp-equivalent recomputes on the refresh. */
-  setCoin(key: string, value: number): void {
+  /** Pure builder: apply one coin denomination. */
+  private buildCoin(key: string, value: number): PC {
     const coins = { cp: 0, sp: 0, ep: 0, gp: 0, pp: 0, ...(this.pc.coins ?? {}) };
     (coins as any)[key] = value;
-    this.pcChange.emit({ ...this.pc, coins });
+    return { ...this.pc, coins };
+  }
+
+  /** Edit one coin denomination; the gp-equivalent recomputes on the refresh. */
+  setCoin(key: string, value: number): void {
+    this.pcChange.emit(this.buildCoin(key, value));
+  }
+
+  /** DM clicked (intercepted) a coin amount — request the edit modal instead of the inline editor.
+   *  Label is the denomination key itself (cp/sp/ep/gp/pp) — the backend's own diff only ever
+   *  summarizes the whole purse ("DM changed coins X → Y"), never a single denomination. */
+  requestCoin(key: string): void {
+    this.editRequested.emit({
+      label: key,
+      value: this.coinAmt(key),
+      min: 0,
+      max: null,
+      apply: v => this.buildCoin(key, v),
+    });
   }
 }

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.html
@@ -6,13 +6,16 @@
     <div class="vital-value numeric">
       <app-editable-number
         [value]="pc.hp?.cur" [editable]="editable" [min]="0" [max]="pc.hp?.max ?? null"
+        [intercept]="true" (editRequested)="requestHp('cur')"
         label="current HP" (committed)="setHp('cur', $event)"
       >{{ pc.hp?.cur }}</app-editable-number><span class="sub">/<app-editable-number
         [value]="pc.hp?.max" [editable]="editable" [min]="0"
+        [intercept]="true" (editRequested)="requestHp('max')"
         label="max HP" (committed)="setHp('max', $event)"
       >{{ pc.hp?.max }}</app-editable-number></span>
       <span *ngIf="editable || (pc.hp?.temp && pc.hp!.temp > 0)" class="sub" style="color: var(--celestial)"> +<app-editable-number
         [value]="pc.hp?.temp" [editable]="editable" [min]="0"
+        [intercept]="true" (editRequested)="requestHp('temp')"
         label="temporary HP" (committed)="setHp('temp', $event)"
       >{{ pc.hp?.temp ?? 0 }}</app-editable-number></span>
     </div>
@@ -24,6 +27,7 @@
     <span class="eyebrow">Armor Class</span>
     <div class="vital-value numeric"><app-editable-number
       [value]="pc.ac" [editable]="editable" [min]="0"
+      [intercept]="true" (editRequested)="requestVital('ac')"
       label="armor class" (committed)="setVital('ac', $event)"
     >{{ pc.ac ?? '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">{{ armorLabel }}</div>
@@ -34,6 +38,7 @@
     <span class="eyebrow">Initiative</span>
     <div class="vital-value numeric"><app-editable-number
       [value]="pc.init" [editable]="editable" [min]="null"
+      [intercept]="true" (editRequested)="requestVital('init')"
       label="initiative" (committed)="setVital('init', $event)"
     >{{ pc.init != null ? fmtMod(pc.init) : '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">d20 + mod</div>
@@ -44,6 +49,7 @@
     <span class="eyebrow">Speed</span>
     <div class="vital-value numeric"><app-editable-number
       [value]="pc.speed" [editable]="editable" [min]="0"
+      [intercept]="true" (editRequested)="requestVital('speed')"
       label="speed" (committed)="setVital('speed', $event)"
     >{{ pc.speed ?? '—' }}</app-editable-number><span class="sub" *ngIf="pc.speed">ft</span></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">per round</div>
@@ -54,6 +60,7 @@
     <span class="eyebrow">Proficiency</span>
     <div class="vital-value numeric">+<app-editable-number
       [value]="pc.prof" [editable]="editable" [min]="0"
+      [intercept]="true" (editRequested)="requestVital('prof')"
       label="proficiency bonus" (committed)="setVital('prof', $event)"
     >{{ pc.prof ?? '—' }}</app-editable-number></div>
     <div style="font-size: 11px; color: var(--text-dim); font-style: italic; margin-top: 8px;">level {{ pc.level }}</div>

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.spec.ts
@@ -29,4 +29,69 @@ describe('VitalsStripComponent', () => {
       expect(component.armorLabel).toBe('unarmored');
     });
   });
+
+  // --- DM edit modal requests ---
+
+  describe('requestHp', () => {
+    beforeEach(() => {
+      component.pc = { ...basePc(), hp: { cur: 12, max: 20, temp: 3 } };
+    });
+
+    it('current HP: label, value, min 0, max = hp.max', () => {
+      const req = captureRequest(() => component.requestHp('cur'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'current HP', value: 12, min: 0, max: 20 }));
+    });
+
+    it('max HP: min 0, unbounded max', () => {
+      const req = captureRequest(() => component.requestHp('max'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'max HP', value: 20, min: 0, max: null }));
+    });
+
+    it('temporary HP: min 0, unbounded max', () => {
+      const req = captureRequest(() => component.requestHp('temp'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'temporary HP', value: 3, min: 0, max: null }));
+    });
+
+    it('apply is a pure builder that clamps current within [0, max]', () => {
+      const req = captureRequest(() => component.requestHp('cur'));
+      const result = req.apply(25); // over max
+      expect(result.hp?.cur).toBe(20);
+      expect(component.pc.hp?.cur).toBe(12); // original untouched
+    });
+  });
+
+  describe('requestVital', () => {
+    beforeEach(() => {
+      component.pc = { ...basePc(), ac: 15, init: 2, speed: 30, prof: 3 };
+    });
+
+    it('AC: label matches the backend diff vocabulary, min 0', () => {
+      const req = captureRequest(() => component.requestVital('ac'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'AC', value: 15, min: 0, max: null }));
+    });
+
+    it('initiative: unbounded (min null)', () => {
+      const req = captureRequest(() => component.requestVital('init'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'initiative', value: 2, min: null, max: null }));
+    });
+
+    it('speed: min 0', () => {
+      const req = captureRequest(() => component.requestVital('speed'));
+      expect(req).toEqual(jasmine.objectContaining({ label: 'speed', min: 0 }));
+    });
+
+    it('apply is a pure builder', () => {
+      const req = captureRequest(() => component.requestVital('ac'));
+      const result = req.apply(18);
+      expect(result.ac).toBe(18);
+      expect(component.pc.ac).toBe(15); // original untouched
+    });
+  });
+
+  function captureRequest(trigger: () => void) {
+    let captured: any;
+    component.editRequested.subscribe((r: any) => (captured = r));
+    trigger();
+    return captured;
+  }
 });

--- a/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
+++ b/src/app/charactermanager/components/character-sheet/vitals-strip/vitals-strip.component.ts
@@ -1,6 +1,17 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { PC } from '../../../models/pc';
 import { hitDieFor, fmtMod } from '../../../utils/character-math';
+import { DmEditRequest } from '../dm-edit-modal/dm-edit-request';
+
+// 'AC' matches the backend's own diff vocabulary (PcActivityLogService.buildDmDiff);
+// initiative/speed/proficiency bonus aren't in that diff at all (DM edits to them
+// aren't auto-summarized server-side), so their labels are free text for the modal.
+const VITAL_LABELS: Record<'ac' | 'init' | 'speed' | 'prof', string> = {
+  ac: 'AC',
+  init: 'initiative',
+  speed: 'speed',
+  prof: 'proficiency bonus',
+};
 
 @Component({
   selector: 'app-vitals-strip',
@@ -13,6 +24,8 @@ export class VitalsStripComponent {
   @Input() editable = false;
   /** Emits the full updated PC for the parent to persist. */
   @Output() pcChange = new EventEmitter<PC>();
+  /** A DM clicked an intercepted vital — the parent opens the DM edit modal. */
+  @Output() editRequested = new EventEmitter<DmEditRequest>();
 
   get hpPct(): number {
     if (!this.pc.hp) return 0;
@@ -32,18 +45,47 @@ export class VitalsStripComponent {
 
   fmtMod(n: number): string { return fmtMod(n); }
 
-  /** Edit one of the HP fields, keeping current within [0, max]. */
-  setHp(field: 'cur' | 'max' | 'temp', value: number): void {
+  /** Pure builder: apply one HP field, keeping current within [0, max]. */
+  private buildHp(field: 'cur' | 'max' | 'temp', value: number): PC {
     const hp = { cur: 0, max: 0, temp: 0, ...(this.pc.hp ?? {}) };
     hp[field] = value;
     if (field === 'max' || field === 'cur') {
       hp.cur = Math.max(0, Math.min(hp.cur, hp.max));
     }
-    this.pcChange.emit({ ...this.pc, hp });
+    return { ...this.pc, hp };
+  }
+
+  /** Pure builder: apply a flat numeric vital (AC, initiative, speed, proficiency bonus). */
+  private buildVital(field: 'ac' | 'init' | 'speed' | 'prof', value: number): PC {
+    return { ...this.pc, [field]: value };
+  }
+
+  /** Edit one of the HP fields, keeping current within [0, max]. */
+  setHp(field: 'cur' | 'max' | 'temp', value: number): void {
+    this.pcChange.emit(this.buildHp(field, value));
   }
 
   /** Edit a flat numeric vital (AC, initiative, speed, proficiency bonus). */
   setVital(field: 'ac' | 'init' | 'speed' | 'prof', value: number): void {
-    this.pcChange.emit({ ...this.pc, [field]: value });
+    this.pcChange.emit(this.buildVital(field, value));
+  }
+
+  /** DM clicked (intercepted) an HP field — request the edit modal instead of the inline editor. */
+  requestHp(field: 'cur' | 'max' | 'temp'): void {
+    const label = field === 'cur' ? 'current HP' : field === 'max' ? 'max HP' : 'temporary HP';
+    const value = field === 'cur' ? this.pc.hp?.cur ?? 0
+      : field === 'max' ? this.pc.hp?.max ?? 0
+      : this.pc.hp?.temp ?? 0;
+    const min = 0;
+    const max = field === 'cur' ? this.pc.hp?.max ?? null : null;
+    this.editRequested.emit({ label, value, min, max, apply: v => this.buildHp(field, v) });
+  }
+
+  /** DM clicked (intercepted) a flat vital — request the edit modal instead of the inline editor. */
+  requestVital(field: 'ac' | 'init' | 'speed' | 'prof'): void {
+    const label = VITAL_LABELS[field];
+    const value = (this.pc[field] as number | undefined) ?? null;
+    const min = field === 'init' ? null : 0;
+    this.editRequested.emit({ label, value, min, max: null, apply: v => this.buildVital(field, v) });
   }
 }

--- a/src/app/charactermanager/services/pc.service.ts
+++ b/src/app/charactermanager/services/pc.service.ts
@@ -212,13 +212,28 @@ export class PCService {
   /**
    * Persist a DM's edit of a campaign member's PC. Same optimistic local mirror
    * as {@link updatePC}, but hits the DM-authorized backend path (authorized by
-   * campaign-DM ownership, not PC ownership). Demo mode behaves like updatePC.
+   * campaign-DM ownership, not PC ownership). `description`, when given, is a
+   * DM-authored log line that replaces the backend's automatic before/after
+   * diff (see PcActivityLogService#logDmEdit on the backend) — omitted or blank
+   * falls back to the auto-diff, which is what GrantService wants. Demo mode has
+   * no backend diff to fall back to, so it mirrors a DM_EDIT entry into the demo
+   * log itself when a description is given, then behaves like updatePC.
    */
-  updatePCAsDm(pc: PC): Observable<PC> {
+  updatePCAsDm(pc: PC, description: string | null = null): Observable<PC> {
     if (environment.demoMode) {
+      const trimmed = description?.trim();
+      if (trimmed) {
+        const entry: PcActivityLogEntry = {
+          id: 'demo-dmedit-' + Date.now(), pcId: pc.id, actionType: 'DM_EDIT',
+          description: trimmed, createdAt: new Date().toISOString(),
+        };
+        this.demoLog[pc.id] = [entry, ...(this.demoLog[pc.id] ?? [])].slice(0, 10);
+      }
       return this.updatePC(pc);
     }
-    return this.http.put<PC>(`${this.pcUrl}${pc.id}/as-dm`, this.serializePC(pc)).pipe(
+    return this.http.put<PC>(`${this.pcUrl}${pc.id}/as-dm`,
+      { pc: this.serializePC(pc), description: description?.trim() || null }
+    ).pipe(
       map(raw => this.deserializePC(raw)),
       tap(updated => {
         this.pcs = this.pcs.map(p => p.id === updated.id ? updated : p);


### PR DESCRIPTION
In DM cross-link mode, clicking an editable value (level, HP/AC/init/ speed/prof, ability scores, coin purse) now opens a modal instead of the inline editor: value + a live-updating auto description ("DM changed AC 15 -> 16") prefilled, hand-editing the description pins it, clearing it re-arms the auto-fill, and a blank save sends null so the backend falls back to its own diff. app-editable-number gains an opt-in `intercept` input + `editRequested` output, inert when editable=false — player self-edit flows are completely untouched (regression-guarded in character-sheet.component.spec.ts).

pc.service.ts's updatePCAsDm(pc, description = null) now sends the { pc, description } wrapper body the backend expects; demo mode mirrors a DM_EDIT entry into the local activity log when a description is given. GrantService needed no change — its one-arg call keeps the default null, i.e. the existing auto-diff grants rely on.

Breaking API change on the shared as-dm PUT contract: this frontend must deploy together with the character-manager-service change on this same branch name, since the backend now rejects the old bare-PC body.