### PR TITLE
feat: campaign week definition UI, weekday dropdown and week field

### DIFF
--- a/src/app/charactermanager/charactermanager.module.ts
+++ b/src/app/charactermanager/charactermanager.module.ts
@@ -46,6 +46,8 @@ import { CampaignDashboardComponent } from './components/campaign-dashboard/camp
 import { PartyBoardComponent } from './components/campaign-dashboard/party-board/party-board.component';
 import { PartyTreasuryComponent } from './components/campaign-dashboard/party-treasury/party-treasury.component';
 import { CampaignNotesComponent } from './components/campaign-dashboard/campaign-notes/campaign-notes.component';
+import { CampaignWeekComponent } from './components/campaign-dashboard/campaign-week/campaign-week.component';
+import { WeekDaysEditorComponent } from './components/week-days-editor/week-days-editor.component';
 import { CuratedShopsComponent } from './components/campaign-dashboard/curated-shops/curated-shops.component';
 import { CuratedEncountersComponent } from './components/campaign-dashboard/curated-encounters/curated-encounters.component';
 import { CreateCampaignModalComponent } from './components/create-campaign-modal/create-campaign-modal.component';
@@ -123,6 +125,8 @@ const routes: Routes = [
     PartyBoardComponent,
     PartyTreasuryComponent,
     CampaignNotesComponent,
+    CampaignWeekComponent,
+    WeekDaysEditorComponent,
     CuratedShopsComponent,
     CuratedEncountersComponent,
     CreateCampaignModalComponent,

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-dashboard.component.html
@@ -81,6 +81,8 @@
 
     <app-campaign-notes [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-campaign-notes>
 
+    <app-campaign-week [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-campaign-week>
+
     <app-curated-shops [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-curated-shops>
 
     <app-curated-encounters [campaign]="vm.campaign" style="display: block; margin-top: 20px;"></app-curated-encounters>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.html
@@ -1,0 +1,23 @@
+<div class="panel">
+  <div class="panel-header">
+    <span class="panel-title">Campaign Week</span>
+    <span style="font-family: 'Newsreader', serif; font-style: italic; font-size: 13px; color: var(--text-dim);">
+      {{ summary }}
+    </span>
+  </div>
+
+  <div *ngIf="!editing">
+    <button class="btn" (click)="edit()">Edit</button>
+  </div>
+
+  <div *ngIf="editing" style="margin-top: 10px;">
+    <app-week-days-editor [value]="draft" (valueChange)="draft = $event"></app-week-days-editor>
+    <div class="modal-sub" style="margin-top: 8px;">
+      Changing the week does not rename the current weekday — set it from Session Mode if needed.
+    </div>
+    <div style="display: flex; gap: 6px; margin-top: 10px;">
+      <button class="btn primary" [disabled]="saving" (click)="save()">Save</button>
+      <button class="btn" (click)="cancel()">Cancel</button>
+    </div>
+  </div>
+</div>

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.spec.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.spec.ts
@@ -1,0 +1,56 @@
+import { of, throwError } from 'rxjs';
+import { CampaignWeekComponent } from './campaign-week.component';
+import { Campaign } from '../../../models/campaign';
+
+/** Tests the component class directly (no TestBed/DOM), per the app convention. */
+describe('CampaignWeekComponent', () => {
+  let component: CampaignWeekComponent;
+  let service: any;
+
+  const campaign = (weekDays: string[] | null = null): Campaign =>
+    ({ id: '1', name: 'The Veiled Compass', weekDays } as unknown as Campaign);
+
+  beforeEach(() => {
+    service = jasmine.createSpyObj('CampaignService', ['setWeekDays']);
+    component = new CampaignWeekComponent(service);
+    component.campaign = campaign();
+  });
+
+  it('summarizes the definition, or the free-text fallback when undefined', () => {
+    expect(component.summary).toBe('Free-text weekdays — repetition counts weeks');
+    component.campaign = campaign(['Sul', 'Mol']);
+    expect(component.summary).toBe('Sul · Mol');
+  });
+
+  it('edit seeds the draft from the campaign; save persists it and closes', () => {
+    component.campaign = campaign(['Sul', 'Mol']);
+    component.edit();
+    expect(component.draft).toEqual(['Sul', 'Mol']);
+
+    component.draft = ['Sul', 'Mol', 'Zol'];
+    service.setWeekDays.and.returnValue(of(campaign(['Sul', 'Mol', 'Zol'])));
+    component.save();
+    expect(service.setWeekDays).toHaveBeenCalledWith('1', ['Sul', 'Mol', 'Zol']);
+    expect(component.editing).toBeFalse();
+    expect(component.saving).toBeFalse();
+  });
+
+  it('save keeps the editor open on an error so the DM can retry', () => {
+    component.edit();
+    component.draft = ['Sul', 'Mol'];
+    service.setWeekDays.and.returnValue(throwError(() => new Error('boom')));
+    component.save();
+    expect(component.editing).toBeTrue();
+    expect(component.saving).toBeFalse();
+  });
+
+  it('cancel closes without saving; a campaign switch resets the editor', () => {
+    component.edit();
+    component.cancel();
+    expect(service.setWeekDays).not.toHaveBeenCalled();
+
+    component.edit();
+    component.ngOnChanges({ campaign: {} as never });
+    expect(component.editing).toBeFalse();
+  });
+});

--- a/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/campaign-week/campaign-week.component.ts
@@ -1,0 +1,58 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Campaign } from '../../../models/campaign';
+import { CampaignService } from '../../../services/campaign.service';
+
+/**
+ * Campaign Week panel on the DM dashboard — shows the campaign's defined week
+ * (the ordered weekday names the clock walks each new day) and lets the DM edit
+ * or clear it after creation via the week-days editor. Without a definition the
+ * clock keeps its free-text weekday whose repetition counts weeks.
+ */
+@Component({
+  selector: 'app-campaign-week',
+  templateUrl: './campaign-week.component.html',
+})
+export class CampaignWeekComponent implements OnChanges {
+  @Input() campaign!: Campaign;
+
+  editing = false;
+  draft: string[] | null = null;
+  saving = false;
+
+  constructor(private campaignService: CampaignService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['campaign']) this.editing = false;
+  }
+
+  /** "Sul · Mol · …" or the free-text fallback description. */
+  get summary(): string {
+    return this.campaign?.weekDays?.length
+      ? this.campaign.weekDays.join(' · ')
+      : 'Free-text weekdays — repetition counts weeks';
+  }
+
+  edit(): void {
+    this.draft = this.campaign.weekDays?.length ? [...this.campaign.weekDays] : null;
+    this.editing = true;
+  }
+
+  cancel(): void {
+    this.editing = false;
+  }
+
+  save(): void {
+    if (this.saving) return;
+    this.saving = true;
+    this.campaignService.setWeekDays(this.campaign.id, this.draft).subscribe({
+      next: () => {
+        this.saving = false;
+        this.editing = false;
+      },
+      error: err => {
+        console.error('Failed to save the week definition', err);
+        this.saving = false; // keep the editor open so the DM can retry
+      },
+    });
+  }
+}

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.html
@@ -56,12 +56,26 @@
   </div>
 
   <div class="field">
+    <label>Days of the week (optional)</label>
+    <app-week-days-editor [value]="weekDays" (valueChange)="onWeekDaysChange($event)"></app-week-days-editor>
+    <div class="modal-sub" style="margin-top: 4px;">
+      Pick a preset or enter custom day names. With a defined week the clock auto-advances the
+      weekday each new day and counts weeks when it wraps. Editable later from the dashboard.
+    </div>
+  </div>
+
+  <div class="field">
     <label>In-world start date (optional)</label>
     <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;">
       <input [(ngModel)]="startDay" autocomplete="off" placeholder="Day · e.g. 3rd" maxlength="40">
       <input [(ngModel)]="startMonth" autocomplete="off" placeholder="Month · e.g. Hammer" maxlength="40">
       <input [(ngModel)]="startYear" autocomplete="off" placeholder="Year · e.g. 1492 DR" maxlength="40">
-      <input [(ngModel)]="startWeekday" autocomplete="off" placeholder="Weekday" maxlength="40">
+      <input *ngIf="!weekDays?.length"
+             [(ngModel)]="startWeekday" autocomplete="off" placeholder="Weekday" maxlength="40">
+      <select *ngIf="weekDays?.length" [(ngModel)]="startWeekday" aria-label="Weekday">
+        <option value="">Weekday…</option>
+        <option *ngFor="let d of weekDays" [value]="d">{{ d }}</option>
+      </select>
     </div>
     <div class="modal-sub" style="margin-top: 4px;">
       Free text — any calendar works. The clock starts at morning of this day; the DM advances time

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.spec.ts
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.spec.ts
@@ -1,0 +1,46 @@
+import { CreateCampaignModalComponent } from './create-campaign-modal.component';
+import { CampaignDraft } from '../../models/campaign';
+
+/** Tests the component class directly (no TestBed/DOM), per the app convention. */
+describe('CreateCampaignModalComponent', () => {
+  let component: CreateCampaignModalComponent;
+  let emitted: CampaignDraft[];
+
+  beforeEach(() => {
+    component = new CreateCampaignModalComponent();
+    emitted = [];
+    component.confirm.subscribe(d => emitted.push(d));
+  });
+
+  it('submit includes the defined week (null when none was picked)', () => {
+    component.name = 'Eberron Table';
+    component.submit();
+    expect(emitted[0].weekDays).toBeNull();
+
+    component.weekDays = ['Sul', 'Mol', 'Zol'];
+    component.submit();
+    expect(emitted[1].weekDays).toEqual(['Sul', 'Mol', 'Zol']);
+  });
+
+  it('a start weekday outside a newly picked definition is cleared', () => {
+    component.startWeekday = 'Far';
+    component.onWeekDaysChange(['Sul', 'Mol', 'Zol']);
+    expect(component.startWeekday).toBe(''); // no longer a defined day — dropped
+
+    component.startWeekday = 'mol';
+    component.onWeekDaysChange(['Sul', 'Mol']);
+    expect(component.startWeekday).toBe('mol'); // still defined (case-insensitive) — kept
+  });
+
+  it('the start date still seeds the clock with the selected weekday', () => {
+    component.name = 'Timed Table';
+    component.weekDays = ['Sul', 'Mol'];
+    component.startDay = '3rd';
+    component.startWeekday = 'Sul';
+    component.submit();
+    expect(emitted[0].gameTime).toEqual({
+      year: '1', month: '1', day: '3rd', timeOfDay: 'morning',
+      weekday: 'Sul', weekdaysSeen: ['Sul'], week: 1,
+    });
+  });
+});

--- a/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
+++ b/src/app/charactermanager/components/create-campaign-modal/create-campaign-modal.component.ts
@@ -14,9 +14,14 @@ export class CreateCampaignModalComponent {
   survivalConditions = false;
   strictComponents = false;
 
+  // Optional defined week — an ordered list of weekday names (preset or
+  // custom). Null keeps free-text weekdays; editable later on the dashboard.
+  weekDays: string[] | null = null;
+
   // Optional in-world start date — free-text labels for any homebrew calendar
   // ("1492 DR" / "Hammer" / "3rd"). The clock starts at morning of that day.
-  // Any part filled counts as "set"; empty parts default to "1".
+  // Any part filled counts as "set"; empty parts default to "1". With a
+  // defined week the weekday becomes a select constrained to the defined days.
   startYear = '';
   startMonth = '';
   startDay = '';
@@ -39,10 +44,19 @@ export class CreateCampaignModalComponent {
         strictComponents: this.strictComponents,
       },
       gameTime: this.draftGameTime(),
+      weekDays: this.weekDays,
     });
   }
 
   cancel(): void { this.close.emit(); }
+
+  /** A new definition may orphan a weekday typed before it — clear the stale pick. */
+  onWeekDaysChange(days: string[] | null): void {
+    this.weekDays = days;
+    if (days?.length && !days.some(d => d.toLowerCase() === this.startWeekday.trim().toLowerCase())) {
+      this.startWeekday = '';
+    }
+  }
 
   private draftGameTime(): CampaignGameTime | undefined {
     const year = this.startYear.trim();

--- a/src/app/charactermanager/components/session-mode/session-mode.component.html
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.html
@@ -122,12 +122,24 @@
         </button>
       </div>
       <div *ngIf="state.dm && editingTime"
-           style="display: grid; grid-template-columns: repeat(5, 1fr) auto; gap: 8px; margin-top: 10px; align-items: center;">
+           style="display: grid; gap: 8px; margin-top: 10px; align-items: center;"
+           [style.grid-template-columns]="state.weekDays?.length ? 'repeat(6, 1fr) auto' : 'repeat(5, 1fr) auto'">
         <input [(ngModel)]="timeDay" placeholder="Day · e.g. 3rd" maxlength="40" aria-label="Day">
         <input [(ngModel)]="timeMonth" placeholder="Month · e.g. Hammer" maxlength="40" aria-label="Month">
         <input [(ngModel)]="timeYear" placeholder="Year · e.g. 1492 DR" maxlength="40" aria-label="Year">
-        <input [(ngModel)]="timeWeekday" placeholder="Weekday" maxlength="40" aria-label="Weekday"
+        <input *ngIf="!state.weekDays?.length"
+               [(ngModel)]="timeWeekday" placeholder="Weekday" maxlength="40" aria-label="Weekday"
                title="Free text. Re-entering a weekday you have used before marks a completed week.">
+        <!-- The empty option keeps an out-of-list current weekday (definition
+             edited mid-campaign) from being silently coerced to a defined day. -->
+        <select *ngIf="state.weekDays?.length" [(ngModel)]="timeWeekday" aria-label="Weekday"
+                title="One of the campaign's defined days. Advancing past night walks it automatically.">
+          <option value="">Weekday…</option>
+          <option *ngFor="let d of state.weekDays" [value]="d">{{ d }}</option>
+        </select>
+        <input *ngIf="state.weekDays?.length" type="number" min="1"
+               [(ngModel)]="timeWeek" placeholder="Week" aria-label="Week"
+               title="The week counter. Wrapping past the last defined day bumps it automatically.">
         <select [(ngModel)]="timeSegment" aria-label="Time of day" style="text-transform: capitalize;">
           <option *ngFor="let s of timeSegments" [value]="s">{{ s }}</option>
         </select>

--- a/src/app/charactermanager/components/session-mode/session-mode.component.ts
+++ b/src/app/charactermanager/components/session-mode/session-mode.component.ts
@@ -46,12 +46,15 @@ export class SessionModeComponent implements OnInit, OnDestroy {
   strictComponents = false;
 
   // DM's set-the-date form (collapsed by default under the clock bar; opens
-  // automatically when night rolls into a new morning). Free-text labels.
+  // automatically when night rolls into a new morning). Free-text labels;
+  // with a defined week the weekday becomes a select and a week number field
+  // appears (the counter never moves on its own from this form).
   editingTime = false;
   timeYear = '';
   timeMonth = '';
   timeDay = '';
   timeWeekday = '';
+  timeWeek: number | null = null;
   timeSegment: TimeOfDay = 'morning';
   readonly timeSegments: TimeOfDay[] = ['morning', 'noon', 'night'];
 
@@ -181,6 +184,7 @@ export class SessionModeComponent implements OnInit, OnDestroy {
     this.timeMonth = t?.month ?? '';
     this.timeDay = t?.day ?? '';
     this.timeWeekday = t?.weekday ?? '';
+    this.timeWeek = state.weekDays?.length ? t?.week ?? 1 : null;
     this.timeSegment = t?.timeOfDay ?? 'morning';
     this.editingTime = true;
   }
@@ -192,6 +196,9 @@ export class SessionModeComponent implements OnInit, OnDestroy {
       day: this.timeDay.trim(),
       timeOfDay: this.timeSegment,
       weekday: this.timeWeekday.trim() || null,
+      // The week field applies only with a defined week — the server ignores
+      // it otherwise, so don't send one.
+      ...(state.weekDays?.length ? { week: this.timeWeek } : {}),
     }).subscribe({
       next: () => { this.editingTime = false; },
       error: () => this.notifications.notify('Could not set the date.'),

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.spec.ts
@@ -36,7 +36,7 @@ describe('ShopPanelComponent', () => {
       sessionId: 1, campaignId: 1, status: 'ACTIVE', round: 1, activeParticipantId: null,
       onDeckParticipantId: null, version: 1, dm: false, enemiesHidden: true, turnSound: null,
       shopOpen: false, shopForMe: false, shopCategory: null,
-      myXp: null, gameTime: null, location: null, participants: [], ...over,
+      myXp: null, gameTime: null, location: null, weekDays: null, participants: [], ...over,
     };
   }
 

--- a/src/app/charactermanager/components/week-days-editor/week-days-editor.component.html
+++ b/src/app/charactermanager/components/week-days-editor/week-days-editor.component.html
@@ -1,0 +1,15 @@
+<select [ngModel]="choice" (ngModelChange)="onChoice($event)" aria-label="Week definition">
+  <option value="">No defined week (free text)</option>
+  <option *ngFor="let p of presets" [value]="p.key">{{ p.label }}</option>
+  <option value="custom">Custom…</option>
+</select>
+
+<input *ngIf="choice === 'custom'"
+       [ngModel]="customText" (ngModelChange)="onCustomText($event)"
+       autocomplete="off" placeholder="e.g. Sul, Mol, Zol, …"
+       aria-label="Custom weekday names, comma-separated"
+       style="margin-top: 8px;">
+
+<div *ngIf="preview?.length" class="modal-sub" style="margin-top: 4px;">
+  {{ preview!.join(' · ') }}
+</div>

--- a/src/app/charactermanager/components/week-days-editor/week-days-editor.component.spec.ts
+++ b/src/app/charactermanager/components/week-days-editor/week-days-editor.component.spec.ts
@@ -1,0 +1,52 @@
+import { WeekDaysEditorComponent } from './week-days-editor.component';
+import { WEEKDAY_PRESETS } from '../../models/campaign';
+
+/** Tests the component class directly (no TestBed/DOM), per the app convention. */
+describe('WeekDaysEditorComponent', () => {
+  let component: WeekDaysEditorComponent;
+  let emitted: (string[] | null)[];
+
+  const eberron = WEEKDAY_PRESETS.find(p => p.key === 'eberron')!;
+
+  beforeEach(() => {
+    component = new WeekDaysEditorComponent();
+    emitted = [];
+    component.valueChange.subscribe(v => emitted.push(v));
+  });
+
+  it('emits a preset\'s ordered days when picked', () => {
+    component.onChoice('eberron');
+    expect(emitted).toEqual([['Sul', 'Mol', 'Zol', 'Wir', 'Zor', 'Far', 'Sar']]);
+    expect(component.preview).toEqual(eberron.days);
+  });
+
+  it('parses custom text — trimmed, blank-dropped, deduped case-insensitively, order kept', () => {
+    component.onChoice('custom');
+    component.onCustomText(' Sul , Mol,, sul , Zol ');
+    expect(emitted[emitted.length - 1]).toEqual(['Sul', 'Mol', 'Zol']);
+  });
+
+  it('emits null for "no defined week" and for empty custom text', () => {
+    component.onChoice('eberron');
+    component.onChoice('');
+    expect(emitted[emitted.length - 1]).toBeNull();
+    component.onChoice('custom');
+    component.onCustomText('  ,  ');
+    expect(emitted[emitted.length - 1]).toBeNull();
+  });
+
+  it('ngOnChanges detects a preset value vs a custom one', () => {
+    component.value = [...eberron.days];
+    component.ngOnChanges();
+    expect(component.choice).toBe('eberron');
+
+    component.value = ['Sul', 'Mol'];
+    component.ngOnChanges();
+    expect(component.choice).toBe('custom');
+    expect(component.customText).toBe('Sul, Mol');
+
+    component.value = null;
+    component.ngOnChanges();
+    expect(component.choice).toBe('');
+  });
+});

--- a/src/app/charactermanager/components/week-days-editor/week-days-editor.component.ts
+++ b/src/app/charactermanager/components/week-days-editor/week-days-editor.component.ts
@@ -1,0 +1,77 @@
+import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { WEEKDAY_PRESETS, WeekdayPreset } from '../../models/campaign';
+
+/**
+ * Shared editor for a campaign's defined week — an ordered list of weekday
+ * names, or null for "no defined week" (free-text weekdays, repetition counts
+ * weeks). A select offers the built-in presets plus a Custom… option that opens
+ * a comma-separated input; every change emits the trimmed, deduped ordered list
+ * (or null). Used by the create-campaign modal and the dashboard's week panel.
+ */
+@Component({
+  selector: 'app-week-days-editor',
+  templateUrl: './week-days-editor.component.html',
+})
+export class WeekDaysEditorComponent implements OnChanges {
+  @Input() value: string[] | null = null;
+  @Output() valueChange = new EventEmitter<string[] | null>();
+
+  readonly presets: WeekdayPreset[] = WEEKDAY_PRESETS;
+
+  /** '' = no defined week; a preset key; or 'custom'. */
+  choice = '';
+  customText = '';
+
+  ngOnChanges(): void {
+    if (!this.value?.length) {
+      this.choice = '';
+      this.customText = '';
+      return;
+    }
+    const preset = this.presets.find(p =>
+      p.days.length === this.value!.length &&
+      p.days.every((d, i) => d === this.value![i]));
+    this.choice = preset ? preset.key : 'custom';
+    this.customText = preset ? '' : this.value.join(', ');
+  }
+
+  onChoice(choice: string): void {
+    this.choice = choice;
+    if (choice === '') {
+      this.valueChange.emit(null);
+      return;
+    }
+    if (choice === 'custom') {
+      this.customText = this.value?.join(', ') ?? '';
+      this.valueChange.emit(this.parseCustom(this.customText));
+      return;
+    }
+    const preset = this.presets.find(p => p.key === choice);
+    this.valueChange.emit(preset ? [...preset.days] : null);
+  }
+
+  onCustomText(text: string): void {
+    this.customText = text;
+    this.valueChange.emit(this.parseCustom(text));
+  }
+
+  /** The days the current selection resolves to, for the "Sul · Mol · …" preview. */
+  get preview(): string[] | null {
+    if (this.choice === '') return null;
+    if (this.choice === 'custom') return this.parseCustom(this.customText);
+    return this.presets.find(p => p.key === this.choice)?.days ?? null;
+  }
+
+  /** Comma-separated names → trimmed, deduped (case-insensitive) ordered list, or null. */
+  private parseCustom(text: string): string[] | null {
+    const seen = new Set<string>();
+    const days: string[] = [];
+    for (const part of text.split(',')) {
+      const day = part.trim();
+      if (!day || seen.has(day.toLowerCase())) continue;
+      seen.add(day.toLowerCase());
+      days.push(day);
+    }
+    return days.length ? days : null;
+  }
+}

--- a/src/app/charactermanager/models/campaign.ts
+++ b/src/app/charactermanager/models/campaign.ts
@@ -19,7 +19,39 @@ export interface Campaign {
   variantRules?: CampaignVariantRules; // creation-time opt-ins, immutable
   gameTime?: CampaignGameTime | null;  // in-world clock; null until set
   location?: CampaignLocation | null;  // party's current place; null until set
+  weekDays?: string[] | null;          // ordered weekday names; null = free-text weekdays
 }
+
+/** A named, ordered week the DM can pick instead of typing custom day names. */
+export interface WeekdayPreset {
+  key: string;
+  label: string;
+  days: string[];
+}
+
+/**
+ * Built-in week templates for the create-campaign modal and the dashboard's
+ * week editor. The DM can also enter a fully custom ordered list.
+ */
+export const WEEKDAY_PRESETS: WeekdayPreset[] = [
+  {
+    key: 'real-world', label: 'Real-world (7 days)',
+    days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  },
+  {
+    key: 'forgotten-realms', label: 'Forgotten Realms tenday',
+    days: ['First-day', 'Second-day', 'Third-day', 'Fourth-day', 'Fifth-day',
+           'Sixth-day', 'Seventh-day', 'Eighth-day', 'Ninth-day', 'Tenth-day'],
+  },
+  {
+    key: 'eberron', label: 'Eberron (7 days)',
+    days: ['Sul', 'Mol', 'Zol', 'Wir', 'Zor', 'Far', 'Sar'],
+  },
+  {
+    key: 'exandria', label: 'Exandria (7 days)',
+    days: ['Miresen', 'Grissen', 'Whelsen', 'Conthsen', 'Folsen', 'Yulisen', "Da'leysen"],
+  },
+];
 
 /** The kinds of place the party can be — drives the type chip on the sheet. */
 export type LocationType = 'Settlement' | 'Wilderness' | 'Dungeon';
@@ -85,6 +117,7 @@ export interface CampaignDraft {
   tint: CampaignTint;
   variantRules: CampaignVariantRules;
   gameTime?: CampaignGameTime;  // optional in-world start date
+  weekDays?: string[] | null;   // optional defined week (editable later)
 }
 
 /** Dice & rolling preferences, persisted to localStorage under `tm_dice`. */

--- a/src/app/charactermanager/models/session.ts
+++ b/src/app/charactermanager/models/session.ts
@@ -96,5 +96,9 @@ export interface SessionState {
   // The party's current location (null until the DM sets it). Broadcast to
   // every viewer; only the DM can change it.
   location: CampaignLocation | null;
+  // The campaign's defined week — the ordered weekday names the clock walks on
+  // each night → morning rollover — or null when the DM never defined one
+  // (free-text weekdays, repetition counts weeks).
+  weekDays: string[] | null;
   participants: ParticipantView[];
 }

--- a/src/app/charactermanager/services/campaign.service.spec.ts
+++ b/src/app/charactermanager/services/campaign.service.spec.ts
@@ -11,7 +11,7 @@ describe('CampaignService', () => {
   let service: CampaignService;
 
   beforeEach(() => {
-    http = jasmine.createSpyObj<HttpClient>('HttpClient', ['get', 'post', 'delete']);
+    http = jasmine.createSpyObj<HttpClient>('HttpClient', ['get', 'post', 'put', 'delete']);
     pcService = jasmine.createSpyObj<PCService>(
       'PCService', ['deserialize', 'patchLocalPC', 'getPCById', 'updatePC']);
     http.get.and.returnValue(of([])); // constructor's refreshCampaigns()
@@ -125,6 +125,68 @@ describe('CampaignService', () => {
                     weekday: 'Sul', weekdaysSeen: ['Sul'], week: 3 };
         service.setLocalGameTime(9, t);
         expect(service.getLocalCampaign(9)?.gameTime).toEqual(t);
+        done();
+      });
+    });
+  });
+
+  describe('week definition (weekDays)', () => {
+    it('createCampaign sends weekDays as a JSON string (null when undefined) and parses it back', done => {
+      http.post.and.returnValue(of({
+        id: 9, name: 'Eberron Table', weekDays: '["Sul","Mol","Zol"]',
+      }));
+
+      service.createCampaign({
+        name: 'Eberron Table', setting: '', tint: 'celestial', variantRules: {},
+        weekDays: ['Sul', 'Mol', 'Zol'],
+      }).subscribe(campaign => {
+        const body = http.post.calls.mostRecent().args[1] as Record<string, unknown>;
+        expect(body['weekDays']).toBe('["Sul","Mol","Zol"]');
+        expect(campaign.weekDays).toEqual(['Sul', 'Mol', 'Zol']);
+        done();
+      });
+    });
+
+    it('createCampaign without a definition sends null; malformed columns parse to null', done => {
+      http.post.and.returnValue(of({ id: 9, name: 'Plain Table', weekDays: 'not json' }));
+
+      service.createCampaign({
+        name: 'Plain Table', setting: '', tint: 'celestial', variantRules: {},
+      }).subscribe(campaign => {
+        const body = http.post.calls.mostRecent().args[1] as Record<string, unknown>;
+        expect(body['weekDays']).toBeNull();
+        expect(campaign.weekDays).toBeNull();
+        done();
+      });
+    });
+
+    it('setWeekDays PUTs the list and patches the stored campaign copy', done => {
+      http.post.and.returnValue(of({ id: 9, name: 'Timed Table', weekDays: null }));
+      service.createCampaign({
+        name: 'Timed Table', setting: '', tint: 'celestial', variantRules: {},
+      }).subscribe(() => {
+        http.put.and.returnValue(of({
+          id: 9, name: 'Timed Table', weekDays: '["Sul","Mol"]',
+        }));
+
+        service.setWeekDays(9, ['Sul', 'Mol']).subscribe(campaign => {
+          expect(http.put).toHaveBeenCalledWith(
+            jasmine.stringMatching(/\/campaign\/9\/week-days$/),
+            { weekDays: ['Sul', 'Mol'] },
+          );
+          expect(campaign.weekDays).toEqual(['Sul', 'Mol']);
+          expect(service.getLocalCampaign(9)?.weekDays).toEqual(['Sul', 'Mol']);
+          done();
+        });
+      });
+    });
+
+    it('setWeekDays with null clears the definition (free-text weekdays resume)', done => {
+      http.put.and.returnValue(of({ id: 9, name: 'Timed Table', weekDays: null }));
+
+      service.setWeekDays(9, null).subscribe(campaign => {
+        expect(http.put).toHaveBeenCalledWith(jasmine.anything(), { weekDays: null });
+        expect(campaign.weekDays).toBeNull();
         done();
       });
     });

--- a/src/app/charactermanager/services/campaign.service.ts
+++ b/src/app/charactermanager/services/campaign.service.ts
@@ -248,6 +248,7 @@ export class CampaignService {
       threads: [],
       variantRules: draft.variantRules ?? {},
       gameTime: draft.gameTime ?? null,
+      weekDays: draft.weekDays ?? null,
     };
 
     if (environment.demoMode) {
@@ -285,6 +286,9 @@ export class CampaignService {
       gameTime: c.gameTime ? JSON.stringify(c.gameTime) : null,
       // null until the DM sets a party location in session.
       location: c.location ? JSON.stringify(c.location) : null,
+      // null (not '[]') when undefined — free-text weekdays until the DM
+      // defines an ordered week.
+      weekDays: c.weekDays?.length ? JSON.stringify(c.weekDays) : null,
     };
   }
 
@@ -307,6 +311,7 @@ export class CampaignService {
       variantRules: this.parseVariantRules(raw.variantRules),
       gameTime: this.parseGameTime(raw.gameTime),
       location: this.parseLocation(raw.location),
+      weekDays: this.parseWeekDays(raw.weekDays),
     };
   }
 
@@ -348,6 +353,41 @@ export class CampaignService {
     const { name, type } = obj as { name?: unknown; type?: unknown };
     if (typeof type !== 'string' || !LOCATION_TYPES.includes(type as CampaignLocation['type'])) return null;
     return { name: typeof name === 'string' ? name : '', type: type as CampaignLocation['type'] };
+  }
+
+  /** Tolerant read of a stored week definition (array passthrough for demo/
+   *  localStorage, JSON string for the backend TEXT column); null = free text. */
+  private parseWeekDays(value: unknown): string[] | null {
+    let arr = value;
+    if (typeof value === 'string') {
+      try { arr = JSON.parse(value); } catch { return null; }
+    }
+    if (!Array.isArray(arr) || !arr.length) return null;
+    return arr.every(d => typeof d === 'string') ? (arr as string[]) : null;
+  }
+
+  /**
+   * DM defines (or clears) the campaign's week: the ordered weekday names the
+   * clock walks on each night → morning rollover. Null clears the definition,
+   * returning the campaign to free-text weekdays. Patches the local campaign
+   * list so the dashboard and demo session pick the change up immediately.
+   */
+  setWeekDays(campaignId: string | number, days: string[] | null): Observable<Campaign> {
+    const key = String(campaignId);
+    const normalized = days?.length ? days : null;
+    if (environment.demoMode) {
+      const updated = this.campaignsSubject.getValue()
+        .map(c => (c.id === key ? { ...c, weekDays: normalized } : c));
+      this.persistDemo(updated);
+      const campaign = updated.find(c => c.id === key);
+      return campaign ? of(campaign).pipe(delay(50))
+        : throwError(() => new Error('Campaign not found'));
+    }
+    return this.http.put<unknown>(`${this.campaignUrl}/${key}/week-days`, { weekDays: normalized }).pipe(
+      map(raw => this.deserialize(raw)),
+      tap(campaign => this.campaignsSubject.next(
+        this.campaignsSubject.getValue().map(c => (c.id === key ? campaign : c)))),
+    );
   }
 
   /** Sync lookup of a campaign already in the local store (demo & session seams). */

--- a/src/app/charactermanager/services/session.service.ts
+++ b/src/app/charactermanager/services/session.service.ts
@@ -14,7 +14,7 @@ import {
   applySegmentToPc,
   initialGameTime,
   normalizeGameTime,
-  registerWeekday,
+  setGameTime,
 } from '../utils/survival';
 import { applyCastToPc } from '../utils/spellcasting';
 
@@ -353,10 +353,12 @@ export class SessionService {
   /**
    * DM sets the campaign clock directly — no condition bumps. Sends the free
    * text date labels + weekday; the server owns the week-counter logic (the
-   * demo branch mirrors it via registerWeekday).
+   * demo branch mirrors it via the shared setGameTime). `week` applies only to
+   * campaigns with a defined week — omit it otherwise.
    */
   setTime(sessionId: number | string,
-          time: { year: string; month: string; day: string; timeOfDay: TimeOfDay; weekday: string | null },
+          time: { year: string; month: string; day: string; timeOfDay: TimeOfDay;
+                  weekday: string | null; week?: number | null },
   ): Observable<SessionState> {
     if (environment.demoMode) return this.demoSetTime(time);
     return this.http.put<unknown>(`${this.sessionBase}/${sessionId}/time`, time).pipe(
@@ -684,7 +686,7 @@ export class SessionService {
     const state = this.stateSubject.getValue() ?? this.emptyState('demo-session');
     const campaign = this.campaignService.getLocalCampaign(state.campaignId);
     const current = state.gameTime ?? campaign?.gameTime ?? null;
-    const next = current ? advanceGameTime(current) : initialGameTime();
+    const next = current ? advanceGameTime(current, campaign?.weekDays) : initialGameTime();
     // First click establishes the clock — no bumps. Every segment bumps under
     // the three-segment mapping (morning +H/T, noon +F, night +all).
     const bumps = current != null && !!campaign?.variantRules?.survivalConditions;
@@ -721,18 +723,16 @@ export class SessionService {
   }
 
   private demoSetTime(
-    time: { year: string; month: string; day: string; timeOfDay: TimeOfDay; weekday: string | null },
+    time: { year: string; month: string; day: string; timeOfDay: TimeOfDay;
+            weekday: string | null; week?: number | null },
   ): Observable<SessionState> {
     const state = this.stateSubject.getValue() ?? this.emptyState('demo-session');
-    const current = state.gameTime
-      ?? this.campaignService.getLocalCampaign(state.campaignId)?.gameTime
-      ?? initialGameTime();
-    // Mirror the server: dates apply verbatim, the weekday history drives the
-    // week counter (registerWeekday guards unchanged-weekday corrections).
-    const next = registerWeekday(
-      { ...current, year: time.year, month: time.month, day: time.day, timeOfDay: time.timeOfDay },
-      time.weekday,
-    );
+    const campaign = this.campaignService.getLocalCampaign(state.campaignId);
+    const current = state.gameTime ?? campaign?.gameTime ?? initialGameTime();
+    // Mirror the server via the shared reducer: with a defined week the weekday
+    // is canonicalized and only an explicit week moves the counter; without one
+    // the weekday history drives it (unchanged-weekday corrections guarded).
+    const next = setGameTime(current, time, campaign?.weekDays);
     this.campaignService.setLocalGameTime(state.campaignId, next);
     return of(this.demoPatch({ gameTime: next }));
   }
@@ -777,6 +777,7 @@ export class SessionService {
       myXp: null,
       gameTime: this.campaignService.getLocalCampaign(campaignId)?.gameTime ?? null,
       location: this.campaignService.getLocalCampaign(campaignId)?.location ?? null,
+      weekDays: this.campaignService.getLocalCampaign(campaignId)?.weekDays ?? null,
       participants,
     };
   }
@@ -787,7 +788,7 @@ export class SessionService {
       activeParticipantId: null, onDeckParticipantId: null, version: 0, dm: true,
       enemiesHidden: true, turnSound: null,
       shopOpen: false, shopForMe: false, shopCategory: null, myXp: null,
-      gameTime: null, location: null, participants: [],
+      gameTime: null, location: null, weekDays: null, participants: [],
     };
   }
 
@@ -839,6 +840,7 @@ export class SessionService {
       myXp: raw.myXp ?? null,
       gameTime: normalizeGameTime(this.parseJsonObject<CampaignGameTime>(raw.gameTime)),
       location: this.parseLocation(this.parseJsonObject<CampaignLocation>(raw.location)),
+      weekDays: Array.isArray(raw.weekDays) && raw.weekDays.length ? raw.weekDays : null,
       participants: (raw.participants ?? []).map((p: any) => this.deserializeParticipant(p)),
     };
   }

--- a/src/app/charactermanager/utils/survival.spec.ts
+++ b/src/app/charactermanager/utils/survival.spec.ts
@@ -7,6 +7,7 @@ import {
   initialGameTime,
   normalizeGameTime,
   registerWeekday,
+  setGameTime,
   SURVIVAL_LABELS,
   survivalExhaustion,
   survivalOf,
@@ -168,6 +169,93 @@ describe('survival util', () => {
       const t = clock({ weekday: 'Mol', weekdaysSeen: ['Sul', 'Mol'] });
       expect(registerWeekday(t, 'Mol')).toEqual(t);      // resubmit = no double count
       expect(registerWeekday(t, '  ').weekdaysSeen).toEqual(['Sul', 'Mol']);
+    });
+
+    describe('defined week (weekDays)', () => {
+      const week = ['Sul', 'Mol', 'Zol'];
+
+      it('advanceGameTime walks the weekday on the night → morning rollover', () => {
+        const t = advanceGameTime(clock({ timeOfDay: 'night', weekday: 'Sul' }), week);
+        expect(t.timeOfDay).toBe('morning');
+        expect(t.weekday).toBe('Mol');
+        expect(t.week).toBe(1); // no wrap — the counter holds
+      });
+
+      it('advanceGameTime wraps past the last day and increments the week', () => {
+        // "zol" — case-insensitive match, canonicalized on the way out
+        const t = advanceGameTime(clock({ timeOfDay: 'night', weekday: 'zol', week: 4 }), week);
+        expect(t.weekday).toBe('Sul');
+        expect(t.week).toBe(5);
+      });
+
+      it('advanceGameTime leaves an unknown or null weekday untouched', () => {
+        // definition edited mid-campaign — "Far" is no longer a defined day
+        const orphaned = advanceGameTime(clock({ timeOfDay: 'night', weekday: 'Far', week: 3 }), week);
+        expect(orphaned.weekday).toBe('Far');
+        expect(orphaned.week).toBe(3);
+        const unset = advanceGameTime(clock({ timeOfDay: 'night', week: 3 }), week);
+        expect(unset.weekday).toBeNull();
+        expect(unset.week).toBe(3);
+      });
+
+      it('advanceGameTime never moves the weekday on non-rollover segments', () => {
+        let t = advanceGameTime(clock({ timeOfDay: 'morning', weekday: 'Sul' }), week); // → noon
+        expect(t.weekday).toBe('Sul');
+        t = advanceGameTime(t, week); // → night
+        expect(t.weekday).toBe('Sul');
+        expect(t.week).toBe(1);
+      });
+
+      it('advanceGameTime without a definition behaves exactly as before', () => {
+        const t = advanceGameTime(clock({ timeOfDay: 'night', weekday: 'Sul' }));
+        expect(t.timeOfDay).toBe('morning');
+        expect(t.weekday).toBe('Sul');
+        expect(t.week).toBe(1);
+      });
+
+      it('setGameTime canonicalizes the weekday and freezes weekdaysSeen', () => {
+        const current = clock({ weekday: 'Zol', weekdaysSeen: ['Mol', 'Zol'] });
+        // "mol" repeats a seen weekday — the fallback would tick the week and
+        // reset the history; a defined week must do neither.
+        const t = setGameTime(current,
+          { year: '1', month: '1', day: '10th', timeOfDay: 'morning', weekday: 'mol' }, week);
+        expect(t.weekday).toBe('Mol'); // defined casing
+        expect(t.week).toBe(1);        // never inferred
+        expect(t.weekdaysSeen).toEqual(['Mol', 'Zol']); // frozen, not reset
+      });
+
+      it('setGameTime keeps the current weekday for a blank or out-of-list entry', () => {
+        const current = clock({ weekday: 'Zol' });
+        expect(setGameTime(current,
+          { year: '1', month: '1', day: '10th', timeOfDay: 'morning', weekday: null }, week).weekday)
+          .toBe('Zol');
+        expect(setGameTime(current,
+          { year: '1', month: '1', day: '10th', timeOfDay: 'morning', weekday: 'Far' }, week).weekday)
+          .toBe('Zol'); // mirror of the server's 400 — never coerced
+      });
+
+      it('setGameTime applies an explicit week, floored at 1', () => {
+        const current = clock({ weekday: 'Sul', week: 2 });
+        expect(setGameTime(current,
+          { year: '1', month: '1', day: '1', timeOfDay: 'morning', weekday: 'Sul', week: 7 }, week).week)
+          .toBe(7);
+        expect(setGameTime(current,
+          { year: '1', month: '1', day: '1', timeOfDay: 'morning', weekday: 'Sul', week: -3 }, week).week)
+          .toBe(1);
+        expect(setGameTime(current,
+          { year: '1', month: '1', day: '1', timeOfDay: 'morning', weekday: 'Sul' }, week).week)
+          .toBe(2); // no explicit week — current kept
+      });
+
+      it('setGameTime without a definition delegates to registerWeekday', () => {
+        const current = clock({ weekday: 'Mol', weekdaysSeen: ['Sul', 'Mol'] });
+        // "sul" was seen before → the repetition counter ticks (fallback intact),
+        // and an explicit week is ignored entirely.
+        const t = setGameTime(current,
+          { year: '1', month: '1', day: '10th', timeOfDay: 'morning', weekday: 'sul', week: 9 });
+        expect(t.week).toBe(2);
+        expect(t.weekdaysSeen).toEqual(['sul']);
+      });
     });
 
     it('describes the clock, skipping blank parts', () => {

--- a/src/app/charactermanager/utils/survival.ts
+++ b/src/app/charactermanager/utils/survival.ts
@@ -192,11 +192,57 @@ export function normalizeGameTime(raw: any): CampaignGameTime | null {
   };
 }
 
-/** morning → noon → night → next day's MORNING; the date never changes here. */
-export function advanceGameTime(t: CampaignGameTime): CampaignGameTime {
+/**
+ * morning → noon → night → next day's MORNING; the date never changes here.
+ * With a defined week (`weekDays`), the night → morning rollover also walks the
+ * weekday to the next defined name — wrapping past the last day increments the
+ * week counter. A null or unknown current weekday (definition edited
+ * mid-campaign) leaves the weekday AND week untouched; no definition behaves
+ * exactly as before. Mirrors the server's GameClock.advanceSegment.
+ */
+export function advanceGameTime(t: CampaignGameTime, weekDays?: string[] | null): CampaignGameTime {
   const idx = TIME_SEGMENTS.indexOf(t.timeOfDay);
   const next = TIME_SEGMENTS[(idx + 1) % TIME_SEGMENTS.length];
-  return { ...t, timeOfDay: idx < 0 ? 'morning' : next };
+  const advanced: CampaignGameTime = { ...t, timeOfDay: idx < 0 ? 'morning' : next };
+  const newDay = idx === TIME_SEGMENTS.length - 1; // night wraps to the next morning
+  if (newDay && weekDays?.length && t.weekday) {
+    const dayIdx = weekDays.findIndex(d => d.toLowerCase() === t.weekday!.toLowerCase());
+    if (dayIdx >= 0) {
+      const nextIdx = (dayIdx + 1) % weekDays.length;
+      advanced.weekday = weekDays[nextIdx];
+      if (nextIdx === 0) advanced.week = t.week + 1; // wrapped — a week completed
+    }
+  }
+  return advanced;
+}
+
+/**
+ * Apply the DM's set-date form to the clock (mirror of the server's setTime).
+ * With a defined week: the weekday is canonicalized to the defined casing (the
+ * current one kept when the form leaves it blank; an out-of-list entry is
+ * ignored the same way the server 400s it), the week moves only when the form
+ * carries an explicit number, and weekdaysSeen is frozen. Without a definition
+ * it delegates to {@link registerWeekday} — byte-identical to today.
+ */
+export function setGameTime(
+  current: CampaignGameTime,
+  form: { year: string; month: string; day: string; timeOfDay: TimeOfDay;
+          weekday: string | null; week?: number | null },
+  weekDays?: string[] | null,
+): CampaignGameTime {
+  const dated: CampaignGameTime = {
+    ...current, year: form.year, month: form.month, day: form.day, timeOfDay: form.timeOfDay,
+  };
+  if (!weekDays?.length) return registerWeekday(dated, form.weekday);
+  const entered = form.weekday?.trim() || null;
+  const canonical = entered
+    ? weekDays.find(d => d.toLowerCase() === entered.toLowerCase()) ?? null
+    : null;
+  return {
+    ...dated,
+    weekday: canonical ?? current.weekday,
+    week: form.week != null ? Math.max(1, Math.round(form.week)) : current.week,
+  };
 }
 
 /**


### PR DESCRIPTION
Deploy together with character-manager-service's feature/campaign-week-definition branch (this client sends the new week field and the /week-days endpoint). Note: expect a small merge conflict in session-mode.component.html with feature/wire-encounter-loader and fix/clock-location-one-line — this branch's template edits are written against develop; merge those two first (C then B) and re-apply the set-date form changes around their wrappers.