### PR TITLE
feat: supply containers — ration boxes and waterskins set carry capacity

### DIFF
--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
@@ -76,7 +76,7 @@ export class InventoryPanelComponent {
 
   get usedSlots(): number {
     // Full inventory, not `items` — supplies are hidden from the list but their
-    // over-the-free-allowance servings still count toward slots.
+    // containers (ration boxes / waterskins, 1 bulk each) still count toward slots.
     return usedSlots(this.pc?.inventory ?? []);
   }
 

--- a/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.html
@@ -7,16 +7,17 @@
     <span class="supply-name">{{ row.label }}</span>
     <span class="supply-track">
       <span *ngFor="let pip of row.pips" class="supply-pip"
-            [class.full]="pip.filled" [class.extra]="pip.extra"></span>
+            [class.full]="pip.filled"></span>
     </span>
-    <span class="supply-count numeric">{{ row.charges }}</span>
-    <span *ngIf="row.slots > 0" class="supply-slots" [title]="'Extra servings beyond the free ' + row.label + ' take inventory slots'">
-      +{{ row.slots }} slot{{ row.slots === 1 ? '' : 's' }}
+    <span class="supply-count numeric"
+          [title]="row.label + ': ' + row.charges + ' of ' + row.capacity + ' servings — each container holds 5'">
+      {{ row.charges }}/{{ row.capacity }}
     </span>
     <span *ngIf="editable" class="supply-steppers">
       <button type="button" class="btn" [disabled]="row.charges <= 0"
               (click)="adjust(row.key, -1)" [attr.aria-label]="'Use one ' + row.label">−</button>
-      <button type="button" class="btn"
+      <button type="button" class="btn" [disabled]="row.charges >= row.capacity"
+              [title]="row.charges >= row.capacity ? 'At capacity — buy another container to carry more' : ''"
               (click)="adjust(row.key, 1)" [attr.aria-label]="'Restock ' + row.label">+</button>
     </span>
   </div>

--- a/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.spec.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.spec.ts
@@ -7,84 +7,124 @@ describe('SuppliesPanelComponent', () => {
   const basePc = (inventory: PcItem[] = []): PC =>
     ({ id: 1, name: 'X', clazz: 'Ranger', level: 3, playerName: 'P', inventory } as PC);
 
+  const kit = (over: Partial<Record<string, number>> = {}): PcItem[] => [
+    { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: over['ration-box'] ?? 1 },
+    { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: over['waterskin'] ?? 1 },
+    { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: over['rations'] ?? 5 },
+    { catalogKey: 'water', name: 'Water', category: 'gear', qty: over['water'] ?? 5 },
+  ];
+
   beforeEach(() => {
     component = new SuppliesPanelComponent();
     component.editable = true;
   });
 
-  it('reads charges from the rations/waterskin lines and labels them', () => {
+  it('shows a Rations and a Water track with capacity = containers × 5', () => {
+    component.pc = basePc(kit({ rations: 3, water: 4 }));
+    const rows = component.rows;
+    expect(rows.map(r => r.label)).toEqual(['Rations', 'Water']);
+    expect(rows[0].charges).toBe(3);
+    expect(rows[0].capacity).toBe(5);
+    expect(rows[1].charges).toBe(4);
+    expect(rows[1].capacity).toBe(5);
+    // pips draw the capacity: 3 filled of 5
+    expect(rows[0].pips).toEqual([
+      { filled: true }, { filled: true }, { filled: true },
+      { filled: false }, { filled: false },
+    ]);
+  });
+
+  it('a second ration box raises the rations track to 10 pips', () => {
+    component.pc = basePc(kit({ 'ration-box': 2, rations: 7 }));
+    const row = component.rows[0];
+    expect(row.capacity).toBe(10);
+    expect(row.pips.length).toBe(10);
+    expect(row.pips.filter(p => p.filled).length).toBe(7);
+  });
+
+  it('normalizes legacy data on read: implied box, waterskin charges become water', () => {
+    // Old model: no box; waterskin qty WAS the water charges.
     component.pc = basePc([
       { catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 3 },
-      { catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 5 },
+      { catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 7 },
     ]);
     const rows = component.rows;
-    expect(rows.map(r => r.label)).toEqual(['Ration box', 'Water skin']);
     expect(rows[0].charges).toBe(3);
-    expect(rows[1].charges).toBe(5);
-    // capacity is max(charges, 5): 3 charges → 5 pips, 3 filled, none extra
-    expect(rows[0].pips).toEqual([
-      { filled: true, extra: false }, { filled: true, extra: false }, { filled: true, extra: false },
-      { filled: false, extra: false }, { filled: false, extra: false },
-    ]);
-    expect(rows[0].slots).toBe(0);
+    expect(rows[0].capacity).toBe(5);  // the implied free box
+    expect(rows[1].charges).toBe(7);
+    expect(rows[1].capacity).toBe(10); // ceil(7/5) = 2 skins
   });
 
-  it('charges the free box/skin no slots but bulk-tags every extra serving', () => {
-    component.pc = basePc([{ catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 7 }]);
-    const row = component.rows[0];
-    expect(row.slots).toBe(2); // 7 − 5 free
-    expect(row.pips.length).toBe(7);
-    expect(row.pips.filter(p => p.extra).length).toBe(2);
-    expect(row.pips[5]).toEqual({ filled: true, extra: true });
-  });
-
-  it('shows both supplies at zero when no lines exist yet', () => {
-    component.pc = basePc([]);
-    const rows = component.rows;
-    expect(rows.length).toBe(2);
-    expect(rows.every(r => r.charges === 0)).toBeTrue();
-    expect(rows.every(r => r.slots === 0)).toBeTrue();
-    expect(rows[0].pips.every(p => !p.filled)).toBeTrue();
-    expect(rows[0].pips.length).toBe(5);
-  });
-
-  it('drops pips (but keeps the count and slot cost) once charges exceed the pip cap', () => {
-    component.pc = basePc([{ catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 20 }]);
+  it('drops pips (but keeps the counts) once the capacity exceeds the pip cap', () => {
+    component.pc = basePc(kit({ 'ration-box': 4, rations: 20 }));
     const row = component.rows[0];
     expect(row.charges).toBe(20);
-    expect(row.slots).toBe(15);
+    expect(row.capacity).toBe(20);
     expect(row.pips).toEqual([]);
   });
 
   it('spends a serving without mutating the input PC', () => {
-    component.pc = basePc([{ catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 4 }]);
+    component.pc = basePc(kit({ rations: 4 }));
     const spy = spyOn(component.pcChange, 'emit');
 
     component.adjust('rations', -1);
 
     const emitted = spy.calls.mostRecent().args[0] as PC;
     expect(emitted.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(3);
-    expect(component.pc.inventory![0].qty).toBe(4); // input untouched
+    expect(component.pc.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(4); // input untouched
   });
 
-  it('creates the line on a restock when none exists', () => {
-    component.pc = basePc([]);
+  it('restock stops at capacity — the + is a no-op when the containers are full', () => {
+    component.pc = basePc(kit({ rations: 5 }));
     const spy = spyOn(component.pcChange, 'emit');
 
-    component.adjust('waterskin', 1);
+    component.adjust('rations', 1);
+
+    expect(spy).not.toHaveBeenCalled(); // 5 of 5 — buy another box instead
+  });
+
+  it('restocks water free up to the skins\' capacity', () => {
+    component.pc = basePc(kit({ water: 0 }));
+    const spy = spyOn(component.pcChange, 'emit');
+
+    component.adjust('water', 1);
 
     const emitted = spy.calls.mostRecent().args[0] as PC;
-    const line = emitted.inventory!.find(i => i.catalogKey === 'waterskin');
-    expect(line).toEqual({ catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 1 });
+    expect(emitted.inventory!.find(i => i.catalogKey === 'water')!.qty).toBe(1);
+  });
+
+  it('creates the charge line on a restock when only the container exists', () => {
+    component.pc = basePc([
+      { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 1 },
+    ]);
+    const spy = spyOn(component.pcChange, 'emit');
+
+    component.adjust('rations', 1);
+
+    const emitted = spy.calls.mostRecent().args[0] as PC;
+    const line = emitted.inventory!.find(i => i.catalogKey === 'rations');
+    expect(line!.qty).toBe(1);
+    expect(line!.category).toBe('gear');
   });
 
   it('does not go below zero when spending an empty supply', () => {
-    component.pc = basePc([{ catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 0 }]);
+    component.pc = basePc(kit({ water: 0 }));
     const spy = spyOn(component.pcChange, 'emit');
 
-    component.adjust('waterskin', -1);
+    component.adjust('water', -1);
+
+    expect(spy).not.toHaveBeenCalled(); // already empty — nothing to persist
+  });
+
+  it('keeps a spent line at qty 0 rather than removing it', () => {
+    component.pc = basePc(kit({ rations: 1 }));
+    const spy = spyOn(component.pcChange, 'emit');
+
+    component.adjust('rations', -1);
 
     const emitted = spy.calls.mostRecent().args[0] as PC;
-    expect(emitted.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(0);
+    const lines = emitted.inventory!.filter(i => i.catalogKey === 'rations');
+    expect(lines.length).toBe(1);
+    expect(lines[0].qty).toBe(0);
   });
 });

--- a/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/supplies-panel/supplies-panel.component.ts
@@ -3,40 +3,42 @@ import { PC } from '../../../../models/pc';
 import {
   SUPPLY_KEYS,
   SUPPLY_LABELS,
-  SUPPLY_FREE_CHARGES,
   SupplyKey,
-  SURVIVAL_STARTING_CHARGES,
+  normalizeSupplies,
+  supplyCapacity,
+  supplyChargeLine,
+  supplyCharges,
 } from '../../../../utils/survival';
 
-/** One pip in a supply track: filled = a serving in hand; extra = a bought
- *  serving beyond the free box/skin, so it costs an inventory slot. */
+/** One pip in a supply track: filled = a serving in hand. */
 interface SupplyPip {
   filled: boolean;
-  extra: boolean;
 }
 
-/** A single supply row as rendered: label, remaining charges, and the pip track. */
+/** A single supply row as rendered: label, charges/capacity, and the pip track. */
 interface SupplyRow {
   key: SupplyKey;
   label: string;
   charges: number;
-  /** Servings beyond the free box/skin — each costs one inventory slot. */
-  slots: number;
-  /** One entry per pip. Empty when the count is too large to draw as pips
-   *  (the numeric count is always shown too). */
+  /** Total servings the containers can hold (containers × 5). */
+  capacity: number;
+  /** One entry per pip — the track IS the capacity. Empty when the capacity is
+   *  too large to draw as pips (the numeric count is always shown too). */
   pips: SupplyPip[];
 }
 
-/** Beyond this many charges we stop drawing pips and lean on the numeric count. */
-const MAX_PIPS = 12;
+/** Beyond this many pips we stop drawing them and lean on the numeric count. */
+const MAX_PIPS = 15;
 
 /**
- * Travel supplies as charges — the Ration box and Water skin, shown like spell
- * slots. The charges live as `qty` on the rations/waterskin inventory lines (so
- * the survival clock can auto-consume them); this pane just reads them and,
- * when editable, lets the owner/DM spend or restock a serving. Display-only
- * otherwise — matching how players see spell slots. Shown only in campaigns
- * with the survivalConditions variant (gated by the host).
+ * Travel supplies under the container model: ration boxes and waterskins are
+ * containers (bought at the shop) whose count sets each track's capacity —
+ * 5 servings per container. The charges live as `qty` on the rations/water
+ * inventory lines (so the survival clock can auto-consume them); this pane
+ * reads them and, when editable, lets the owner/DM spend or restock a serving.
+ * Restock is capped at capacity — buy another container to raise it. Legacy
+ * supply data is container-normalized on read and on the first edit. Shown
+ * only in campaigns with the survivalConditions variant (gated by the host).
  */
 @Component({
   selector: 'app-supplies-panel',
@@ -48,38 +50,36 @@ export class SuppliesPanelComponent {
   @Input() editable = false;
   @Output() pcChange = new EventEmitter<PC>();
 
-  private chargesFor(key: SupplyKey): number {
-    const line = (this.pc?.inventory ?? []).find(i => i.catalogKey === key && i.status !== 'dropped');
-    return Math.max(0, line?.qty ?? 0);
-  }
-
   get rows(): SupplyRow[] {
+    // Read through the normalizer so legacy data displays under the container
+    // model without waiting for a server write.
+    const inventory = normalizeSupplies(this.pc?.inventory ?? []);
     return SUPPLY_KEYS.map(key => {
-      const charges = this.chargesFor(key);
-      const capacity = Math.max(charges, SURVIVAL_STARTING_CHARGES);
-      const pips = capacity <= MAX_PIPS
-        ? Array.from({ length: capacity }, (_, i) => ({ filled: i < charges, extra: i >= SUPPLY_FREE_CHARGES }))
+      const charges = supplyCharges(inventory, key);
+      const capacity = supplyCapacity(inventory, key);
+      const track = Math.max(capacity, charges); // odd data: still show every serving
+      const pips = track <= MAX_PIPS
+        ? Array.from({ length: track }, (_, i) => ({ filled: i < charges }))
         : [];
-      return {
-        key,
-        label: SUPPLY_LABELS[key],
-        charges,
-        slots: Math.max(0, charges - SUPPLY_FREE_CHARGES),
-        pips,
-      };
+      return { key, label: SUPPLY_LABELS[key], charges, capacity, pips };
     });
   }
 
-  /** Spend (−1) or restock (+1) a serving. Creates the line on the first +. */
+  /**
+   * Spend (−1) or restock (+1) a serving. Restock stops at capacity (containers
+   * × 5); spending floors at 0 and keeps the line (an empty box persists).
+   */
   adjust(key: SupplyKey, delta: number): void {
-    const inventory = (this.pc.inventory ?? []).map(i => ({ ...i }));
+    const inventory = normalizeSupplies(this.pc.inventory ?? []);
+    const capacity = supplyCapacity(inventory, key);
     const line = inventory.find(i => i.catalogKey === key && i.status !== 'dropped');
-    const next = Math.max(0, (line?.qty ?? 0) + delta);
+    const current = Math.max(0, line?.qty ?? 0);
+    const next = Math.min(capacity, Math.max(0, current + delta));
+    if (next === current && line) return; // at a bound — nothing to persist
     if (line) {
       line.qty = next;
     } else {
-      if (next === 0) return;
-      inventory.push({ catalogKey: key, name: SUPPLY_LABELS[key], category: 'gear', qty: next });
+      inventory.push(supplyChargeLine(key, next));
     }
     this.pcChange.emit({ ...this.pc, inventory });
   }

--- a/src/app/charactermanager/utils/slot-inventory.spec.ts
+++ b/src/app/charactermanager/utils/slot-inventory.spec.ts
@@ -62,20 +62,24 @@ describe('slot-inventory util', () => {
       expect(usedSlots(undefined)).toBe(0);
     });
 
-    it('gives the free starting box/skin no bulk but 1 slot per extra serving', () => {
-      // Starting supplies: rations & water at 5 each — weightless despite bulk: 1.
+    it('bulks each supply CONTAINER at 1 slot and keeps the charges weightless', () => {
+      // Starting kit: 1 box + 1 skin (1 bulk each); the servings inside are free.
       const starting: PcItem[] = [
-        { catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 5, bulk: 1 },
-        { catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 5, bulk: 1 },
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 1, bulk: 1 },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1, bulk: 1 },
+        { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 5, bulk: 0.2 },
+        { catalogKey: 'water', name: 'Water', category: 'gear', qty: 5, bulk: 0 },
       ];
-      expect(usedSlots(starting)).toBe(0);
+      expect(usedSlots(starting)).toBe(2);
 
-      // Bought extras: 8 rations (3 over) + 6 water (1 over) = 4 slots.
+      // More containers = more slots; charge counts never matter.
       const stocked: PcItem[] = [
-        { catalogKey: 'rations', name: 'Ration box', category: 'gear', qty: 8, bulk: 1 },
-        { catalogKey: 'waterskin', name: 'Water skin', category: 'gear', qty: 6, bulk: 1 },
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 2, bulk: 1 },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 3, bulk: 1 },
+        { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 10, bulk: 0.2 },
+        { catalogKey: 'water', name: 'Water', category: 'gear', qty: 15, bulk: 0 },
       ];
-      expect(usedSlots(stocked)).toBe(4);
+      expect(usedSlots(stocked)).toBe(5);
     });
   });
 

--- a/src/app/charactermanager/utils/slot-inventory.ts
+++ b/src/app/charactermanager/utils/slot-inventory.ts
@@ -28,8 +28,8 @@ export function itemBulk(item: PcItem): number {
 
 /**
  * Slots filled: Σ bulk × qty over owned (non-dropped) lines, to 1 decimal.
- * Travel supplies (rations/water) are the exception — the free starting box/skin
- * is weightless and only servings bought beyond it take a slot ({@link supplyBulk}).
+ * Travel supplies are the exception — each CONTAINER (ration box / waterskin)
+ * takes 1 slot and the charges inside it are weightless ({@link supplyBulk}).
  */
 export function usedSlots(items: PcItem[] | undefined): number {
   const total = (items ?? [])

--- a/src/app/charactermanager/utils/survival.spec.ts
+++ b/src/app/charactermanager/utils/survival.spec.ts
@@ -6,9 +6,13 @@ import {
   describeGameTime,
   incrementDayLabel,
   initialGameTime,
+  isSupplyItem,
   normalizeGameTime,
+  normalizeSupplies,
   registerWeekday,
   setGameTime,
+  supplyBulk,
+  supplyCapacity,
   SURVIVAL_LABELS,
   survivalExhaustion,
   survivalOf,
@@ -47,20 +51,27 @@ describe('survival util', () => {
     });
   });
 
-  describe('applySegmentToPc (auto-consume)', () => {
-    const rations: PcItem = { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 5 };
-    const waterskin: PcItem = { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 5 };
+  describe('applySegmentToPc (auto-consume, container model)', () => {
+    const kit: PcItem[] = [
+      { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 1, bulk: 1 },
+      { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1, bulk: 1 },
+      { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 5, bulk: 0.2 },
+      { catalogKey: 'water', name: 'Water', category: 'gear', qty: 5, bulk: 0 },
+    ];
     const fedPc = (over: Partial<PC> = {}): PC => basePC({
       survival: { hunger: 2, thirst: 2, fatigue: 2, seeded: true },
-      inventory: [{ ...rations }, { ...waterskin }],
+      inventory: kit.map(i => ({ ...i })),
       ...over,
     });
 
-    it('morning: eats/drinks to hold hunger & thirst, decrementing supplies', () => {
+    it('morning: eats/drinks to hold hunger & thirst, decrementing the charge lines', () => {
       const after = applySegmentToPc(fedPc(), 'morning');
       expect(after.survival).toEqual({ hunger: 2, thirst: 2, fatigue: 2, seeded: true });
       expect(after.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(4);
-      expect(after.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(4);
+      expect(after.inventory!.find(i => i.catalogKey === 'water')!.qty).toBe(4);
+      // the containers themselves are never consumed
+      expect(after.inventory!.find(i => i.catalogKey === 'ration-box')!.qty).toBe(1);
+      expect(after.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(1);
     });
 
     it('noon: raises fatigue only and consumes nothing', () => {
@@ -74,24 +85,98 @@ describe('survival util', () => {
       expect(after.survival).toEqual({ hunger: 3, thirst: 3, fatigue: 5, seeded: true });
     });
 
-    it('raises hunger/thirst once the supplies run out', () => {
+    it('raises hunger/thirst once the charges run out', () => {
       const pc = basePC({ survival: { hunger: 2, thirst: 2, fatigue: 2, seeded: true }, inventory: [] });
       const after = applySegmentToPc(pc, 'night');
       expect(after.survival).toEqual({ hunger: 3, thirst: 3, fatigue: 3, seeded: true });
     });
 
-    it('seeds the starting supplies once for an unseeded character', () => {
+    it('consumes a line down to 0 and KEEPS it — empty containers persist', () => {
+      const pc = fedPc({
+        inventory: [
+          { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 1, bulk: 1 },
+          { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1, bulk: 1 },
+          { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 1, bulk: 0.2 },
+          { catalogKey: 'water', name: 'Water', category: 'gear', qty: 1, bulk: 0 },
+        ],
+      });
+      const after = applySegmentToPc(pc, 'morning');
+      expect(after.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(0);
+      expect(after.inventory!.find(i => i.catalogKey === 'water')!.qty).toBe(0);
+      expect(after.inventory!.filter(i => i.catalogKey === 'rations').length).toBe(1);
+    });
+
+    it('seeds the starting kit once for an unseeded character', () => {
       const pc = basePC({ inventory: [] }); // no survival → unseeded
       const after = applySegmentToPc(pc, 'noon'); // noon consumes nothing, so 5 remain
       expect(after.survival!.seeded).toBeTrue();
+      expect(after.inventory!.find(i => i.catalogKey === 'ration-box')!.qty).toBe(1);
+      expect(after.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(1);
       expect(after.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(5);
-      expect(after.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(5);
+      expect(after.inventory!.find(i => i.catalogKey === 'water')!.qty).toBe(5);
+    });
+
+    it('normalizes legacy supply data: implied box added, waterskin charges become water', () => {
+      // Old model: waterskin qty WAS the water servings (here 7); no box line.
+      const pc = basePC({
+        survival: { hunger: 2, thirst: 2, fatigue: 2, seeded: true },
+        inventory: [
+          { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 3 },
+          { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 7 },
+        ],
+      });
+      const after = applySegmentToPc(pc, 'noon'); // noon consumes nothing
+      expect(after.inventory!.find(i => i.catalogKey === 'ration-box')!.qty).toBe(1);
+      expect(after.inventory!.find(i => i.catalogKey === 'water')!.qty).toBe(7);
+      expect(after.inventory!.find(i => i.catalogKey === 'waterskin')!.qty).toBe(2); // ceil(7/5)
     });
 
     it('does not mutate the input PC', () => {
       const pc = fedPc();
       applySegmentToPc(pc, 'night');
       expect(pc.inventory!.find(i => i.catalogKey === 'rations')!.qty).toBe(5);
+      expect(pc.inventory!.length).toBe(4);
+    });
+  });
+
+  describe('supply bulk & capacity (container model)', () => {
+    it('supplyBulk charges 1 per container and nothing for the servings', () => {
+      expect(supplyBulk({ catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 2 })).toBe(2);
+      expect(supplyBulk({ catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1 })).toBe(1);
+      expect(supplyBulk({ catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 10 })).toBe(0);
+      expect(supplyBulk({ catalogKey: 'water', name: 'Water', category: 'gear', qty: 10 })).toBe(0);
+      expect(supplyBulk({ name: 'Rope', category: 'gear', qty: 1 })).toBe(0);
+    });
+
+    it('isSupplyItem covers charges and containers — water never shows as a normal row', () => {
+      expect(isSupplyItem({ catalogKey: 'rations' })).toBeTrue();
+      expect(isSupplyItem({ catalogKey: 'water' })).toBeTrue();
+      expect(isSupplyItem({ catalogKey: 'ration-box' })).toBeTrue();
+      expect(isSupplyItem({ catalogKey: 'waterskin' })).toBeTrue();
+      expect(isSupplyItem({ catalogKey: 'rope' })).toBeFalse();
+    });
+
+    it('supplyCapacity is containers × 5 per track', () => {
+      const inv: PcItem[] = [
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 2 },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1 },
+      ];
+      expect(supplyCapacity(inv, 'rations')).toBe(10);
+      expect(supplyCapacity(inv, 'water')).toBe(5);
+      expect(supplyCapacity([], 'rations')).toBe(0);
+    });
+
+    it('normalizeSupplies is idempotent and leaves converted data alone', () => {
+      const converted: PcItem[] = [
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 2 },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1 },
+        { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 4 },
+        { catalogKey: 'water', name: 'Water', category: 'gear', qty: 4 },
+      ];
+      const out = normalizeSupplies(converted);
+      expect(out.length).toBe(4);
+      expect(out.find(i => i.catalogKey === 'waterskin')!.qty).toBe(1);
+      expect(out.find(i => i.catalogKey === 'water')!.qty).toBe(4);
     });
   });
 

--- a/src/app/charactermanager/utils/survival.ts
+++ b/src/app/charactermanager/utils/survival.ts
@@ -39,60 +39,134 @@ export function survivalOf(pc: PC): PcSurvival {
 
 export const SURVIVAL_STARTING_CHARGES = 5;
 
-// ── Travel supplies (rations / water) ───────────────────────────────────────
-// These two lines live in pc.inventory (so the survival clock can auto-consume
-// them by decrementing qty), but the sheet treats them specially: they show as
-// charges in the Supplies pane — like spell slots — and never count toward the
-// slot-inventory bulk. The qty IS the number of servings left.
+// ── Travel supplies: the container model ────────────────────────────────────
+// Ration boxes and waterskins are CONTAINERS (1 bulk each, never auto-
+// consumed); each holds 5 servings. The servings are separate charge lines —
+// 'rations' (purchasable, 1 sp each) and 'water' (never sold; refilled free) —
+// whose qty the survival clock decrements. Charges are weightless inside their
+// containers and capped at containers × 5 everywhere. Mirrors the server's
+// SurvivalSupplies so demo mode behaves identically.
 
-export const SUPPLY_KEYS = ['rations', 'waterskin'] as const;
+/** One container (ration box / waterskin) holds this many servings. */
+export const SERVINGS_PER_CONTAINER = 5;
+
+/** The charge lines shown as tracks in the Supplies pane. */
+export const SUPPLY_KEYS = ['rations', 'water'] as const;
 export type SupplyKey = typeof SUPPLY_KEYS[number];
 
-/** Display labels for the two auto-consumed travel supplies. */
+/** The container lines that set each charge track's capacity. */
+export const SUPPLY_CONTAINER_KEYS = ['ration-box', 'waterskin'] as const;
+
+/** Display labels for the two consumable charge tracks. */
 export const SUPPLY_LABELS: Record<SupplyKey, string> = {
-  rations: 'Ration box',
-  waterskin: 'Water skin',
+  rations: 'Rations',
+  water: 'Water',
 };
 
-/** True for a rations/waterskin line — tracked as charges in the Supplies pane. */
-export function isSupplyItem(item: Pick<PcItem, 'catalogKey'>): boolean {
-  return item.catalogKey === 'rations' || item.catalogKey === 'waterskin';
-}
-
-/** Servings you carry for free (the starting box/skin); extras cost bulk. */
-export const SUPPLY_FREE_CHARGES = SURVIVAL_STARTING_CHARGES;
+/** Which container holds each charge line. */
+export const CONTAINER_FOR: Record<SupplyKey, string> = {
+  rations: 'ration-box',
+  water: 'waterskin',
+};
 
 /**
- * A supply line's bulk: the starting box/skin (up to {@link SUPPLY_FREE_CHARGES}
- * servings) is weightless; every serving bought beyond that takes 1 slot. A
- * non-supply item contributes nothing here (the caller bulks it normally).
+ * True for any supply line — charges (rations/water) or containers (ration
+ * box/waterskin). These never render as ordinary inventory rows: the Supplies
+ * pane shows charges as pips and containers as capacity.
  */
-export function supplyBulk(item: PcItem): number {
-  if (!isSupplyItem(item)) return 0;
-  return Math.max(0, (item.qty ?? 0) - SUPPLY_FREE_CHARGES);
+export function isSupplyItem(item: Pick<PcItem, 'catalogKey'>): boolean {
+  return item.catalogKey === 'rations' || item.catalogKey === 'water'
+      || item.catalogKey === 'ration-box' || item.catalogKey === 'waterskin';
 }
 
-/** Add a full Ration box and Water skin if a live line for each isn't present. */
-function seedSupplies(inventory: PcItem[]): PcItem[] {
-  const items = inventory.map(i => ({ ...i }));
-  const has = (key: string) => items.some(i => i.catalogKey === key && i.status !== 'dropped');
-  if (!has('rations')) {
-    items.push({ catalogKey: 'rations', name: SUPPLY_LABELS.rations, category: 'gear',
-      qty: SURVIVAL_STARTING_CHARGES, weight: 2, unitCostCp: 50 });
+/** Summed qty of every live line with this catalog key. */
+function liveCount(inventory: PcItem[], catalogKey: string): number {
+  return inventory
+    .filter(i => i.catalogKey === catalogKey && i.status !== 'dropped')
+    .reduce((sum, i) => sum + Math.max(0, i.qty ?? 0), 0);
+}
+
+/** Total servings a charge track can hold: its containers × 5. */
+export function supplyCapacity(inventory: PcItem[], key: SupplyKey): number {
+  return liveCount(inventory, CONTAINER_FOR[key]) * SERVINGS_PER_CONTAINER;
+}
+
+/** Servings currently in hand for a charge track. */
+export function supplyCharges(inventory: PcItem[], key: SupplyKey): number {
+  return liveCount(inventory, key);
+}
+
+/**
+ * A supply line's bulk: each CONTAINER (ration box / waterskin) is 1 bulk;
+ * the charges inside are weightless. A non-supply item contributes nothing
+ * here (the caller bulks it normally).
+ */
+export function supplyBulk(item: PcItem): number {
+  if (item.catalogKey === 'ration-box' || item.catalogKey === 'waterskin') {
+    return Math.max(0, item.qty ?? 0);
   }
-  if (!has('waterskin')) {
-    items.push({ catalogKey: 'waterskin', name: SUPPLY_LABELS.waterskin, category: 'gear',
-      qty: SURVIVAL_STARTING_CHARGES, weight: 5, unitCostCp: 20 });
+  return 0;
+}
+
+/** A fresh charge line for the pane/seed — mirrors the server's line shapes. */
+export function supplyChargeLine(key: SupplyKey, qty: number): PcItem {
+  return key === 'rations'
+    ? { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear',
+        qty, weight: 0.2, bulk: 0.2, unitCostCp: 10 }
+    : { catalogKey: 'water', name: 'Water', category: 'gear', qty, weight: 0, bulk: 0 };
+}
+
+/** A fresh container line — 1 bulk each, never auto-consumed. */
+function containerLine(catalogKey: string, name: string, costCp: number, qty: number): PcItem {
+  return { catalogKey, name, category: 'gear', qty, weight: 1, bulk: 1, unitCostCp: costCp };
+}
+
+/**
+ * Lazily migrate legacy (pre-container) supply data — mirror of the server's
+ * SurvivalSupplies.normalize:
+ * - no live ration-box line → add one (qty 1), the old model's implied free box;
+ * - no live water line but a live waterskin line → the skin's qty WAS the
+ *   water charges: move it to a new water line and turn the skin into
+ *   max(1, ceil(oldQty / 5)) containers.
+ * Returns a new array; the input is untouched.
+ */
+export function normalizeSupplies(inventory: PcItem[]): PcItem[] {
+  const items = inventory.map(i => ({ ...i }));
+  const live = (key: string) => items.find(i => i.catalogKey === key && i.status !== 'dropped');
+  if (!live('ration-box')) {
+    items.push(containerLine('ration-box', 'Ration box', 50, 1));
+  }
+  const skin = live('waterskin');
+  if (skin && !live('water')) {
+    const oldQty = Math.max(0, skin.qty ?? 0);
+    items.push(supplyChargeLine('water', oldQty));
+    skin.qty = Math.max(1, Math.ceil(oldQty / SERVINGS_PER_CONTAINER));
+    skin.weight = 1;
+    skin.bulk = 1;
   }
   return items;
 }
 
-/** Decrement one unit of the first live line with this key; returns [items, consumed]. */
+/** Seed the starting kit: 1 ration box, 1 waterskin, 5 rations, 5 water. */
+function seedSupplies(inventory: PcItem[]): PcItem[] {
+  const items = inventory.map(i => ({ ...i }));
+  const has = (key: string) => items.some(i => i.catalogKey === key && i.status !== 'dropped');
+  if (!has('ration-box')) items.push(containerLine('ration-box', 'Ration box', 50, 1));
+  if (!has('waterskin')) items.push(containerLine('waterskin', 'Waterskin', 20, 1));
+  if (!has('rations')) items.push(supplyChargeLine('rations', SURVIVAL_STARTING_CHARGES));
+  if (!has('water')) items.push(supplyChargeLine('water', SURVIVAL_STARTING_CHARGES));
+  return items;
+}
+
+/**
+ * Decrement one unit of the first live line with this key; returns
+ * [items, consumed]. The line is KEPT at qty 0 — an empty box/skin persists
+ * for refilling (no more line removal). Mirrors the server's tryConsume.
+ */
 function tryConsume(inventory: PcItem[], key: string): [PcItem[], boolean] {
   const items = inventory.map(i => ({ ...i }));
   const line = items.find(i => i.catalogKey === key && i.status !== 'dropped' && (i.qty ?? 0) > 0);
   if (!line) return [items, false];
-  if (line.qty === 1) return [items.filter(i => i !== line), true];
   line.qty -= 1;
   return [items, true];
 }
@@ -100,12 +174,14 @@ function tryConsume(inventory: PcItem[], key: string): [PcItem[], boolean] {
 /**
  * Advance one PC by a day-segment — the demo/local mirror of the server. The
  * party auto-eats/drinks their supplies: hunger and thirst hold while a
- * ration/water serving lasts and rise only when the box runs out; fatigue
- * always climbs on its steps. Starting supplies are seeded once (seeded flag).
+ * ration/water serving lasts and rise only when the charges run out; fatigue
+ * always climbs on its steps. Legacy supply lines are container-normalized
+ * first; starting supplies are seeded once (seeded flag). Water is drunk from
+ * the 'water' charge line — never from the skin itself.
  * Returns a new PC; the input is untouched.
  */
 export function applySegmentToPc(pc: PC, segment: TimeOfDay): PC {
-  let inventory: PcItem[] = pc.inventory ?? [];
+  let inventory: PcItem[] = normalizeSupplies(pc.inventory ?? []);
   if (pc.survival?.seeded !== true) inventory = seedSupplies(inventory);
 
   const s = survivalOf(pc);
@@ -114,7 +190,7 @@ export function applySegmentToPc(pc: PC, segment: TimeOfDay): PC {
   let drank = false;
   if (supplyStep) {
     [inventory, ate] = tryConsume(inventory, 'rations');
-    [inventory, drank] = tryConsume(inventory, 'waterskin');
+    [inventory, drank] = tryConsume(inventory, 'water');
   }
   const survival: PcSurvival = {
     hunger: supplyStep && !ate ? clampStage(s.hunger + 1) : s.hunger,

--- a/src/styles.css
+++ b/src/styles.css
@@ -776,16 +776,7 @@ app-root { display: block; height: 100vh; width: 100vw; }
   background: transparent;
 }
 .supply-pip.full { background: var(--gold); box-shadow: var(--glow-gold); }
-/* Servings beyond the free box/skin — square off + tint to signal they cost a slot. */
-.supply-pip.extra { border-color: var(--crimson); border-radius: 2px; }
-.supply-pip.extra.full { background: var(--crimson); box-shadow: none; }
-.supply-count { min-width: 18px; text-align: right; color: var(--text-dim); font-size: 13px; }
-.supply-slots {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--crimson);
-  white-space: nowrap;
-}
+.supply-count { min-width: 34px; text-align: right; color: var(--text-dim); font-size: 13px; }
 .supply-steppers { display: inline-flex; gap: 4px; }
 .supply-steppers .btn { padding: 0 8px; line-height: 20px; }
 .supply-note { margin-top: 8px; }


### PR DESCRIPTION
Mirrors character-manager-service's feature/supply-containers (deploy together): containers hold 5 servings each, rations/water are charge lines kept at 0 when spent, legacy supply data normalizes lazily, the supplies pane caps restocking at containers × 5, and supply bulk = container count.