### PR TITLE
feat: grab-and-throw dice cluster with flick gesture

### DIFF
--- a/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.html
+++ b/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.html
@@ -4,7 +4,7 @@
 
   <div class="modal-title">Cast The Bones</div>
   <div class="modal-sub">
-    Drag dice into the field, then wind up the orb and let them fly.
+    Drag dice into the field, then grab the cluster and flick it to throw.
   </div>
 
   <!-- ── Palette: pick die types from the top ─────────────────────────────── -->
@@ -43,8 +43,24 @@
       Your dice field is empty — drag dice here.
     </p>
 
-    <!-- Resting / flying dice live on the shelf at the bottom of the arena -->
-    <div class="dice-shelf">
+    <!-- Resting / flying dice live on the shelf at the bottom of the arena.
+         The shelf itself is the grab target: drag to reposition (clamped to
+         the arena), release with a flick to throw. Tap, Enter, or Space rolls. -->
+    <div
+      class="dice-shelf"
+      #shelfEl
+      tabindex="0"
+      role="button"
+      aria-label="Roll the dice"
+      [class.grabbing]="dragging"
+      [style.--cluster-x.px]="clusterX"
+      [style.--cluster-y.px]="clusterY"
+      (pointerdown)="onClusterPointerDown($event)"
+      (pointermove)="onClusterPointerMove($event)"
+      (pointerup)="onClusterPointerUp($event)"
+      (pointercancel)="onClusterPointerCancel()"
+      (keydown.enter)="throwButton()"
+      (keydown.space)="throwButton()">
       <span
         *ngFor="let d of staged; trackBy: trackById"
         class="arena-die"
@@ -56,8 +72,7 @@
         [style.--rest.px]="d.rest"
         [style.--spin.deg]="d.spin"
         [style.--delay.ms]="d.delay"
-        (click)="removeDie(d.id)"
-        title="{{ phase === 'staging' ? 'Click to remove' : 'd' + d.sides }}">
+        title="d{{ d.sides }}">
         <span class="die-shape" [attr.data-die]="'d' + d.sides">
           <span class="die-face">{{ d.display }}</span>
         </span>
@@ -80,7 +95,7 @@
     </div>
   </div>
 
-  <!-- ── Throw bar: the pokéball-style orb ────────────────────────────────── -->
+  <!-- ── Throw bar: Clear + the keyboard/click Roll fallback ──────────────── -->
   <div class="dice-throwbar">
     <button
       type="button"
@@ -90,45 +105,14 @@
       Clear
     </button>
 
-    <div class="orb-stage">
-      <div class="power-gauge" [class.active]="charging">
-        <div class="power-fill" [style.height.%]="power * 100"></div>
-      </div>
-
-      <button
-        type="button"
-        class="throw-orb"
-        [class.charging]="charging"
-        [class.spent]="phase === 'rolling'"
-        [style.--lift.px]="-(charging ? power * 40 : 0)"
-        [disabled]="!canThrow"
-        (pointerdown)="onBallDown($event)"
-        (keydown.enter)="throwButton()"
-        (keydown.space)="throwButton()"
-        title="Hold and flick the die upward to throw — or press Enter">
-        <svg class="orb-d20" viewBox="0 0 100 100" aria-hidden="true">
-          <!-- d20 silhouette: outer hexagon + central triangular face -->
-          <polygon class="orb-d20-body" points="50,3 91,26 91,74 50,97 9,74 9,26" />
-          <polygon class="orb-d20-face" points="50,30 74,70 26,70" />
-          <g class="orb-d20-facets">
-            <line x1="50" y1="3"  x2="50" y2="30" />
-            <line x1="9"  y1="26" x2="50" y2="30" />
-            <line x1="91" y1="26" x2="50" y2="30" />
-            <line x1="9"  y1="74" x2="26" y2="70" />
-            <line x1="91" y1="74" x2="74" y2="70" />
-            <line x1="50" y1="97" x2="50" y2="70" />
-          </g>
-          <text class="orb-d20-num" x="50" y="60">20</text>
-        </svg>
-      </button>
-    </div>
-
     <button
       type="button"
-      class="btn sm"
+      class="btn primary"
       [disabled]="!canThrow"
-      (click)="throwButton()">
-      Throw
+      (click)="throwButton()"
+      (keydown.enter)="throwButton()"
+      (keydown.space)="throwButton()">
+      Roll
     </button>
   </div>
 

--- a/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.scss
+++ b/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.scss
@@ -177,29 +177,54 @@
   gap: 8px;
   justify-content: center;
   padding: 0 16px;
+
+  // Grab-and-throw target: the cluster itself. touch-action: none stops
+  // mobile scroll/pinch from hijacking the drag; the transform follows the
+  // pointer via --cluster-x/--cluster-y, eased back home when not actively
+  // dragging (the drop-in-place / snap-back feel).
+  touch-action: none;
+  cursor: grab;
+  transform: translate(var(--cluster-x, 0px), var(--cluster-y, 0px));
+  transition: transform .15s ease-out;
+
+  &.grabbing {
+    cursor: grabbing;
+    transition: none; // no lag between finger/mouse and cluster while actively dragging
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in oklch, var(--gold) 70%, transparent);
+    outline-offset: 4px;
+  }
 }
 
 .arena-die {
-  cursor: pointer;
+  pointer-events: none; // the shelf itself is the drag/tap target, not individual dice
   will-change: transform;
 
   &.flying {
     animation: diceFlight 1.15s cubic-bezier(0.45, 0, 0.3, 1) both;
     animation-delay: var(--delay, 0ms);
-    cursor: default;
   }
 
   &.landed {
-    cursor: default;
     .die-shape { box-shadow: inset 0 2px 5px rgba(255,255,255,0.4),
                              inset 0 -3px 6px rgba(0,0,0,0.35),
                              0 0 14px color-mix(in oklch, var(--gold) 45%, transparent); }
   }
+}
 
-  &:not(.flying):not(.landed):hover .die-shape {
-    outline: 2px solid color-mix(in oklch, var(--crimson) 60%, transparent);
-    outline-offset: 2px;
-  }
+// Spinning tumble while the cluster is held (not yet thrown) — reuses the
+// same die-shape visual language as .flying but loops instead of playing
+// once. .grabbing (staging) and .flying (rolling) are phase-exclusive, so
+// these two animation rules on .arena-die never actually compete at runtime.
+.dice-shelf.grabbing .arena-die {
+  animation: diceHeld 0.6s linear infinite;
+}
+@keyframes diceHeld {
+  0%   { transform: rotate(0deg) scale(1.04); }
+  50%  { transform: rotate(180deg) scale(1.08); }
+  100% { transform: rotate(360deg) scale(1.04); }
 }
 
 // Launch up, smack the ceiling, tumble, settle mid-field showing the number.
@@ -274,106 +299,20 @@
 .breakdown-rolls { flex: 1; color: var(--text-2); }
 .breakdown-sub   { color: var(--gold); font-weight: 600; }
 
-// ── Throw bar / pokéball orb ─────────────────────────────────────────────────
+// ── Throw bar ──────────────────────────────────────────────────────────────
 
 .dice-throwbar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
   padding-top: 16px;
   border-top: 1px solid var(--border-soft);
 }
 
-.orb-stage {
-  position: relative;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  gap: 10px;
-}
-
-.power-gauge {
-  width: 8px;
-  height: 56px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  overflow: hidden;
-  background: color-mix(in oklch, var(--bg) 60%, #000);
-  opacity: 0.35;
-  transition: opacity .15s;
-
-  &.active { opacity: 1; }
-}
-.power-fill {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  background: linear-gradient(180deg, var(--crimson), var(--gold));
-  transition: height .05s linear;
-}
-// keep the fill anchored inside the gauge box
-.power-gauge { position: relative; }
-
-.throw-orb {
-  position: relative;
-  width: 58px;
-  height: 58px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  cursor: grab;
-  transform: translateY(var(--lift, 0));
-  transition: transform .08s linear, filter .15s;
-  touch-action: none;
-  filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.45));
-
-  &:disabled { opacity: 0.4; cursor: not-allowed; }
-  &.charging { cursor: grabbing; filter: drop-shadow(0 0 14px color-mix(in oklch, var(--gold) 80%, transparent)); }
-  &.spent { animation: orbToss .5s ease-in forwards; }
-}
-
-// d20 throwing die icon
-.orb-d20 {
-  display: block;
-  width: 100%;
-  height: 100%;
-
-  .orb-d20-body {
-    fill: var(--d20-color, #e8c98a);
-    stroke: #14151b;
-    stroke-width: 3;
-    stroke-linejoin: round;
-  }
-  .orb-d20-face {
-    fill: color-mix(in oklch, var(--d20-color, #e8c98a) 78%, #000);
-  }
-  .orb-d20-facets line {
-    stroke: rgba(20, 21, 27, 0.55);
-    stroke-width: 2;
-  }
-  .orb-d20-num {
-    fill: #14151b;
-    font-family: 'Cinzel', serif;
-    font-weight: 700;
-    font-size: 26px;
-    text-anchor: middle;
-  }
-}
-.throw-orb.charging .orb-d20 {
-  .orb-d20-body { fill: var(--gold-2, #e8c98a); }
-  .orb-d20-face { fill: color-mix(in oklch, var(--gold) 85%, #000); }
-}
-
-@keyframes orbToss {
-  0%   { transform: translateY(var(--lift, 0)) scale(1) rotate(0); opacity: 1; }
-  40%  { transform: translateY(-120px) scale(0.7) rotate(220deg); opacity: 1; }
-  60%  { transform: translateY(-180px) scale(0.4) rotate(420deg); opacity: 0.6; }
-  100% { transform: translateY(-220px) scale(0.2) rotate(680deg); opacity: 0; }
-}
-
 // ── Reduced motion: keep it usable, skip the acrobatics ──────────────────────
 @media (prefers-reduced-motion: reduce) {
   .arena-die.flying { animation: none; }
-  .throw-orb.spent { animation: none; }
+  .dice-shelf.grabbing .arena-die { animation: none; }
+  .dice-shelf { transition: none; } // no eased snap-back either
 }

--- a/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.spec.ts
+++ b/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.spec.ts
@@ -30,13 +30,6 @@ describe('DiceRollerModalComponent', () => {
     expect(component.countOf(6)).toBe(1);
   });
 
-  it('removes a die only while staging', () => {
-    component.addDie(8);
-    const id = component.staged[0].id;
-    component.removeDie(id);
-    expect(component.totalDice).toBe(0);
-  });
-
   it('cannot throw with an empty field', () => {
     expect(component.canThrow).toBeFalse();
     component.addDie(12);
@@ -78,5 +71,105 @@ describe('DiceRollerModalComponent', () => {
     component.close.subscribe(() => (closed = true));
     component.cancel();
     expect(closed).toBeTrue();
+  });
+
+  // ── Grab-and-throw cluster gesture ────────────────────────────────────────
+  // Synthetic PointerEvent-shaped objects, calling the handler methods
+  // directly — matches this file's existing style of calling component
+  // methods rather than dispatching real DOM events.
+
+  function pointerEvent(x: number, y: number): PointerEvent {
+    return {
+      clientX: x,
+      clientY: y,
+      pointerId: 1,
+      target: { setPointerCapture: () => undefined },
+      preventDefault: () => undefined,
+    } as unknown as PointerEvent;
+  }
+
+  beforeEach(() => {
+    // Deterministic clock for gesture timing — real performance.now() would
+    // make elapsed/velocity assertions flaky.
+    let now = 0;
+    spyOn(performance, 'now').and.callFake(() => now);
+    (window as any).__advanceClock = (ms: number) => (now += ms);
+  });
+
+  it('a tap on the cluster (minimal movement, short duration) rolls at power 0.45', () => {
+    component.addDie(6);
+    component.onClusterPointerDown(pointerEvent(100, 100));
+    (window as any).__advanceClock(50);
+    component.onClusterPointerUp(pointerEvent(102, 101)); // 2px move, well under threshold
+
+    expect(component.phase).toBe('rolling');
+  });
+
+  it('a slow drag below the flick threshold drops in place without rolling', () => {
+    component.addDie(6);
+    component.onClusterPointerDown(pointerEvent(100, 100));
+    (window as any).__advanceClock(50);
+    component.onClusterPointerMove(pointerEvent(120, 100)); // 20px over 50ms = 0.4px/ms
+    (window as any).__advanceClock(400);
+    component.onClusterPointerUp(pointerEvent(120, 100));
+
+    expect(component.phase).toBe('staging');
+    expect(component.canThrow).toBeTrue();
+  });
+
+  it('a fast flick above the threshold throws', () => {
+    component.addDie(6);
+    component.onClusterPointerDown(pointerEvent(100, 100));
+    (window as any).__advanceClock(10);
+    component.onClusterPointerMove(pointerEvent(300, 100)); // 200px over 10ms = 20px/ms
+    component.onClusterPointerUp(pointerEvent(300, 100));
+
+    expect(component.phase).toBe('rolling');
+  });
+
+  it('pointercancel resets drag state without rolling', () => {
+    component.addDie(6);
+    component.onClusterPointerDown(pointerEvent(100, 100));
+    (window as any).__advanceClock(10);
+    component.onClusterPointerMove(pointerEvent(300, 100));
+    component.onClusterPointerCancel();
+
+    expect(component.dragging).toBeFalse();
+    expect(component.clusterX).toBe(0);
+    expect(component.clusterY).toBe(0);
+    expect(component.phase).toBe('staging');
+  });
+
+  // ── computeVelocity: pure function, direct unit tests ─────────────────────
+
+  it('computeVelocity returns straight-line px/ms from the oldest windowed sample to release', () => {
+    const samples = [{ x: 0, y: 0, t: 0 }];
+    expect(component.computeVelocity(samples, { x: 100, y: 0, t: 100 })).toBeCloseTo(1, 5); // 100px / 100ms
+  });
+
+  it('computeVelocity handles diagonal movement via hypot', () => {
+    const samples = [{ x: 0, y: 0, t: 0 }];
+    // 30px / 100ms and 40px / 100ms → hypot(0.3, 0.4) = 0.5 px/ms
+    expect(component.computeVelocity(samples, { x: 30, y: 40, t: 100 })).toBeCloseTo(0.5, 5);
+  });
+
+  it('computeVelocity uses only the oldest sample in the window, not a per-frame sum', () => {
+    const samples = [
+      { x: 0, y: 0, t: 0 },
+      { x: 5, y: 0, t: 20 },
+      { x: 40, y: 0, t: 40 },
+    ];
+    // straight line from the oldest sample (0,0 @ t=0) to release (100,0 @ t=100)
+    expect(component.computeVelocity(samples, { x: 100, y: 0, t: 100 })).toBeCloseTo(1, 5);
+  });
+
+  it('computeVelocity returns 0 for an empty sample list', () => {
+    expect(component.computeVelocity([], { x: 100, y: 0, t: 100 })).toBe(0);
+  });
+
+  it('computeVelocity avoids division by zero on a zero-duration window', () => {
+    const samples = [{ x: 0, y: 0, t: 100 }];
+    // dt is floored at 1ms — must not throw or return Infinity/NaN
+    expect(Number.isFinite(component.computeVelocity(samples, { x: 5, y: 0, t: 100 }))).toBeTrue();
   });
 });

--- a/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.ts
+++ b/src/app/charactermanager/components/dice-roller-modal/dice-roller-modal.component.ts
@@ -53,13 +53,30 @@ export class DiceRollerModalComponent implements OnDestroy {
   staged: StagedDie[] = [];
   phase: Phase = 'staging';
 
-  // ── Pokéball throw gesture ─────────────────────────────────────────────────
-  charging = false;
-  /** 0 (tap) … 1 (full wind-up). Drives bounce height + ball lift. */
   power = 0;
-  private ballStartY = 0;
-  /** A full-strength drag spans ~180px of upward travel. */
-  private readonly MAX_DRAG = 180;
+
+  // ── Grab-and-throw gesture: the staged dice cluster itself is the drag
+  // target (Pokemon Go pokeball feel) — drag it around the arena (clamped to
+  // arena bounds), dice spin while held, release with a velocity flick to
+  // throw (speed → power); a slow release just drops the cluster in place.
+  @ViewChild('shelfEl') shelfRef?: ElementRef<HTMLElement>;
+
+  dragging = false;
+  /** Cluster's current offset from its resting position, px — drives the CSS transform. */
+  clusterX = 0;
+  clusterY = 0;
+  private dragStartX = 0;
+  private dragStartY = 0;
+  private dragStartClientX = 0;
+  private dragStartClientY = 0;
+  private dragStartTime = 0;
+  /** Rolling buffer of recent pointer samples for release-velocity — {x, y, t}[]. */
+  private pointerSamples: { x: number; y: number; t: number }[] = [];
+  private readonly VELOCITY_WINDOW_MS = 100; // only samples within the last 100ms count toward release velocity
+  private readonly TAP_MOVE_THRESHOLD = 8;   // px — under this, a pointerup is a tap not a drag
+  private readonly TAP_TIME_THRESHOLD = 300; // ms
+  private readonly FLICK_MIN_VELOCITY = 0.5; // px/ms — below this, release = drop in place, not throw
+  private readonly FLICK_MAX_VELOCITY = 2.5; // px/ms — at/above this, power = 1
 
   private nextId = 1;
   private scrambleTimer?: number;
@@ -92,11 +109,6 @@ export class DiceRollerModalComponent implements OnDestroy {
     });
   }
 
-  removeDie(id: number): void {
-    if (this.phase !== 'staging') return;
-    this.staged = this.staged.filter(d => d.id !== id);
-  }
-
   /** Drop from the palette into the arena adds a fresh die of that type. */
   onDrop(event: CdkDragDrop<unknown>): void {
     if (event.previousContainer === event.container) return;
@@ -125,29 +137,114 @@ export class DiceRollerModalComponent implements OnDestroy {
     }));
   }
 
-  // ── Pokéball charge / release ──────────────────────────────────────────────
+  // ── Grab-and-throw cluster gesture ──────────────────────────────────────────
+  // The staged dice cluster (.dice-shelf) is the grab target itself. Drag it
+  // around the arena (clamped to bounds), release with a velocity flick to
+  // throw — speed maps to power. A tap still rolls at a gentle default; a slow
+  // release just drops the cluster where it was let go, no roll.
 
-  onBallDown(event: PointerEvent): void {
-    if (!this.canThrow) return;
+  onClusterPointerDown(event: PointerEvent): void {
+    if (this.phase !== 'staging') return;
     event.preventDefault();
-    this.charging = true;
-    this.power = 0;
-    this.ballStartY = event.clientY;
+    // Keeps moves/up bound to this element even if the pointer leaves it —
+    // critical for a fast flick on a small touch target.
+    (event.target as HTMLElement).setPointerCapture?.(event.pointerId);
+    this.dragging = true;
+    this.dragStartClientX = event.clientX;
+    this.dragStartClientY = event.clientY;
+    this.dragStartX = this.clusterX;
+    this.dragStartY = this.clusterY;
+    this.dragStartTime = performance.now();
+    this.pointerSamples = [{ x: event.clientX, y: event.clientY, t: this.dragStartTime }];
   }
 
-  @HostListener('document:pointermove', ['$event'])
-  onPointerMove(event: PointerEvent): void {
-    if (!this.charging) return;
-    const dragUp = Math.max(0, this.ballStartY - event.clientY);
-    this.power = Math.min(1, dragUp / this.MAX_DRAG);
+  onClusterPointerMove(event: PointerEvent): void {
+    if (!this.dragging) return;
+    const now = performance.now();
+    const dx = event.clientX - this.dragStartClientX;
+    const dy = event.clientY - this.dragStartClientY;
+
+    // Clamp so the cluster can't be dragged out of the arena — same
+    // rect-measurement approach as throwDice's flight clamping.
+    const arenaRect = this.arenaRef?.nativeElement.getBoundingClientRect();
+    const shelfRect = this.shelfRef?.nativeElement.getBoundingClientRect();
+    let clampedDx = dx;
+    let clampedDy = dy;
+    if (arenaRect && shelfRect) {
+      const margin = 10;
+      const minDx = arenaRect.left - shelfRect.left + margin;
+      const maxDx = arenaRect.right - shelfRect.right - margin;
+      const minDy = arenaRect.top - shelfRect.top + margin;
+      const maxDy = arenaRect.bottom - shelfRect.bottom - margin;
+      clampedDx = Math.min(maxDx, Math.max(minDx, dx));
+      clampedDy = Math.min(maxDy, Math.max(minDy, dy));
+    }
+    this.clusterX = this.dragStartX + clampedDx;
+    this.clusterY = this.dragStartY + clampedDy;
+
+    this.pointerSamples.push({ x: event.clientX, y: event.clientY, t: now });
+    const cutoff = now - this.VELOCITY_WINDOW_MS;
+    while (this.pointerSamples.length > 2 && this.pointerSamples[0].t < cutoff) {
+      this.pointerSamples.shift();
+    }
   }
 
-  @HostListener('document:pointerup')
-  onPointerUp(): void {
-    if (!this.charging) return;
-    this.charging = false;
-    // A bare tap (no meaningful drag) still throws, at a gentle default power.
-    this.throwDice(this.power < 0.05 ? 0.45 : this.power);
+  onClusterPointerUp(event: PointerEvent): void {
+    if (!this.dragging) return;
+    this.dragging = false;
+
+    const now = performance.now();
+    const totalDx = event.clientX - this.dragStartClientX;
+    const totalDy = event.clientY - this.dragStartClientY;
+    const totalDist = Math.hypot(totalDx, totalDy);
+    const elapsed = now - this.dragStartTime;
+
+    if (totalDist < this.TAP_MOVE_THRESHOLD && elapsed < this.TAP_TIME_THRESHOLD) {
+      // Tap: roll at the existing gentle default — the cluster never moved.
+      this.throwDice(0.45);
+      return;
+    }
+
+    const speed = this.computeVelocity(this.pointerSamples, { x: event.clientX, y: event.clientY, t: now });
+
+    if (speed < this.FLICK_MIN_VELOCITY) {
+      // Slow release: drop in place (cluster stays wherever it was let go; no roll).
+      return;
+    }
+
+    const power = Math.min(1, (speed - this.FLICK_MIN_VELOCITY) / (this.FLICK_MAX_VELOCITY - this.FLICK_MIN_VELOCITY));
+    // Reset the drag offset before throwDice runs, so its dx/peak/rest math
+    // (which assumes dice start at their resting shelf position) is
+    // undisturbed by wherever the cluster was dragged to.
+    this.clusterX = 0;
+    this.clusterY = 0;
+    this.throwDice(power);
+  }
+
+  onClusterPointerCancel(): void {
+    // iOS fires this on OS interruptions (e.g. a notification banner) —
+    // abandon the drag and snap the cluster home; never throw.
+    this.dragging = false;
+    this.clusterX = 0;
+    this.clusterY = 0;
+  }
+
+  /**
+   * Straight-line release velocity in px/ms, from the OLDEST sample still in
+   * the trailing window to the release point — not a sum of per-frame deltas,
+   * which would overweight jittery high-frequency samples. A pure function so
+   * it's directly unit-testable without mocking performance.now()/the DOM.
+   */
+  computeVelocity(
+    samples: { x: number; y: number; t: number }[],
+    release: { x: number; y: number; t: number },
+  ): number {
+    if (!samples.length) return 0;
+    const oldest = samples[0];
+    const dt = Math.max(1, release.t - oldest.t); // avoid div-by-zero on a single-sample window
+    const vx = (release.x - oldest.x) / dt;
+    const vy = (release.y - oldest.y) / dt;
+    return Math.hypot(vx, vy);
   }
 
   /** Keyboard / click fallback for the throw. */


### PR DESCRIPTION
Replaces the separate throw-orb apparatus with the staged dice cluster itself as the grab target (Pokemon Go pokeball feel): drag it around the arena (clamped to bounds), dice spin while held, release with a velocity flick to throw — speed maps to power. A slow release drops the cluster in place; a tap or the repurposed "Roll" button/Enter/ Space still rolls at the existing default power. Per-die click-to-remove is dropped (Clear + palette re-add remains the removal path). Release velocity is computed by a pure, directly-unit-tested function from a trailing 100ms window of pointer samples.