### PR TITLE
chore: remove deprecated @angular/animations package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "character-creator",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "^21.2.18",
         "@angular/cdk": "^21.2.14",
         "@angular/common": "^21.2.18",
         "@angular/compiler": "^21.2.18",
@@ -799,22 +798,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/@angular/animations": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
-      "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "21.2.18"
       }
     },
     "node_modules/@angular/build": {
@@ -16349,15 +16332,6 @@
           "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
           "dev": true
         }
-      }
-    },
-    "@angular/animations": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
-      "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
-      "peer": true,
-      "requires": {
-        "tslib": "^2.3.0"
       }
     },
     "@angular/build": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^21.2.18",
     "@angular/cdk": "^21.2.14",
     "@angular/common": "^21.2.18",
     "@angular/compiler": "^21.2.18",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,7 +4,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { Routes, RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LoginComponent } from './charactermanager/components/login/login.component';
 import { RegisterComponent } from './charactermanager/components/register/register.component';
 import { FormsModule } from '@angular/forms';
@@ -27,7 +26,6 @@ const routes: Routes = [
         RegisterComponent,
     ],
     bootstrap: [AppComponent], imports: [BrowserModule,
-        BrowserAnimationsModule,
         FormsModule,
         RouterModule.forRoot(routes)], providers: [
         { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },


### PR DESCRIPTION
Zero production usage (no trigger(), no [@...] bindings) and the package is deprecated since v20.2; Material 21 slide-toggle/tooltip and CDK drag-drop no longer require BrowserAnimationsModule. Drops the module from AppModule and the dependency from package.json. Initial bundle: 497.19 kB -> 433.33 kB raw (-63.9 kB), 111.66 kB estimated transfer.