### PR TITLE
feat: password recovery via admin-issued reset links and change-password

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 import { LoginComponent } from './charactermanager/components/login/login.component';
 import { RegisterComponent } from './charactermanager/components/register/register.component';
+import { ResetPasswordComponent } from './charactermanager/components/reset-password/reset-password.component';
 import { FormsModule } from '@angular/forms';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { AuthInterceptor } from './interceptors/auth.interceptor';
@@ -17,6 +18,8 @@ const routes: Routes = [
   { path: '',             redirectTo: 'login', pathMatch: 'full' },
   { path: 'login',        component: LoginComponent,    canActivate: [guestGuard] },
   { path: 'register',     component: RegisterComponent, canActivate: [guestGuard] },
+  // No guard: a reset link must work whether or not someone is signed in.
+  { path: 'reset-password', component: ResetPasswordComponent },
   { path: 'charactermanager', canActivate: [authGuard], loadChildren: () => import('./charactermanager/charactermanager.module').then(m => m.CharactermanagerModule) }
 ];
 
@@ -24,6 +27,7 @@ const routes: Routes = [
         AppComponent,
         LoginComponent,
         RegisterComponent,
+        ResetPasswordComponent,
     ],
     bootstrap: [AppComponent], imports: [BrowserModule,
         FormsModule,

--- a/src/app/charactermanager/components/login/login.component.html
+++ b/src/app/charactermanager/components/login/login.component.html
@@ -89,5 +89,9 @@
             <a routerLink="/register" class="auth-link">Create an account</a>
           </div>
 
+          <div class="auth-footer">
+            Forgot your password? Ask your DM for a reset link.
+          </div>
+
         </div>
       </div>

--- a/src/app/charactermanager/components/reset-password/reset-password.component.html
+++ b/src/app/charactermanager/components/reset-password/reset-password.component.html
@@ -1,0 +1,86 @@
+<div class="login-page">
+  <div class="login-card">
+
+    <!-- Brand -->
+    <div class="login-brand">
+      <div class="login-brand-name">Table Mimic</div>
+      <div class="login-brand-sub">Reset your password</div>
+    </div>
+
+    <div class="login-divider"></div>
+
+    @if (!done) {
+      <form (ngSubmit)="submit()" #resetForm="ngForm">
+        <div class="field">
+          <label for="newPassword">New password</label>
+          <div class="input-reveal">
+            <input
+              [type]="showPassword ? 'text' : 'password'"
+              id="newPassword"
+              [(ngModel)]="newPassword"
+              name="newPassword"
+              required
+              placeholder="At least 8 characters"
+              autocomplete="new-password">
+            <button type="button" class="reveal-toggle" (click)="showPassword = !showPassword"
+              [attr.aria-label]="showPassword ? 'Hide password' : 'Show password'">
+              @if (!showPassword) {
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
+              }
+              @if (showPassword) {
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94"/>
+                  <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19"/>
+                  <line x1="1" y1="1" x2="23" y2="23"/>
+                </svg>
+              }
+            </button>
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="confirmPassword">Confirm new password</label>
+          <input
+            [type]="showPassword ? 'text' : 'password'"
+            id="confirmPassword"
+            [(ngModel)]="confirmPassword"
+            name="confirmPassword"
+            required
+            placeholder="Repeat the new password"
+            autocomplete="new-password">
+        </div>
+
+        @if (errorMessage) {
+          <div class="login-error">
+            {{ errorMessage }}
+          </div>
+        }
+
+        <button
+          type="submit"
+          class="btn primary login-submit"
+          [disabled]="resetForm.invalid || !token || submitting">
+          Set New Password
+        </button>
+      </form>
+    }
+
+    @if (done) {
+      <div class="reset-done">
+        <p>Your password has been reset.</p>
+        <a routerLink="/login" class="btn primary login-submit">Back to Sign In</a>
+      </div>
+    }
+
+    @if (!done) {
+      <div class="auth-footer">
+        Remembered it after all?
+        <a routerLink="/login" class="auth-link">Sign in</a>
+      </div>
+    }
+
+  </div>
+</div>

--- a/src/app/charactermanager/components/reset-password/reset-password.component.scss
+++ b/src/app/charactermanager/components/reset-password/reset-password.component.scss
@@ -1,0 +1,16 @@
+// Auth card chrome is defined globally in styles.css (.login-page, .login-card, etc.)
+// Only the success state below is component-specific.
+
+.reset-done {
+  text-align: center;
+
+  p {
+    margin: 0 0 16px;
+    color: var(--text-dim);
+  }
+
+  a.login-submit {
+    display: block;
+    text-decoration: none;
+  }
+}

--- a/src/app/charactermanager/components/reset-password/reset-password.component.spec.ts
+++ b/src/app/charactermanager/components/reset-password/reset-password.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ResetPasswordComponent } from './reset-password.component';
+import { AuthService } from '../../services/auth.service';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+
+describe('ResetPasswordComponent', () => {
+  let component: ResetPasswordComponent;
+  let fixture: ComponentFixture<ResetPasswordComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+
+  async function setup(token: string | null): Promise<void> {
+    const authSpy = jasmine.createSpyObj('AuthService', ['resetPassword']);
+
+    await TestBed.configureTestingModule({
+      declarations: [ResetPasswordComponent],
+      imports: [FormsModule],
+      providers: [
+        { provide: AuthService, useValue: authSpy },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: convertToParamMap(token === null ? {} : { token }) } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResetPasswordComponent);
+    component = fixture.componentInstance;
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+    fixture.detectChanges();
+  }
+
+  it('reads the token from the query string', async () => {
+    await setup('abc123');
+    expect(component.token).toBe('abc123');
+    expect(component.errorMessage).toBe('');
+  });
+
+  it('shows an error when the link has no token', async () => {
+    await setup(null);
+    expect(component.errorMessage).toBeTruthy();
+  });
+
+  it('rejects a short password without calling the backend', async () => {
+    await setup('abc123');
+    component.newPassword = component.confirmPassword = 'short';
+
+    component.submit();
+
+    expect(component.errorMessage).toBeTruthy();
+    expect(authService.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('rejects mismatched passwords without calling the backend', async () => {
+    await setup('abc123');
+    component.newPassword = 'longenough1';
+    component.confirmPassword = 'different1';
+
+    component.submit();
+
+    expect(component.errorMessage).toBeTruthy();
+    expect(authService.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it('submits the token and new password, then shows the done state', async () => {
+    await setup('abc123');
+    authService.resetPassword.and.returnValue(of({ success: true }));
+    component.newPassword = component.confirmPassword = 'longenough1';
+
+    component.submit();
+
+    expect(authService.resetPassword).toHaveBeenCalledWith('abc123', 'longenough1');
+    expect(component.done).toBeTrue();
+  });
+
+  it('shows the invalid-or-expired error when the backend rejects the token', async () => {
+    await setup('abc123');
+    authService.resetPassword.and.returnValue(of({ success: false }));
+    component.newPassword = component.confirmPassword = 'longenough1';
+
+    component.submit();
+
+    expect(component.done).toBeFalse();
+    expect(component.errorMessage).toContain('invalid or has expired');
+  });
+});

--- a/src/app/charactermanager/components/reset-password/reset-password.component.ts
+++ b/src/app/charactermanager/components/reset-password/reset-password.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
+
+/**
+ * Landing page for an admin-issued reset link
+ * (/reset-password?token=...). The user picks a new password; on success
+ * they're pointed back to the normal sign-in. Unrouted-token and expired
+ * cases share one generic error, matching the backend.
+ */
+@Component({
+    selector: 'app-reset-password',
+    templateUrl: './reset-password.component.html',
+    styleUrls: ['./reset-password.component.scss'],
+    standalone: false
+})
+export class ResetPasswordComponent implements OnInit {
+  token = '';
+  newPassword = '';
+  confirmPassword = '';
+  showPassword = false;
+  errorMessage = '';
+  done = false;
+  submitting = false;
+
+  constructor(private route: ActivatedRoute, private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.token = this.route.snapshot.queryParamMap.get('token') ?? '';
+    if (!this.token) {
+      this.errorMessage = 'This reset link is incomplete — ask your DM for a new one.';
+    }
+  }
+
+  submit(): void {
+    this.errorMessage = '';
+    if (this.newPassword.length < 8) {
+      this.errorMessage = 'Password must be at least 8 characters.';
+      return;
+    }
+    if (this.newPassword !== this.confirmPassword) {
+      this.errorMessage = 'Passwords do not match.';
+      return;
+    }
+    this.submitting = true;
+    this.authService.resetPassword(this.token, this.newPassword).subscribe(response => {
+      this.submitting = false;
+      if (response.success) {
+        this.done = true;
+      } else {
+        this.errorMessage = 'This reset link is invalid or has expired — ask your DM for a new one.';
+      }
+    });
+  }
+}

--- a/src/app/charactermanager/components/settings-panel/settings-panel.component.html
+++ b/src/app/charactermanager/components/settings-panel/settings-panel.component.html
@@ -36,6 +36,80 @@
       </div>
     </div>
 
+    <!-- Security -->
+    @if (!demoMode) {
+      <div class="slideover-section">
+        <span class="panel-title">Security</span>
+        <div class="pref-row">
+          <div>
+            <div class="pref-label">Password</div>
+            <div class="pref-sub">change your sign-in password</div>
+          </div>
+          <button class="btn" type="button" (click)="toggleChangePassword()">
+            {{ showChangePassword ? 'Cancel' : 'Change' }}
+          </button>
+        </div>
+        @if (showChangePassword) {
+          <div class="field">
+            <label for="currentPassword">Current password</label>
+            <input type="password" id="currentPassword" [(ngModel)]="currentPassword"
+              name="currentPassword" autocomplete="current-password">
+          </div>
+          <div class="field">
+            <label for="newPassword">New password</label>
+            <input type="password" id="newPassword" [(ngModel)]="newPassword"
+              name="newPassword" placeholder="At least 8 characters" autocomplete="new-password">
+          </div>
+          <div class="field">
+            <label for="confirmPassword">Confirm new password</label>
+            <input type="password" id="confirmPassword" [(ngModel)]="confirmPassword"
+              name="confirmPassword" autocomplete="new-password">
+          </div>
+          @if (passwordError) {
+            <div class="login-error">{{ passwordError }}</div>
+          }
+          <button class="btn primary" type="button" (click)="savePassword()"
+            [disabled]="savingPassword || !currentPassword || !newPassword || !confirmPassword">
+            Save Password
+          </button>
+        }
+        @if (passwordSaved) {
+          <div class="pref-sub">Password changed.</div>
+        }
+      </div>
+    }
+
+    <!-- Admin: password reset links -->
+    @if (!demoMode && user.isAdmin) {
+      <div class="slideover-section">
+        <span class="panel-title">Admin · Reset Links</span>
+        <div class="pref-sub" style="margin-bottom: 8px;">
+          Generate a one-time password-reset link and send it to the player yourself.
+        </div>
+        <div class="field">
+          <label for="resetUserName">Username</label>
+          <input type="text" id="resetUserName" [(ngModel)]="resetUserName"
+            name="resetUserName" placeholder="Who forgot their password?" autocomplete="off">
+        </div>
+        @if (resetError) {
+          <div class="login-error">{{ resetError }}</div>
+        }
+        <button class="btn primary" type="button" (click)="generateResetLink()"
+          [disabled]="generatingReset || !resetUserName.trim()">
+          Generate Reset Link
+        </button>
+        @if (resetLink) {
+          <div class="field" style="margin-top: 10px;">
+            <label>One-time link (expires in 24h)</label>
+            <input type="text" [value]="resetLink" readonly (focus)="$any($event.target).select()">
+          </div>
+          <button class="btn" type="button" (click)="copyResetLink()">
+            {{ resetLinkCopied ? 'Copied!' : 'Copy Link' }}
+          </button>
+        }
+      </div>
+    }
+
     <!-- Default Theme -->
     <div class="slideover-section">
       <span class="panel-title">Default Theme</span>

--- a/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
+++ b/src/app/charactermanager/components/settings-panel/settings-panel.component.ts
@@ -5,6 +5,7 @@ import { CurrentUserService } from '../../services/current-user.service';
 import { AuthService } from '../../services/auth.service';
 import { DicePrefs } from '../../models/campaign';
 import { tintFor } from '../../utils/character-math';
+import { environment } from '../../../../environments/environment';
 
 interface ThemeSwatch {
   id: Theme;
@@ -27,6 +28,25 @@ export class SettingsPanelComponent {
   user = this.currentUser.getUser();
   theme$ = this.prefs.theme$;
   dice$ = this.prefs.dice$;
+
+  // Password sections are meaningless in demo mode (no backend, fake login).
+  get demoMode(): boolean { return environment.demoMode; }
+
+  // ── Change password ──
+  showChangePassword = false;
+  currentPassword = '';
+  newPassword = '';
+  confirmPassword = '';
+  passwordError = '';
+  passwordSaved = false;
+  savingPassword = false;
+
+  // ── Admin: reset links ──
+  resetUserName = '';
+  resetLink = '';
+  resetError = '';
+  resetLinkCopied = false;
+  generatingReset = false;
 
   readonly themes: ThemeSwatch[] = [
     { id: 'midnight',  label: 'Midnight',  bg: '#0d1224', gold: '#d4b06a', accent: '#8fb4ff' },
@@ -55,6 +75,63 @@ export class SettingsPanelComponent {
   toggleDice(key: 'showMods' | 'advPrompt' | 'critFx'): void {
     const dice = this.prefs.dice;
     this.prefs.setDice({ ...dice, [key]: !dice[key] });
+  }
+
+  toggleChangePassword(): void {
+    this.showChangePassword = !this.showChangePassword;
+    this.passwordError = '';
+    this.passwordSaved = false;
+  }
+
+  savePassword(): void {
+    this.passwordError = '';
+    this.passwordSaved = false;
+    if (this.newPassword.length < 8) {
+      this.passwordError = 'New password must be at least 8 characters.';
+      return;
+    }
+    if (this.newPassword !== this.confirmPassword) {
+      this.passwordError = 'New passwords do not match.';
+      return;
+    }
+    this.savingPassword = true;
+    this.auth.changePassword(this.currentPassword, this.newPassword).subscribe(response => {
+      this.savingPassword = false;
+      if (response.success) {
+        this.passwordSaved = true;
+        this.currentPassword = this.newPassword = this.confirmPassword = '';
+      } else {
+        // The backend rejects a wrong current password with a 400 + message.
+        this.passwordError = 'Could not change password — check your current password.';
+      }
+    });
+  }
+
+  generateResetLink(): void {
+    this.resetError = '';
+    this.resetLink = '';
+    this.resetLinkCopied = false;
+    const userName = this.resetUserName.trim();
+    if (!userName) return;
+    this.generatingReset = true;
+    this.auth.issueResetToken(userName).subscribe({
+      next: response => {
+        this.generatingReset = false;
+        // The backend returns only the raw token; the shareable link is
+        // composed here so no base-URL config exists server-side.
+        this.resetLink = `${location.origin}/reset-password?token=${response.token}`;
+      },
+      error: () => {
+        this.generatingReset = false;
+        this.resetError = `No user named “${userName}” was found.`;
+      },
+    });
+  }
+
+  copyResetLink(): void {
+    navigator.clipboard?.writeText(this.resetLink).then(() => {
+      this.resetLinkCopied = true;
+    });
   }
 
   signOut(): void {

--- a/src/app/charactermanager/models/campaign.ts
+++ b/src/app/charactermanager/models/campaign.ts
@@ -136,4 +136,6 @@ export interface CurrentUser {
   tint: CampaignTint;
   title?: string;
   member_since?: string;
+  /** True when the auth service reports the ADMIN role (site owner). */
+  isAdmin?: boolean;
 }

--- a/src/app/charactermanager/services/auth.service.ts
+++ b/src/app/charactermanager/services/auth.service.ts
@@ -16,6 +16,12 @@ export interface AuthResponse {
   error?: unknown;
 }
 
+/** An admin-issued one-time reset token; the UI composes the shareable link. */
+export interface ResetTokenResponse {
+  token: string;
+  expiresAt: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -56,6 +62,40 @@ export class AuthService {
         }
       }),
       catchError(err => of({ success: false, error: err }))
+    );
+  }
+
+  /**
+   * Redeem an admin-issued one-time reset token for a new password (public
+   * endpoint — the user is locked out, so no Authorization header applies).
+   */
+  resetPassword(token: string, newPassword: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(this.authUrl + '/reset-password', { token, newPassword }).pipe(
+      catchError(err => of({ success: false, error: err }))
+    );
+  }
+
+  /**
+   * Change the signed-in user's password. Lives under /api/v1/account (not
+   * /api/v1/auth), so the auth interceptor attaches the Bearer token.
+   */
+  changePassword(currentPassword: string, newPassword: string): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(
+      `${environment.authApiUrl}/api/v1/account/change-password`,
+      { currentPassword, newPassword }
+    ).pipe(
+      catchError(err => of({ success: false, error: err }))
+    );
+  }
+
+  /**
+   * Admin only (enforced server-side): mint a one-time reset token for the
+   * given user. The caller composes `${origin}/reset-password?token=...` and
+   * hands the link to the user out-of-band. Errors propagate to the caller.
+   */
+  issueResetToken(userName: string): Observable<ResetTokenResponse> {
+    return this.http.post<ResetTokenResponse>(
+      `${environment.authApiUrl}/api/admin/users/${encodeURIComponent(userName)}/reset-token`, {}
     );
   }
 

--- a/src/app/charactermanager/services/current-user.service.ts
+++ b/src/app/charactermanager/services/current-user.service.ts
@@ -9,6 +9,7 @@ interface AuthorizeResponse {
   email?: string;
   userName?: string;
   username?: string;
+  roles?: string[];
 }
 
 /**
@@ -46,6 +47,7 @@ export class CurrentUserService {
     this.user.name = username || 'Adventurer';
     this.user.initials = this.initialsOf(this.user.name);
     this.user.email = '';
+    this.user.isAdmin = false;
 
     if (environment.demoMode) return;
 
@@ -62,6 +64,7 @@ export class CurrentUserService {
           this.user.name = name;
           this.user.initials = this.initialsOf(name);
         }
+        this.user.isAdmin = dto?.roles?.includes('ADMIN') ?? false;
       },
       error: () => { /* keep the username-derived display, no email */ },
     });


### PR DESCRIPTION
- /reset-password page redeems a one-time token from the link's query string
- settings panel: Security section (change password) and admin-only Reset Links section that composes ${origin}/reset-password?token=... from the raw token the backend returns (no server-side base-URL config)
- CurrentUserService captures roles from /authorize to gate the admin tool
- login page nudge: ask your DM for a reset link
- pairs with authentication-service feature/password-recovery