### PR TITLE
Feature/dd item bulk catalog (#226)

### DIFF
--- a/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.html
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.html
@@ -85,6 +85,9 @@
               <div class="item-main">
                 <span class="item-name">{{ item.name }}</span>
                 <span class="item-meta">{{ itemMeta(item) }}</span>
+                @if (item.customNotes) {
+                  <span class="item-notes">{{ item.customNotes }}</span>
+                }
               </div>
               <input class="num-input qty-input" type="number" min="1" [ngModel]="item.qty"
                 (ngModelChange)="changeQty(item, $event)" title="Quantity" />

--- a/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.scss
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.scss
@@ -129,6 +129,12 @@
   font-size: 0.78rem;
   color: var(--muted, rgba(255, 255, 255, 0.6));
 }
+.item-notes {
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  overflow-wrap: anywhere;
+}
 
 .btn-x {
   width: 26px;

--- a/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.spec.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.spec.ts
@@ -87,9 +87,9 @@ describe('CuratedLootComponent', () => {
     expect(service.setCoins).toHaveBeenCalledWith(5, 10);
   });
 
-  it('itemMeta summarizes a custom line’s attributes', () => {
+  it('itemMeta summarizes a custom line’s attributes (notes render separately)', () => {
     expect(component.itemMeta(loot.items[1]))
-      .toBe('weapon · 1d8 slashing + 2d6 fire · 3 lb · 5000 gp · Ignites.');
+      .toBe('weapon · 1d8 slashing + 2d6 fire · 3 lb · 5000 gp');
     expect(component.itemMeta(loot.items[0])).toBe('Catalog item');
   });
 

--- a/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-loot/curated-loot.component.ts
@@ -158,7 +158,7 @@ export class CuratedLootComponent implements OnChanges {
     if (item.armorClass) parts.push(`AC ${item.armorClass}`);
     if (item.weight != null) parts.push(`${item.weight} lb`);
     if (item.unitCostCp != null) parts.push(formatCp(item.unitCostCp));
-    if (item.customNotes) parts.push(item.customNotes);
+    // Notes render on their own line under the row, not squeezed in here.
     return parts.length ? parts.join(' · ') : 'Custom item';
   }
 

--- a/src/app/charactermanager/components/campaign-dashboard/curated-shops/curated-shops.component.ts
+++ b/src/app/charactermanager/components/campaign-dashboard/curated-shops/curated-shops.component.ts
@@ -40,6 +40,7 @@ export class CuratedShopsComponent implements OnChanges {
     { value: 'ARMOR', label: 'Armor' },
     { value: 'MATERIAL_COMPONENT', label: 'Components' },
     { value: 'GEAR', label: 'Gear' },
+    { value: 'TRANSPORT', label: 'Transport' },
   ];
 
   readonly formatCp = formatCp;

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.html
@@ -77,6 +77,9 @@
               <span> · {{ formatCp(item.unitCostCp) }}</span>
             }
           </span>
+          @if (item.notes) {
+            <span class="inv-item-notes">{{ item.notes }}</span>
+          }
         </div>
         @if (editable) {
           <div class="inv-controls">

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.scss
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.scss
@@ -55,6 +55,13 @@
   }
 }
 
+.inv-item-notes {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
+
 .inv-equipped-tag {
   margin-left: 6px;
   color: var(--accent, gold);

--- a/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
+++ b/src/app/charactermanager/components/character-sheet/panels/inventory-panel/inventory-panel.component.ts
@@ -97,6 +97,7 @@ export class InventoryPanelComponent {
       case 'armor': return 'Armor';
       case 'material-component': return 'Material';
       case 'gear': return 'Gear';
+      case 'transport': return 'Transport';
       default: return category;
     }
   }

--- a/src/app/charactermanager/components/item-composer/item-composer.component.html
+++ b/src/app/charactermanager/components/item-composer/item-composer.component.html
@@ -32,7 +32,7 @@
             <label class="composer-option" [class.on]="catalogSelectedKey === item.itemKey">
               <input type="radio" name="composerCatalogItem" [value]="item.itemKey" [(ngModel)]="catalogSelectedKey">
               <span class="composer-option-name">{{ item.name }}</span>
-              <span class="composer-option-meta">{{ formatCp(item.costCp) }}</span>
+              <span class="composer-option-meta">{{ formatCp(item.costCp) }} · {{ item.bulk }} bulk</span>
             </label>
           }
           @if (!filteredCatalog.length) {
@@ -60,12 +60,13 @@
           <option value="armor">Armor</option>
           <option value="material-component">Material</option>
           <option value="gear">Gear</option>
+          <option value="transport">Transport</option>
         </select>
         <input type="number" min="1" [(ngModel)]="customQty" class="composer-qty" aria-label="Quantity">
       </div>
       <div class="composer-row">
         <input type="number" min="0" [(ngModel)]="customValueGp" class="composer-qty" placeholder="Value (gp)" aria-label="Value in gold">
-        <input type="number" min="0" [(ngModel)]="customWeight" class="composer-qty" placeholder="Weight (lb)" aria-label="Weight in pounds">
+        <input type="number" min="0" [(ngModel)]="customWeight" class="composer-qty" placeholder="Weight (lb, 0 = tiny)" aria-label="Weight in pounds (0 means negligible — 0.2 bulk)">
       </div>
       @if (customCategory === 'weapon') {
         <input type="text" [(ngModel)]="customDamage" class="composer-text"

--- a/src/app/charactermanager/components/item-composer/item-composer.component.spec.ts
+++ b/src/app/charactermanager/components/item-composer/item-composer.component.spec.ts
@@ -168,4 +168,20 @@ describe('pcItemFromAuthored', () => {
       kind: 'custom', name: 'Mithral Plate', category: 'armor', qty: 1, armorClass: '18',
     })).toEqual({ name: 'Mithral Plate', category: 'armor', qty: 1, bulk: 1, armorClass: '18' });
   });
+
+  it('denormalizes a TRANSPORT catalog pick — fractional-safe bulk and ride notes intact', () => {
+    const pony: CatalogItem = {
+      itemKey: 'pony', name: 'Pony', category: 'TRANSPORT', costCp: 3000,
+      bulk: 20, details: { notes: 'Mount — Medium, speed 40 ft, carries 20 slots' },
+    };
+    expect(pcItemFromAuthored({ kind: 'catalog', item: pony, qty: 1 })).toEqual({
+      catalogKey: 'pony',
+      name: 'Pony',
+      category: 'transport',
+      qty: 1,
+      unitCostCp: 3000,
+      bulk: 20,
+      notes: 'Mount — Medium, speed 40 ft, carries 20 slots',
+    });
+  });
 });

--- a/src/app/charactermanager/components/item-composer/item-composer.component.ts
+++ b/src/app/charactermanager/components/item-composer/item-composer.component.ts
@@ -36,7 +36,7 @@ export class ItemComposerComponent implements OnInit {
   constructor(private shopService: ShopService) {}
 
   readonly demoMode = environment.demoMode;
-  readonly categories: ShopCategory[] = ['WEAPON', 'ARMOR', 'MATERIAL_COMPONENT', 'GEAR'];
+  readonly categories: ShopCategory[] = ['WEAPON', 'ARMOR', 'MATERIAL_COMPONENT', 'GEAR', 'TRANSPORT'];
   readonly categoryLabelFor = categoryLabelFor;
   readonly formatCp = formatCp;
 
@@ -94,6 +94,7 @@ export class ItemComposerComponent implements OnInit {
       case 'armor': return 'Armor';
       case 'material-component': return 'Material';
       case 'gear': return 'Gear';
+      case 'transport': return 'Transport';
       default: return category;
     }
   }

--- a/src/app/charactermanager/components/session-mode/loot-panel/loot-panel.component.html
+++ b/src/app/charactermanager/components/session-mode/loot-panel/loot-panel.component.html
@@ -70,10 +70,13 @@
                             <span class="item-name">{{ item.name }}</span>
                             <span class="item-meta">
                               @if (item.custom) {
-                                {{ item.customNotes || 'Custom item' }} ·
+                                Custom item ·
                               }
                               {{ item.qtyRemaining }} of {{ item.qty }} left
                             </span>
+                            @if (item.customNotes) {
+                              <span class="item-notes">{{ item.customNotes }}</span>
+                            }
                           </div>
                           <input class="num-input qty-input" type="number" min="1" [ngModel]="item.qty"
                             (ngModelChange)="changeQty(item, $event)" title="Quantity" />
@@ -114,11 +117,11 @@
                               <div class="item-main">
                                 <span class="item-name">{{ item.name }}</span>
                                 <span class="item-meta">
-                                  @if (item.custom && item.customNotes) {
-                                    {{ item.customNotes }} ·
-                                  }
                                   {{ item.qtyRemaining > 0 ? item.qtyRemaining + ' left' : 'All claimed' }}
                                 </span>
+                                @if (item.customNotes) {
+                                  <span class="item-notes">{{ item.customNotes }}</span>
+                                }
                               </div>
                               @if (myParticipant && item.qtyRemaining > 0) {
                                 @if (item.qtyRemaining > 1) {

--- a/src/app/charactermanager/components/session-mode/loot-panel/loot-panel.component.scss
+++ b/src/app/charactermanager/components/session-mode/loot-panel/loot-panel.component.scss
@@ -133,6 +133,13 @@
   color: var(--muted, rgba(255, 255, 255, 0.6));
 }
 
+.item-notes {
+  font-size: 0.8rem;
+  font-style: italic;
+  color: var(--muted, rgba(255, 255, 255, 0.6));
+  overflow-wrap: anywhere;
+}
+
 .qty-input { width: 70px; }
 
 .btn.buy {

--- a/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
+++ b/src/app/charactermanager/components/session-mode/shop-panel/shop-panel.component.ts
@@ -46,6 +46,7 @@ export class ShopPanelComponent implements OnChanges {
     { value: 'ARMOR', label: 'Armor' },
     { value: 'MATERIAL_COMPONENT', label: 'Components' },
     { value: 'GEAR', label: 'Gear' },
+    { value: 'TRANSPORT', label: 'Transport' },
   ];
 
   /** Guards re-fetching the catalog on every 2s poll; only refetch on a real change. */
@@ -125,6 +126,8 @@ export class ShopPanelComponent implements OnChanges {
     } else if (cat === 'MATERIAL_COMPONENT') {
       const consumed = item.details?.['consumedOnCast'] ? 'consumed on cast' : 'reusable';
       fields = [this.detail(item, 'spell'), consumed];
+    } else if (cat === 'TRANSPORT') {
+      fields = [this.detail(item, 'notes')];   // ride stats, e.g. "Mount — Large, speed 50 ft…"
     } else {
       fields = [this.detail(item, 'damage'), this.detail(item, 'properties')];
     }
@@ -137,6 +140,7 @@ export class ShopPanelComponent implements OnChanges {
       case 'ARMOR': return 'Armor';
       case 'MATERIAL_COMPONENT': return 'Component';
       case 'GEAR': return 'Gear';
+      case 'TRANSPORT': return 'Transport';
       default: return 'Weapon';
     }
   }

--- a/src/app/charactermanager/models/loot.ts
+++ b/src/app/charactermanager/models/loot.ts
@@ -9,7 +9,7 @@ import { PcItem } from './pc';
 
 /** The lowercase inventory categories a custom loot item may carry. */
 export const LOOT_ITEM_CATEGORIES: ReadonlyArray<PcItem['category']> =
-  ['weapon', 'armor', 'material-component', 'gear'];
+  ['weapon', 'armor', 'material-component', 'gear', 'transport'];
 
 export interface LootItem {
   id: number;

--- a/src/app/charactermanager/models/pc.ts
+++ b/src/app/charactermanager/models/pc.ts
@@ -24,7 +24,7 @@ export interface PcSpell {
 export interface PcItem {
   catalogKey?: string;          // SRD slug, e.g. 'longsword'; absent for ad-hoc items
   name: string;
-  category: 'weapon' | 'armor' | 'material-component' | 'gear';
+  category: 'weapon' | 'armor' | 'material-component' | 'gear' | 'transport';
   qty: number;
   unitCostCp?: number;          // unit price paid, in copper
   weight?: number;

--- a/src/app/charactermanager/models/shop.ts
+++ b/src/app/charactermanager/models/shop.ts
@@ -7,7 +7,7 @@
 import { PcItem } from './pc';
 import { bulkFromWeight } from '../utils/slot-inventory';
 
-export type ShopCategory = 'WEAPON' | 'ARMOR' | 'MATERIAL_COMPONENT' | 'GEAR';
+export type ShopCategory = 'WEAPON' | 'ARMOR' | 'MATERIAL_COMPONENT' | 'GEAR' | 'TRANSPORT';
 
 /**
  * One entry from the raw SRD catalog browse (`GET /api/v1/catalog`), used by the

--- a/src/app/charactermanager/utils/slot-inventory.spec.ts
+++ b/src/app/charactermanager/utils/slot-inventory.spec.ts
@@ -81,6 +81,31 @@ describe('slot-inventory util', () => {
       ];
       expect(usedSlots(stocked)).toBe(5);
     });
+
+    it('charges 0.2 per ration bought beyond box capacity', () => {
+      // 1 box (holds 5) + 9 rations: 4 loose rations ride outside the box.
+      const overflowing: PcItem[] = [
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: 1, bulk: 1 },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1, bulk: 1 },
+        { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 9, bulk: 0.2 },
+        { catalogKey: 'water', name: 'Water', category: 'gear', qty: 5, bulk: 0 },
+      ];
+      expect(usedSlots(overflowing)).toBe(2.8); // 2 containers + 4 × 0.2
+
+      // A second box shelters them again.
+      const rebozed = overflowing.map(i =>
+        i.catalogKey === 'ration-box' ? { ...i, qty: 2 } : i);
+      expect(usedSlots(rebozed)).toBe(3); // 3 containers, no loose rations
+    });
+
+    it('excludes transport lines — mounts and vehicles carry themselves', () => {
+      const items: PcItem[] = [
+        { name: 'Dagger', category: 'weapon', qty: 1, bulk: 1 },
+        { catalogKey: 'pony', name: 'Pony', category: 'transport', qty: 1, bulk: 20 },
+        { catalogKey: 'rowboat', name: 'Rowboat', category: 'transport', qty: 1, bulk: 60 },
+      ];
+      expect(usedSlots(items)).toBe(1); // only the dagger fills the pack
+    });
   });
 
   describe('slotCapacity', () => {

--- a/src/app/charactermanager/utils/slot-inventory.ts
+++ b/src/app/charactermanager/utils/slot-inventory.ts
@@ -1,6 +1,6 @@
 import { PC, PcItem } from '../models/pc';
 import { modFromScore } from './character-math';
-import { isSupplyItem, supplyBulk } from './survival';
+import { isSupplyItem, suppliesSlots } from './survival';
 
 // ── Darker Dungeons "Active Inventory" (ch. 10) ─────────────────────────────
 // Pure slot/bulk math for campaigns with the slotInventory variant rule.
@@ -28,13 +28,18 @@ export function itemBulk(item: PcItem): number {
 
 /**
  * Slots filled: Σ bulk × qty over owned (non-dropped) lines, to 1 decimal.
- * Travel supplies are the exception — each CONTAINER (ration box / waterskin)
- * takes 1 slot and the charges inside it are weightless ({@link supplyBulk}).
+ * Two exceptions: travel supplies — handled as a system by
+ * {@link suppliesSlots} (containers 1 slot each, servings free, rations
+ * bought beyond box capacity 0.2 each) — and 'transport' lines
+ * (mounts/vehicles), which carry themselves rather than ride in your pack
+ * (DD p. 58); their bulk is reference-only display.
  */
 export function usedSlots(items: PcItem[] | undefined): number {
-  const total = (items ?? [])
-    .filter(i => i.status !== 'dropped')
-    .reduce((sum, i) => sum + (isSupplyItem(i) ? supplyBulk(i) : itemBulk(i) * (i.qty || 1)), 0);
+  const live = (items ?? []).filter(i => i.status !== 'dropped' && i.category !== 'transport');
+  const total = live
+    .filter(i => !isSupplyItem(i))
+    .reduce((sum, i) => sum + itemBulk(i) * (i.qty || 1), 0)
+    + suppliesSlots(live);
   return Math.round(total * 10) / 10; // kill 0.2 float drift
 }
 

--- a/src/app/charactermanager/utils/survival.spec.ts
+++ b/src/app/charactermanager/utils/survival.spec.ts
@@ -12,6 +12,7 @@ import {
   normalizeSupplies,
   registerWeekday,
   setGameTime,
+  suppliesSlots,
   supplyBulk,
   supplyCapacity,
   SURVIVAL_LABELS,
@@ -177,6 +178,18 @@ describe('survival util', () => {
       expect(supplyBulk({ catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: 10 })).toBe(0);
       expect(supplyBulk({ catalogKey: 'water', name: 'Water', category: 'gear', qty: 10 })).toBe(0);
       expect(supplyBulk({ name: 'Rope', category: 'gear', qty: 1 })).toBe(0);
+    });
+
+    it('suppliesSlots adds 0.2 per ration beyond box capacity (loose rations)', () => {
+      const inv = (rations: number, boxes: number): PcItem[] => [
+        { catalogKey: 'ration-box', name: 'Ration box', category: 'gear', qty: boxes },
+        { catalogKey: 'waterskin', name: 'Waterskin', category: 'gear', qty: 1 },
+        { catalogKey: 'rations', name: 'Rations (1 day)', category: 'gear', qty: rations },
+        { catalogKey: 'water', name: 'Water', category: 'gear', qty: 5 },
+      ];
+      expect(suppliesSlots(inv(5, 1))).toBe(2);          // box full, nothing loose
+      expect(suppliesSlots(inv(8, 1))).toBeCloseTo(2.6); // 3 loose × 0.2
+      expect(suppliesSlots(inv(8, 2))).toBe(3);          // second box shelters them
     });
 
     it('isSupplyItem covers charges and containers — water never shows as a normal row', () => {

--- a/src/app/charactermanager/utils/survival.ts
+++ b/src/app/charactermanager/utils/survival.ts
@@ -44,8 +44,9 @@ export const SURVIVAL_STARTING_CHARGES = 5;
 // consumed); each holds 5 servings. The servings are separate charge lines —
 // 'rations' (purchasable, 1 sp each) and 'water' (never sold; refilled free) —
 // whose qty the survival clock decrements. Charges are weightless inside their
-// containers and capped at containers × 5 everywhere. Mirrors the server's
-// SurvivalSupplies so demo mode behaves identically.
+// containers; rations bought beyond containers × 5 ride loose and fill slots
+// at 0.2 each ({@link suppliesSlots}). Mirrors the server's SurvivalSupplies
+// so demo mode behaves identically.
 
 /** One container (ration box / waterskin) holds this many servings. */
 export const SERVINGS_PER_CONTAINER = 5;
@@ -106,6 +107,23 @@ export function supplyBulk(item: PcItem): number {
     return Math.max(0, item.qty ?? 0);
   }
   return 0;
+}
+
+/** A loose ration outside its box fills slots at the catalog's Tiny rating. */
+export const RATION_BULK = 0.2;
+
+/**
+ * Slots the whole supply system fills: each container is 1 bulk and the
+ * servings inside ride free — but rations bought BEYOND box capacity have
+ * nowhere to ride, and fill slots like the loose 0.2-bulk items they are.
+ * (Water can't overflow: it's never stored outside a skin.)
+ */
+export function suppliesSlots(inventory: PcItem[]): number {
+  const containers = inventory.reduce(
+    (sum, i) => sum + (i.status !== 'dropped' ? supplyBulk(i) : 0), 0);
+  const looseRations =
+    Math.max(0, supplyCharges(inventory, 'rations') - supplyCapacity(inventory, 'rations'));
+  return containers + looseRations * RATION_BULK;
 }
 
 /** A fresh charge line for the pane/seed — mirrors the server's line shapes. */


### PR DESCRIPTION
* feat: transport catalog category, picker bulk display, and slot-free mounts

Official Darker Dungeons p. 59 transportation joins the catalog (backend V39): 'transport' items are grantable/sellable like any other category, their bulk renders as reference, and usedSlots skips them - a mount or vehicle carries itself rather than riding in the pack (DD p. 58). The DM grant picker now shows each catalog item's bulk (incl. 0.2 tinies).

* feat: loose-ration slot cost and item notes under inventory/loot rows

Rations bought past ration-box capacity now fill inventory slots at the book's 0.2 Tiny rating (suppliesSlots) instead of riding free - servings inside a box stay weightless, and another box shelters the overflow again. Item notes get their own line under the row in the inventory panel (never shown before) and in the loot pool and curated-loot lists (previously squeezed into the qty line).